### PR TITLE
Initial work on splitting

### DIFF
--- a/R/split.R
+++ b/R/split.R
@@ -75,6 +75,40 @@ split_list <- function(
   return(split_list)
 }
 
+analyses_split <- function(
+  split_plan,
+  methods,
+  wildcard = "..datasets..",
+  # Magic wildcards will expand the wildcard automatically, such that the
+  # wildcard for the second step does not need to be prefixed with the
+  # targetname from the first
+  magic_wildcards = TRUE
+  ){
+  valid_targets <- split_plan$target[!grepl(
+    pattern = "^split_list(.*, splits = .*)$",
+    x = split_plan$command
+    )]
+  if (magic_wildcards){
+    methods_targets <- methods$target
+    wild_prefix <- paste0(dplyr::lag(methods_targets), "_")
+    # remove the initial wildcard prefix, since we want the first argument to
+    # find the original splits, not NA_splits
+    wild_prefix[1] <- ""
+    # Actually substutute the wild_prefix into for wildcard
+    methods <- evaluate(
+      plan = methods,
+      wildcard = wildcard,
+      values = paste0(wild_prefix, wildcard),
+      expand = FALSE
+      )
+  }
+  evaluate(
+    plan = methods,
+    wildcard = wildcard,
+    values = valid_targets
+    )
+}
+
 drake_unsplit <- function(
   plan,
   out_target,

--- a/R/split.R
+++ b/R/split.R
@@ -1,0 +1,131 @@
+drake_split <- function(
+  .data,
+  out_target,
+  # this is here so you can use the expected rows, if data does not yet exist
+  data_rows = nrow(.data),
+  splits = ceiling(nrow(.data) / 1e6)
+  ){
+  name <- deparse(substitute(.data))
+  # Check if .data is an object in a magrittr pipeline.
+  if (name == "."){
+    name <- find_lhs_name(.data)
+  }
+  # Ensure that splits is an integer:
+  splits <- ceiling(splits)
+  digits <- ceiling(log10(splits))
+  # deparse target names (pre-application)
+  slice_targets <- paste(
+    "slice",
+    name,
+    stringr::str_pad(seq(splits), pad = "0", side = "left", width = digits),
+    sep = "_")
+  # determine the number of rows in each split (also an integer)
+  split_rows <- ceiling(data_rows / splits)
+  if (dplyr::is_grouped_df(.data)){
+    grouplist_target <- paste("slice", name, "grouplist", sep = "_")
+    slice_targets <- c(
+      grouplist_target,
+      slice_targets
+      )
+    slice_commands <- c(
+      paste0("group_list(", name, ", splits = ", splits, ")"),
+      paste0(
+        name,
+        "[dplyr::group_indices(", name, ") %in% ",
+        grouplist_target, "[[", seq(splits), "]], ]"
+        )
+      )
+  } else {
+    split_seq_low <- seq(
+      from = 1L,
+      by = split_rows,
+      length.out = splits
+      )
+    split_seq_high <- seq(
+      from = split_rows,
+      by = split_rows,
+      length.out = splits
+      )
+    slice_commands <- paste0(
+      "dplyr::slice(",
+      name, ", ",
+      split_seq_low, ":", split_seq_high,
+      ")")
+  }
+  slice_plan <- data.frame(target = slice_targets, command = slice_commands)
+  return(slice_plan)
+}
+
+group_list <- function(
+  .data,
+  splits
+  ){
+  # determine the size of each group
+  data_groups <- dplyr::group_size(.data)
+  names(data_groups) <- seq_along(data_groups)
+  # ensure split_rows is an integer
+  split_rows <- ceiling(sum(data_groups) / splits)
+  group_list <- vector("list", length = splits)
+  for (i in data_groups){
+    push_to <- which.min(lapply(group_list, sum))
+    push_value <- data_groups[which.max(data_groups)]
+    group_list[[push_to]] <- c(group_list[[push_to]], push_value)
+    data_groups[which.max(data_groups)] <- NA
+  }
+  # Extract just the names, since those are the actual values we want.
+  group_list <- lapply(group_list, names)
+  group_list <- lapply(group_list, as.numeric)
+  return(group_list)
+}
+
+drake_unsplit <- function(
+  plan,
+  out_target,
+  last_method = gsub(
+    x = tail(plan$target, 1),
+    pattern = "^(.*)_slice.*$", "\\1"
+    ),
+  plan_type = "analysis" #c("analysis", "split")
+  ){
+  stopifnot(is.character(last_method))
+  stopifnot(plan_type %in% c("analysis", "split"))
+  if (missing(out_target)){
+    out_target <- deparse(substitute(plan))
+  }
+  stopifnot(is.character(out_target))
+  if (plan_type == "analysis"){
+    bind_targets <- paste0(
+      grep(
+        pattern = last_method,
+        x = plan$target,
+        value = TRUE
+        ),
+      collapse = ", "
+      )
+  } else {
+    bind_targets <- paste0(
+      last_method, "_",
+      split_plan[["target"]],
+      collapse = ", "
+      )
+  }
+  unsplit_plan <- data.frame(
+    target = out_target,
+    command = paste0("rbind(", bind_targets, ")")
+    )
+  return(unsplit_plan)
+}
+
+# So, so much thanks to Mr. Flick
+# https://stackoverflow.com/a/42561430/7571303
+# TODO: Make some unit tests for this
+find_lhs_name <- function(x) {
+  i <- 1
+  while (
+    !("chain_parts" %in% ls(envir = parent.frame(i)))
+    && i < sys.nframe()
+    ) {
+    i <- i + 1
+  }
+  return(parent.frame(i)$lhs)
+}

--- a/R/split.R
+++ b/R/split.R
@@ -80,9 +80,9 @@ drake_unsplit <- function(
   out_target,
   last_method = gsub(
     x = tail(plan$target, 1),
-    pattern = "^(.*)_slice.*$", "\\1"
+    pattern = "^(.*)_split.*$", "\\1"
     ),
-  plan_type = "analysis" #c("analysis", "split")
+  plan_type = "analysis"
   ){
   stopifnot(is.character(last_method))
   stopifnot(plan_type %in% c("analysis", "split"))

--- a/R/split.R
+++ b/R/split.R
@@ -57,15 +57,8 @@ split_list <- function(
         floo,
         ceil
         )
-      print(rep_num)
-      # browser()
       data_groups <- c(data_groups, rep(i, rep_num))
     }
-    # data_groups <- cut(
-    #   seq(nrow(.data)),
-    #   breaks = splits,
-    #   labels = FALSE
-    #   )
   }
   stopifnot(length(data_groups) == nrow(.data))
   n_groups <- max(data_groups)

--- a/R/split.R
+++ b/R/split.R
@@ -71,7 +71,7 @@ split_list <- function(
     data_groups[push_indices] <- NA
   }
   # ensure it's a numeric vector in each list element
-  split_list <- lapply(split_list, as.numeric)
+  split_list <- lapply(split_list, as.integer)
   return(split_list)
 }
 

--- a/R/split.R
+++ b/R/split.R
@@ -63,7 +63,7 @@ split_list <- function(
   stopifnot(length(data_groups) == nrow(.data))
   n_groups <- max(data_groups)
   for (i in seq(from = 1, to = n_groups)){
-    push_to <- which.min(lapply(split_list, sum))
+    push_to <- which.min(lapply(split_list, length))
     push_group <- names(which.max(table(data_groups)))
     push_indices <- which(data_groups == push_group)
     split_list[[push_to]] <- c(split_list[[push_to]], push_indices)

--- a/R/split.R
+++ b/R/split.R
@@ -11,7 +11,12 @@ drake_split <- function(
   # Ensure that splits is an integer:
   splits <- ceiling(splits)
   digits <- ceiling(log10(splits))
-  splits_vec <- stringr::str_pad(seq(splits), pad = "0", side = "left", width = digits)
+  splits_vec <- stringr::str_pad(
+    seq(splits),
+    pad = "0",
+    side = "left",
+    width = digits
+    )
   # deparse target names (pre-application)
   slice_targets <- paste(
     "split",
@@ -69,7 +74,7 @@ split_list <- function(
     # determine the size of each group
     data_groups <- dplyr::group_indices(.data)
     n_groups <- max(data_groups)
-    for (i in seq(from =1, to = n_groups)){
+    for (i in seq(from = 1, to = n_groups)){
       push_to <- which.min(lapply(split_list, sum))
     push_group <- which.max(table(data_groups))
     push_indices <- which(data_groups == push_group)

--- a/tests/testthat/test-split.R
+++ b/tests/testthat/test-split.R
@@ -41,71 +41,10 @@ test_that("split_list works - grouped", {
   }
 })
 
-test_that("drake_split splits correctly", {
-  # the default number of groups is nrow() / 1 million
-  expect_identical(
-    drake_split(starwars),
-    split_sw_1
-    )
-  expect_identical(
-    drake_split(starwars, splits = 2),
-    split_sw_2
-    )
-  expect_identical(
-    drake_split(starwars, splits = 12),
-    split_sw_12
-    )
-})
 
-test_that("drake_split splits correctly - magrittr", {
-  # the default number of groups is nrow() / 1 million
-  expect_identical(
-    starwars %>% drake_split(),
-    split_sw_1
-    )
-  expect_identical(
-    starwars %>% drake_split(splits = 2),
-    split_sw_2
-    )
-  expect_identical(
-    starwars %>% drake_split(splits = 12),
-    split_sw_12
-    )
-})
-
-test_that("drake_split splits correctly - dplyr groups", {
-  # the default number of groups is nrow() / 1 million
-  expect_identical(
-    drake_split(sw_hair),
-    split_swg_1
-    )
-  expect_identical(
-    drake_split(sw_hair, splits = 2),
-    split_swg_2
-    )
-  expect_identical(
-    drake_split(sw_hair, splits = 12),
-    split_swg_12
-    )
-})
-
-test_that("drake_split splits correctly - pipe + groups", {
-  # the default number of groups is nrow() / 1 million
-  expect_identical(
-    sw_hair %>% drake_split(),
-    split_swg_1
-    )
-  expect_identical(
-    sw_hair %>% drake_split(splits = 2),
-    split_swg_2
-    )
-  expect_identical(
-    sw_hair %>% drake_split(splits = 12),
-    split_swg_12
-    )
-})
 
 test_that("split plans work", {
+  dclean()
   # Please not this is mostly an example, and should  not be thought of as an
   # actual, practical workflow
   plan_split <- drake_split(mtcars, splits = 3)
@@ -122,7 +61,9 @@ test_that("split plans work", {
     step_three = dplyr::select_(step_two_..dataset.., "qsec", "wt"), #nolint: wildcard
     strings_in_dots = "literals"
     )
-  plan_analyses <- analyses(plan = methods, datasets = plan_split)
+  # Notice me subsetting the datasets to avoid the list, and only operate on
+  # the frames
+  plan_analyses <- analyses(plan = methods, datasets = plan_split[2:4, ])
   plan_unsplit <- drake_unsplit(plan_analyses, out_target = "mtc_cleaned")
   plan_lm <- plan(lm_out  = lm(wt ~ qsec, data = mtc_cleaned))
   my_plan <- rbind(plan_split, plan_analyses, plan_unsplit, plan_lm)
@@ -135,4 +76,5 @@ test_that("split plans work", {
     lm("wt ~ qsec", data = .)
 
   expect_identical(coef(sane_way_lm), coef(lm_out))
+  dclean()
 })

--- a/tests/testthat/test-split.R
+++ b/tests/testthat/test-split.R
@@ -57,13 +57,18 @@ test_that("split plans work", {
     # step.
     # Further Notce that the filter_ command would not work on the generic
     # ..dataset.., since that doesn't have a hp_per_cyl column.
-    step_two = dplyr::filter_(step_one_..dataset.., "hp_per_cyl > 20"), #nolint: wildcard
-    step_three = dplyr::select_(step_two_..dataset.., "qsec", "wt"), #nolint: wildcard
+    step_two = dplyr::filter_(..dataset.., "hp_per_cyl > 20"), #nolint: wildcard
+    step_three = dplyr::select_(..dataset.., "qsec", "wt"), #nolint: wildcard
     strings_in_dots = "literals"
     )
   # Notice me subsetting the datasets to avoid the list, and only operate on
   # the frames
-  plan_analyses <- analyses(plan = methods, datasets = plan_split[2:4, ])
+  plan_analyses <- analyses_split(
+    split_plan = plan_split,
+    methods = methods,
+    wildcard = "..dataset..",
+    magic_wildcards = TRUE
+    )
   plan_unsplit <- drake_unsplit(plan_analyses, out_target = "mtc_cleaned")
   plan_lm <- plan(lm_out  = lm(wt ~ qsec, data = mtc_cleaned))
   my_plan <- rbind(plan_split, plan_analyses, plan_unsplit, plan_lm)

--- a/tests/testthat/test-split.R
+++ b/tests/testthat/test-split.R
@@ -1,72 +1,30 @@
 context("split")
 
+# I picked the `starwars` dataset becasue It is large enough to actaully split nicely. Also, it groups well.
 data(starwars, package = "dplyr")
 sw_hair <- dplyr::group_by_(starwars, "hair_color")
 
-split_sw_1 <- data.frame(
-  target = paste0("slice_starwars_", 1),
-  command = paste0("dplyr::slice(starwars, ", 1, ":", 87, ")")
-  )
-split_sw_2 <- data.frame(
-  target = paste0("slice_starwars_", 1:2),
-  command = paste0(
-    "dplyr::slice(starwars, ",
-    seq(1, by = 44, length.out = 2), ":",
-    seq(44, by = 44, length.out = 2), ")")
-  )
-split_sw_12 <- data.frame(
-  target = paste0(
-    "slice_starwars_",
-    stringr::str_pad(1:12, width = 2, pad = "0", side = "left")
-    ),
-  command = paste0(
-    "dplyr::slice(starwars, ",
-    seq(1, by = 8, length.out = 12), ":",
-    seq(8, by = 8, length.out = 12), ")")
-  )
+test_that("split_list works - ungrouped", {
+  # Notice that i'm attemting at multiple split levels
+  for (i in c(1, 4, 7, 12)){
+    temp_list <- split_list(starwars, splits = i)
+    #expect correct number of vectors
+    expect_length(temp_list, i)
+    lengths_temp <- vapply(temp_list, length, integer(1))
+    expect_true(all(lengths_temp >= floor(nrow(starwars) / i)))
+    expect_true(all(lengths_temp <= ceiling(nrow(starwars) / i)))
+    # Check that the vectors get monotonically shorter
+    expect_true(all(diff(lengths_temp) <= 0))
+    # expect that the vectors are all there, and are in order
+    expect_identical(unlist(temp_list), seq(nrow(starwars)))
+  }
+})
 
-split_swg_1 <- data.frame(
-  target = c(
-    "slice_sw_hair_grouplist",
-    paste0("slice_sw_hair_", 1)
-    ),
-  command = c(
-    "group_list(sw_hair, splits = 1)",
-    paste0(
-      "sw_hair[dplyr::group_indices(sw_hair) %in% slice_sw_hair_grouplist[[", 1, "]], ]" #nolint: i don't want to split the string
-      )
-    )
-  )
-split_swg_2 <- data.frame(
-  target = c(
-    "slice_sw_hair_grouplist",
-    paste0("slice_sw_hair_", 1:2)
-    ),
-  command = c(
-    "group_list(sw_hair, splits = 2)",
-    paste0(
-      "sw_hair[dplyr::group_indices(sw_hair) %in% slice_sw_hair_grouplist[[", 1:2, "]], ]" #nolint: i don't want to split the string
-      )
-    )
-  )
-split_swg_12 <- data.frame(
-  target = c(
-    "slice_sw_hair_grouplist",
-    paste0(
-      "slice_sw_hair_",
-      stringr::str_pad(1:12, width = 2, pad = "0", side = "left")
-      )
-    ),
-  command = c(
-    "group_list(sw_hair, splits = 12)",
-    paste0(
-      "sw_hair[dplyr::group_indices(sw_hair) %in% slice_sw_hair_grouplist[[", 1:12, "]], ]" #nolint: i don't want to split the string
-      )
-    )
-  )
+test_that("split_list works - grouped", {
 
+})
 
-test_with_dir("drake_split splits correctly", {
+test_that("drake_split splits correctly", {
   # the default number of groups is nrow() / 1 million
   expect_identical(
     drake_split(starwars),
@@ -82,7 +40,7 @@ test_with_dir("drake_split splits correctly", {
     )
 })
 
-test_with_dir("drake_split splits correctly - magrittr", {
+test_that("drake_split splits correctly - magrittr", {
   # the default number of groups is nrow() / 1 million
   expect_identical(
     starwars %>% drake_split(),
@@ -98,7 +56,7 @@ test_with_dir("drake_split splits correctly - magrittr", {
     )
 })
 
-test_with_dir("drake_split splits correctly - dplyr groups", {
+test_that("drake_split splits correctly - dplyr groups", {
   # the default number of groups is nrow() / 1 million
   expect_identical(
     drake_split(sw_hair),
@@ -114,7 +72,7 @@ test_with_dir("drake_split splits correctly - dplyr groups", {
     )
 })
 
-test_with_dir("drake_split splits correctly - pipe + groups", {
+test_that("drake_split splits correctly - pipe + groups", {
   # the default number of groups is nrow() / 1 million
   expect_identical(
     sw_hair %>% drake_split(),
@@ -130,7 +88,7 @@ test_with_dir("drake_split splits correctly - pipe + groups", {
     )
 })
 
-test_with_dir("split plans work", {
+test_that("split plans work", {
   # Please not this is mostly an example, and should  not be thought of as an
   # actual, practical workflow
   plan_split <- drake_split(mtcars, splits = 3)

--- a/tests/testthat/test-split.R
+++ b/tests/testthat/test-split.R
@@ -1,6 +1,7 @@
 context("split")
 
-# I picked the `starwars` dataset becasue It is large enough to actaully split nicely. Also, it groups well.
+# I picked the `starwars` dataset becasue It is large enough to actaully split
+# nicely. Also, it groups well.
 data(starwars, package = "dplyr")
 sw_hair <- dplyr::group_by_(starwars, "hair_color")
 
@@ -21,7 +22,23 @@ test_that("split_list works - ungrouped", {
 })
 
 test_that("split_list works - grouped", {
-
+  # Notice that i'm attemting at multiple split levels
+  for (i in c(1, 4, 7, 12)){
+    temp_list <- split_list(sw_hair, splits = i)
+    #expect correct number of vectors
+    expect_length(temp_list, i)
+    lengths_temp <- vapply(temp_list, length, integer(1))
+    # expect that the vectors are all there, and nothing else
+    expect_identical(sort(unlist(temp_list)), seq(nrow(sw_hair)))
+    # expect that elements of a group only show up in one list
+    group_lists <- lapply(
+      temp_list,
+      function(x){
+        unique(dplyr::group_indices(sw_hair)[x])
+      }
+      )
+    expect_identical(unlist(group_lists), unique(unlist(group_lists)))
+  }
 })
 
 test_that("drake_split splits correctly", {

--- a/tests/testthat/test-split.R
+++ b/tests/testthat/test-split.R
@@ -1,0 +1,163 @@
+context("split")
+
+data(starwars, package = "dplyr")
+sw_hair <- dplyr::group_by_(starwars, "hair_color")
+
+split_sw_1 <- data.frame(
+  target = paste0("slice_starwars_", 1),
+  command = paste0("dplyr::slice(starwars, ", 1, ":", 87, ")")
+  )
+split_sw_2 <- data.frame(
+  target = paste0("slice_starwars_", 1:2),
+  command = paste0(
+    "dplyr::slice(starwars, ",
+    seq(1, by = 44, length.out = 2), ":",
+    seq(44, by = 44, length.out = 2), ")")
+  )
+split_sw_12 <- data.frame(
+  target = paste0(
+    "slice_starwars_",
+    stringr::str_pad(1:12, width = 2, pad = "0", side = "left")
+    ),
+  command = paste0(
+    "dplyr::slice(starwars, ",
+    seq(1, by = 8, length.out = 12), ":",
+    seq(8, by = 8, length.out = 12), ")")
+  )
+
+split_swg_1 <- data.frame(
+  target = c(
+    "slice_sw_hair_grouplist",
+    paste0("slice_sw_hair_", 1)
+    ),
+  command = c(
+    "group_list(sw_hair, splits = 1)",
+    paste0(
+      "sw_hair[dplyr::group_indices(sw_hair) %in% slice_sw_hair_grouplist[[", 1, "]], ]" #nolint: i don't want to split the string
+      )
+    )
+  )
+split_swg_2 <- data.frame(
+  target = c(
+    "slice_sw_hair_grouplist",
+    paste0("slice_sw_hair_", 1:2)
+    ),
+  command = c(
+    "group_list(sw_hair, splits = 2)",
+    paste0(
+      "sw_hair[dplyr::group_indices(sw_hair) %in% slice_sw_hair_grouplist[[", 1:2, "]], ]" #nolint: i don't want to split the string
+      )
+    )
+  )
+split_swg_12 <- data.frame(
+  target = c(
+    "slice_sw_hair_grouplist",
+    paste0(
+      "slice_sw_hair_",
+      stringr::str_pad(1:12, width = 2, pad = "0", side = "left")
+      )
+    ),
+  command = c(
+    "group_list(sw_hair, splits = 12)",
+    paste0(
+      "sw_hair[dplyr::group_indices(sw_hair) %in% slice_sw_hair_grouplist[[", 1:12, "]], ]" #nolint: i don't want to split the string
+      )
+    )
+  )
+
+
+test_with_dir("drake_split splits correctly", {
+  # the default number of groups is nrow() / 1 million
+  expect_identical(
+    drake_split(starwars),
+    split_sw_1
+    )
+  expect_identical(
+    drake_split(starwars, splits = 2),
+    split_sw_2
+    )
+  expect_identical(
+    drake_split(starwars, splits = 12),
+    split_sw_12
+    )
+})
+
+test_with_dir("drake_split splits correctly - magrittr", {
+  # the default number of groups is nrow() / 1 million
+  expect_identical(
+    starwars %>% drake_split(),
+    split_sw_1
+    )
+  expect_identical(
+    starwars %>% drake_split(splits = 2),
+    split_sw_2
+    )
+  expect_identical(
+    starwars %>% drake_split(splits = 12),
+    split_sw_12
+    )
+})
+
+test_with_dir("drake_split splits correctly - dplyr groups", {
+  # the default number of groups is nrow() / 1 million
+  expect_identical(
+    drake_split(sw_hair),
+    split_swg_1
+    )
+  expect_identical(
+    drake_split(sw_hair, splits = 2),
+    split_swg_2
+    )
+  expect_identical(
+    drake_split(sw_hair, splits = 12),
+    split_swg_12
+    )
+})
+
+test_with_dir("drake_split splits correctly - pipe + groups", {
+  # the default number of groups is nrow() / 1 million
+  expect_identical(
+    sw_hair %>% drake_split(),
+    split_swg_1
+    )
+  expect_identical(
+    sw_hair %>% drake_split(splits = 2),
+    split_swg_2
+    )
+  expect_identical(
+    sw_hair %>% drake_split(splits = 12),
+    split_swg_12
+    )
+})
+
+test_with_dir("split plans work", {
+  # Please not this is mostly an example, and should  not be thought of as an
+  # actual, practical workflow
+  plan_split <- drake_split(mtcars, splits = 3)
+  methods <- plan(
+    step_one = dplyr::mutate_(..dataset.., hp_per_cyl = "hp / cyl"), #nolint: wildcard
+    # notice the arguement that I'm passing instead of `..dataset`:
+    # step_one_..dataset..
+    # when analyses does its replacement magic, that will turn into the
+    # step_one_mtcars_slice_XX that was generated as a target in the previous
+    # step.
+    # Further Notce that the filter_ command would not work on the generic
+    # ..dataset.., since that doesn't have a hp_per_cyl column.
+    step_two = dplyr::filter_(step_one_..dataset.., "hp_per_cyl > 20"), #nolint: wildcard
+    step_three = dplyr::select_(step_two_..dataset.., "qsec", "wt"), #nolint: wildcard
+    strings_in_dots = "literals"
+    )
+  plan_analyses <- analyses(plan = methods, datasets = plan_split)
+  plan_unsplit <- drake_unsplit(plan_analyses, out_target = "mtc_cleaned")
+  plan_lm <- plan(lm_out  = lm(wt ~ qsec, data = mtc_cleaned))
+  my_plan <- rbind(plan_split, plan_analyses, plan_unsplit, plan_lm)
+  make(my_plan, verbose = FALSE)
+  # the normal (nonparallel) pipechain alternative
+  sane_way_lm <- mtcars %>%
+    dplyr::mutate_(hp_per_cyl = "hp / cyl") %>%
+    dplyr::filter_("hp_per_cyl > 20") %>%
+    dplyr::select_("qsec", "wt") %>%
+    lm("wt ~ qsec", data = .)
+
+  expect_identical(coef(sane_way_lm), coef(lm_out))
+})


### PR DESCRIPTION
This is a start on building the `do` functionality that I mentioned in #77. 

I expect this to fail on Travis and Appveyor, since I used `test_with_dir()` rather than the vanilla `test_that()`. Also there is no documentation, but the last test shows an (impractical, but fast running) example case, for sequential work. The graph for the plan is shown here:
![image](https://user-images.githubusercontent.com/2974734/29839304-c17103f6-8ccb-11e7-9bc0-7bb73931ae05.png)

I have no idea why the parallel pipelines are graphed with a curve to them, but notice that they all stem from the (imported blue) `mtcars` on the left, and reconnect at `mtc_cleaned` near the right. I chose to run the recombined dataframe through an `lm`, so that I woulnd't have to worry about `test_that` complaining about differently ordered rows, even though they should be the same.
