### PR TITLE
Add a random seed argument to make() and drake_config().

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # Version 5.1.0
 
+- Add a `seed` argument to `make()`, `drake_config()`, and `load_basic_example()`. Also hard-code a default seed of `0`. That way, the pseudo-randomness in projects should be reproducible
+across R sessions.
 - Cache the pseudo-random seed at the time the project is created and use that seed to build targets until the cache is destroyed.
 - Add a new `drake_read_seed()` function to read the seed from the cache. Its examples illustrate what `drake` is doing to try to ensure reproducible random numbers.
 - Evaluate the quasiquotation operator `!!` for the `...` argument to `drake_plan()`. Suppress this behavior using `tidy_evaluation = FALSE` or by passing in commands passed through the `list` argument.

--- a/R/basic_example.R
+++ b/R/basic_example.R
@@ -24,18 +24,18 @@
 #' @param seed integer, the root pseudo-random seed to use for your project.
 #'   To ensure reproducibility across different R sessions,
 #'   `set.seed()` and `.Random.seed` are ignored and have no affect on
-#'   `drake` workflows. Conversely, `make()` does not change `.Random.seed`,
+#'   `drake` workflows. Conversely, [make()] does not change `.Random.seed`,
 #'   even when pseudo-random numbers are generated.
 #'
-#'   On the first call to `make()` or `drake_config()`, `drake`
+#'   On the first call to [make()] or [drake_config()], `drake`
 #'   uses the random number generator seed from the `seed` argument.
 #'   Here, if the `seed` is `NULL` (default), `drake` uses a `seed` of `0`.
-#'   On subsequent `make()`s for existing projects, the project's
+#'   On subsequent [make()]s for existing projects, the project's
 #'   cached seed will be used in order to ensure reproducibility.
 #'   Thus, the `seed` argument must either be `NULL` or the same
 #'   seed from the project's cache (usually the `.drake/` folder).
 #'   To reset the random number generator seed for a project,
-#'   use [clean(destroy = TRUE)].
+#'   use `clean(destroy = TRUE)`.
 #' @param cache Optional `storr` cache to use.
 #' @param report_file where to write the report file `report.Rmd`.
 #' @param to deprecated, where to write the dynamic report source file

--- a/R/basic_example.R
+++ b/R/basic_example.R
@@ -21,6 +21,21 @@
 #'   Defaults to your workspace.
 #'   For an insulated workspace,
 #'   set `envir = new.env(parent = globalenv())`.
+#' @param seed integer, the root pseudo-random seed to use for your project.
+#'   To ensure reproducibility across different R sessions,
+#'   `set.seed()` and `.Random.seed` are ignored and have no affect on
+#'   `drake` workflows. Conversely, `make()` does not change `.Random.seed`,
+#'   even when pseudo-random numbers are generated.
+#'
+#'   On the first call to `make()` or `drake_config()`, `drake`
+#'   uses the random number generator seed from the `seed` argument.
+#'   Here, if the `seed` is `NULL` (default), `drake` uses a `seed` of `0`.
+#'   On subsequent `make()`s for existing projects, the project's
+#'   cached seed will be used in order to ensure reproducibility.
+#'   Thus, the `seed` argument must either be `NULL` or the same
+#'   seed from the project's cache (usually the `.drake/` folder).
+#'   To reset the random number generator seed for a project,
+#'   use [clean(destroy = TRUE)].
 #' @param cache Optional `storr` cache to use.
 #' @param report_file where to write the report file `report.Rmd`.
 #' @param to deprecated, where to write the dynamic report source file
@@ -57,6 +72,7 @@
 #' }
 load_basic_example <- function(
   envir = parent.frame(),
+  seed = NULL,
   cache = NULL,
   report_file = "report.Rmd",
   overwrite = FALSE,
@@ -153,6 +169,7 @@ load_basic_example <- function(
   invisible(drake_config(
     plan = envir$my_plan,
     envir = envir,
+    seed = seed,
     cache = cache,
     force = force,
     verbose = verbose

--- a/R/config.R
+++ b/R/config.R
@@ -41,6 +41,7 @@ drake_config <- function(
   plan = drake_plan(),
   targets = drake::possible_targets(plan),
   envir = parent.frame(),
+  seed = NULL,
   verbose = 1,
   hook = default_hook,
   cache = drake::get_cache(verbose = verbose, force = force),
@@ -96,7 +97,7 @@ drake_config <- function(
     overwrite_hash_algos = FALSE,
     jobs = jobs
   )
-  seed <- get_previous_seed(cache = cache)
+  seed <- choose_seed(supplied = seed, cache = cache)
   trigger <- match.arg(arg = trigger, choices = triggers())
   if (is.null(graph)){
     graph <- build_drake_graph(plan = plan, targets = targets,

--- a/R/make.R
+++ b/R/make.R
@@ -386,6 +386,7 @@ make <- function(
       plan = plan,
       targets = targets,
       envir = envir,
+      seed = seed,
       verbose = verbose,
       hook = hook,
       parallelism = parallelism,

--- a/R/make.R
+++ b/R/make.R
@@ -57,7 +57,7 @@
 #'   Thus, the `seed` argument must either be `NULL` or the same
 #'   seed from the project's cache (usually the `.drake/` folder).
 #'   To reset the random number generator seed for a project,
-#'   use [clean(destroy = TRUE)].
+#'   use `clean(destroy = TRUE)`.
 #'
 #' @param verbose logical or numeric, control printing to the console.
 #'   \describe{

--- a/R/make.R
+++ b/R/make.R
@@ -43,6 +43,22 @@
 #'   from `envir` and the global environment and
 #'   then reproducibly tracked as dependencies.
 #'
+#' @param seed integer, the root pseudo-random seed to use for your project.
+#'   To ensure reproducibility across different R sessions,
+#'   `set.seed()` and `.Random.seed` are ignored and have no affect on
+#'   `drake` workflows. Conversely, `make()` does not change `.Random.seed`,
+#'   even when pseudo-random numbers are generated.
+#'
+#'   On the first call to `make()` or `drake_config()`, `drake`
+#'   uses the random number generator seed from the `seed` argument.
+#'   Here, if the `seed` is `NULL` (default), `drake` uses a `seed` of `0`.
+#'   On subsequent `make()`s for existing projects, the project's
+#'   cached seed will be used in order to ensure reproducibility.
+#'   Thus, the `seed` argument must either be `NULL` or the same
+#'   seed from the project's cache (usually the `.drake/` folder).
+#'   To reset the random number generator seed for a project,
+#'   use [clean(destroy = TRUE)].
+#'
 #' @param verbose logical or numeric, control printing to the console.
 #'   \describe{
 #'     \item{0 or `FALSE`:}{print nothing.}
@@ -324,6 +340,7 @@ make <- function(
   plan = drake_plan(),
   targets = drake::possible_targets(plan),
   envir = parent.frame(),
+  seed = NULL,
   verbose = 1,
   hook = default_hook,
   cache = drake::get_cache(verbose = verbose, force = force),

--- a/R/random.R
+++ b/R/random.R
@@ -1,23 +1,27 @@
+choose_seed <- function(supplied, cache){
+  previous <- get_previous_seed(cache = cache)
+  seed_conflict <- 
+    !is.null(previous) &&
+    !is.null(supplied) &&
+    !identical(previous, supplied)
+  if (seed_conflict){
+    stop(
+      "You supplied a seed of ", supplied,
+      "to either make() or drake_config(). ",
+      "Your project already has a different seed: ", previous, ". ",
+      "Use read_drake_seed() to see for yourself.",
+      call. = FALSE
+    )
+  }
+  (previous %||% supplied) %||% 0
+}
+
 get_previous_seed <- function(cache){
   if (cache$exists(key = "seed", namespace = "config")){
     cache$get(key = "seed", namespace = "config")
   } else {
-    get_valid_seed()
+    NULL
   }
-}
-
-# From withr
-get_valid_seed <- function(seed = get_seed()){
-  if (is.null(seed)) {
-    runif(1L)
-    seed <- get_seed()
-  }
-  seed
-}
-
-# From withr
-get_seed <- function(){
-  get0(".Random.seed", globalenv(), mode = "integer")
 }
 
 # A numeric hash that could be used as a
@@ -27,4 +31,13 @@ seed_from_object <- function(x) {
   hash <- digest::digest(x, algo = "murmur32")
   hexval <- paste0("0x", hash)
   utils::type.convert(hexval) %% .Machine$integer.max
+}
+
+# From lintr
+`%||%` <- function(x, y) {
+  if (is.null(x) || length(x) <= 0) {
+    y
+  } else {
+    x
+  }
 }

--- a/R/random.R
+++ b/R/random.R
@@ -1,6 +1,6 @@
 choose_seed <- function(supplied, cache){
   previous <- get_previous_seed(cache = cache)
-  seed_conflict <- 
+  seed_conflict <-
     !is.null(previous) &&
     !is.null(supplied) &&
     !identical(previous, supplied)

--- a/R/read.R
+++ b/R/read.R
@@ -305,49 +305,6 @@ read_drake_config <- function(
   out
 }
 
-#' @title Read the workflow plan
-#'   from your last attempted call to [make()].
-#' @description Uses the cache.
-#' @seealso [read_drake_config()]
-#' @export
-#' @return A workflow plan data frame.
-#' @param cache optional drake cache. See code{\link{new_cache}()}.
-#'   If `cache` is supplied,
-#'   the `path` and `search` arguments are ignored.
-#' @param path Root directory of the drake project,
-#'   or if `search` is `TRUE`, either the
-#'   project root or a subdirectory of the project.
-#' @param search logical. If `TRUE`, search parent directories
-#'   to find the nearest drake cache. Otherwise, look in the
-#'   current working directory only.
-#' @param verbose whether to print console messages
-#' @examples
-#' \dontrun{
-#' test_with_dir("Quarantine side effects.", {
-#' load_basic_example() # Get the code with drake_example("basic").
-#' make(my_plan) # Run the project, build the targets.
-#' read_drake_plan() # Retrieve the workflow plan data frame from the cache.
-#' })
-#' }
-read_drake_plan <- function(
-  path = getwd(),
-  search = TRUE,
-  cache = NULL,
-  verbose = TRUE
-){
-  if (is.null(cache)){
-    cache <- get_cache(path = path, search = search, verbose = verbose)
-  }
-  if (is.null(cache)){
-    stop("cannot find drake cache.")
-  }
-  if (cache$exists(key = "plan", namespace = "config")){
-    cache$get(key = "plan", namespace = "config")
-  } else {
-    drake_plan()
-  }
-}
-
 #' @title Read the igraph dependency network
 #'   from your last attempted call to [make()].
 #' @description For more user-friendly graphing utilities,
@@ -482,6 +439,49 @@ read_drake_meta <- function(
   out
 }
 
+#' @title Read the workflow plan
+#'   from your last attempted call to [make()].
+#' @description Uses the cache.
+#' @seealso [read_drake_config()]
+#' @export
+#' @return A workflow plan data frame.
+#' @param cache optional drake cache. See code{\link{new_cache}()}.
+#'   If `cache` is supplied,
+#'   the `path` and `search` arguments are ignored.
+#' @param path Root directory of the drake project,
+#'   or if `search` is `TRUE`, either the
+#'   project root or a subdirectory of the project.
+#' @param search logical. If `TRUE`, search parent directories
+#'   to find the nearest drake cache. Otherwise, look in the
+#'   current working directory only.
+#' @param verbose whether to print console messages
+#' @examples
+#' \dontrun{
+#' test_with_dir("Quarantine side effects.", {
+#' load_basic_example() # Get the code with drake_example("basic").
+#' make(my_plan) # Run the project, build the targets.
+#' read_drake_plan() # Retrieve the workflow plan data frame from the cache.
+#' })
+#' }
+read_drake_plan <- function(
+  path = getwd(),
+  search = TRUE,
+  cache = NULL,
+  verbose = TRUE
+){
+  if (is.null(cache)){
+    cache <- get_cache(path = path, search = search, verbose = verbose)
+  }
+  if (is.null(cache)){
+    stop("cannot find drake cache.")
+  }
+  if (cache$exists(key = "plan", namespace = "config")){
+    cache$get(key = "plan", namespace = "config")
+  } else {
+    drake_plan()
+  }
+}
+
 #' @title Read the pseudo-random number generator seed of the project.
 #' @description When a project is created with [make()]
 #' or [drake_config()], the project's pseudo-random number generator
@@ -503,24 +503,37 @@ read_drake_meta <- function(
 #'   current working directory only.
 #' @param verbose whether to print console messages
 #' @examples
-#' cache <- storr::storr_environment() # For the examples.
+#' cache <- storr::storr_environment() # Just for the examples.
 #' my_plan <- drake_plan(
 #'   target1 = sqrt(1234),
 #'   target2 = rnorm(n = 1, mean = target1)
 #' )
-#' digest::digest(.Random.seed) # Take the fingerprint of the current seed.
+#' tmp <- runif(1) # Make sure your R session has a pseudo-random number generator seed.
+#' digest::digest(.Random.seed) # Take the fingerprint of the current R session's seed.
 #' make(my_plan, cache = cache) # Run the project, build the targets.
-#' digest::digest(.Random.seed) # make() protects your R session's seed from being changed.
-#' # Drake takes the seed from the R session that originally created the cache.
-#' digest::digest(read_drake_seed(cache = cache))
-#' readd(target2, cache = cache) # Here is some randomly-generated data.
-#' clean(target2, cache = cache) # Oops, I removed the data.
-#' x <- runif(1) # Maybe I also changed the R session's seed.
-#' digest::digest(.Random.seed) # Different from before.
+#' digest::digest(.Random.seed) # Your session's seed did not change.
+#' # Drake uses a hard-coded seed if you do not supply one.
+#' read_drake_seed(cache = cache)
+#' readd(target2, cache = cache) # Randomly-generated target data.
+#' clean(target2, cache = cache) # Oops, I removed the data!
+#' tmp <- runif(1) # Maybe the R session's seed also changed.
 #' make(my_plan, cache = cache) # Rebuild target2.
 #' # Same as before:
-#' digest::digest(read_drake_seed(cache = cache))
-#' digest::digest(.Random.seed)
+#' read_drake_seed(cache = cache)
+#' readd(target2, cache = cache)
+#' # You can also supply a seed.
+#' # If your project already exists, it must agree with the project's
+#' # preexisting seed (default: 0)
+#' clean(target2, cache = cache)
+#' make(my_plan, cache = cache, seed = 0)
+#' read_drake_seed(cache = cache)
+#' readd(target2, cache = cache)
+#' # If you want to supply a different seed than 0,
+#' # you need to destroy the cache and start over first.
+#' clean(destroy = TRUE, cache = cache)
+#' cache <- storr::storr_environment() # Just for the examples.
+#' make(my_plan, cache = cache, seed = 1234)
+#' read_drake_seed(cache = cache)
 #' readd(target2, cache = cache)
 read_drake_seed <- function(
   path = getwd(),

--- a/man/drake_config.Rd
+++ b/man/drake_config.Rd
@@ -59,7 +59,7 @@ cached seed will be used in order to ensure reproducibility.
 Thus, the \code{seed} argument must either be \code{NULL} or the same
 seed from the project's cache (usually the \code{.drake/} folder).
 To reset the random number generator seed for a project,
-use \link{clean(destroy = TRUE)}.}
+use \code{clean(destroy = TRUE)}.}
 
 \item{verbose}{logical or numeric, control printing to the console.
 \describe{

--- a/man/drake_config.Rd
+++ b/man/drake_config.Rd
@@ -6,7 +6,7 @@
 used internally in \code{\link[=make]{make()}}.}
 \usage{
 drake_config(plan = drake_plan(), targets = drake::possible_targets(plan),
-  envir = parent.frame(), verbose = 1, hook = default_hook,
+  envir = parent.frame(), seed = NULL, verbose = 1, hook = default_hook,
   cache = drake::get_cache(verbose = verbose, force = force),
   fetch_cache = NULL, parallelism = drake::default_parallelism(),
   jobs = 1, packages = rev(.packages()), prework = character(0),
@@ -44,6 +44,22 @@ by \code{make}. The deep copy inherits from the global environment.
 Wherever necessary, objects and functions are imported
 from \code{envir} and the global environment and
 then reproducibly tracked as dependencies.}
+
+\item{seed}{integer, the root pseudo-random seed to use for your project.
+To ensure reproducibility across different R sessions,
+\code{set.seed()} and \code{.Random.seed} are ignored and have no affect on
+\code{drake} workflows. Conversely, \code{make()} does not change \code{.Random.seed},
+even when pseudo-random numbers are generated.
+
+On the first call to \code{make()} or \code{drake_config()}, \code{drake}
+uses the random number generator seed from the \code{seed} argument.
+Here, if the \code{seed} is \code{NULL} (default), \code{drake} uses a \code{seed} of \code{0}.
+On subsequent \code{make()}s for existing projects, the project's
+cached seed will be used in order to ensure reproducibility.
+Thus, the \code{seed} argument must either be \code{NULL} or the same
+seed from the project's cache (usually the \code{.drake/} folder).
+To reset the random number generator seed for a project,
+use \link{clean(destroy = TRUE)}.}
 
 \item{verbose}{logical or numeric, control printing to the console.
 \describe{

--- a/man/load_basic_example.Rd
+++ b/man/load_basic_example.Rd
@@ -17,18 +17,18 @@ set \code{envir = new.env(parent = globalenv())}.}
 \item{seed}{integer, the root pseudo-random seed to use for your project.
 To ensure reproducibility across different R sessions,
 \code{set.seed()} and \code{.Random.seed} are ignored and have no affect on
-\code{drake} workflows. Conversely, \code{make()} does not change \code{.Random.seed},
+\code{drake} workflows. Conversely, \code{\link[=make]{make()}} does not change \code{.Random.seed},
 even when pseudo-random numbers are generated.
 
-On the first call to \code{make()} or \code{drake_config()}, \code{drake}
+On the first call to \code{\link[=make]{make()}} or \code{\link[=drake_config]{drake_config()}}, \code{drake}
 uses the random number generator seed from the \code{seed} argument.
 Here, if the \code{seed} is \code{NULL} (default), \code{drake} uses a \code{seed} of \code{0}.
-On subsequent \code{make()}s for existing projects, the project's
+On subsequent \code{\link[=make]{make()}}s for existing projects, the project's
 cached seed will be used in order to ensure reproducibility.
 Thus, the \code{seed} argument must either be \code{NULL} or the same
 seed from the project's cache (usually the \code{.drake/} folder).
 To reset the random number generator seed for a project,
-use \link{clean(destroy = TRUE)}.}
+use \code{clean(destroy = TRUE)}.}
 
 \item{cache}{Optional \code{storr} cache to use.}
 

--- a/man/load_basic_example.Rd
+++ b/man/load_basic_example.Rd
@@ -4,7 +4,7 @@
 \alias{load_basic_example}
 \title{Load the basic example from \code{drake_example("basic")}}
 \usage{
-load_basic_example(envir = parent.frame(), cache = NULL,
+load_basic_example(envir = parent.frame(), seed = NULL, cache = NULL,
   report_file = "report.Rmd", overwrite = FALSE, to = report_file,
   verbose = TRUE, force = FALSE)
 }
@@ -13,6 +13,22 @@ load_basic_example(envir = parent.frame(), cache = NULL,
 Defaults to your workspace.
 For an insulated workspace,
 set \code{envir = new.env(parent = globalenv())}.}
+
+\item{seed}{integer, the root pseudo-random seed to use for your project.
+To ensure reproducibility across different R sessions,
+\code{set.seed()} and \code{.Random.seed} are ignored and have no affect on
+\code{drake} workflows. Conversely, \code{make()} does not change \code{.Random.seed},
+even when pseudo-random numbers are generated.
+
+On the first call to \code{make()} or \code{drake_config()}, \code{drake}
+uses the random number generator seed from the \code{seed} argument.
+Here, if the \code{seed} is \code{NULL} (default), \code{drake} uses a \code{seed} of \code{0}.
+On subsequent \code{make()}s for existing projects, the project's
+cached seed will be used in order to ensure reproducibility.
+Thus, the \code{seed} argument must either be \code{NULL} or the same
+seed from the project's cache (usually the \code{.drake/} folder).
+To reset the random number generator seed for a project,
+use \link{clean(destroy = TRUE)}.}
 
 \item{cache}{Optional \code{storr} cache to use.}
 

--- a/man/make.Rd
+++ b/man/make.Rd
@@ -59,7 +59,7 @@ cached seed will be used in order to ensure reproducibility.
 Thus, the \code{seed} argument must either be \code{NULL} or the same
 seed from the project's cache (usually the \code{.drake/} folder).
 To reset the random number generator seed for a project,
-use \link{clean(destroy = TRUE)}.}
+use \code{clean(destroy = TRUE)}.}
 
 \item{verbose}{logical or numeric, control printing to the console.
 \describe{

--- a/man/make.Rd
+++ b/man/make.Rd
@@ -5,7 +5,7 @@
 \title{Run your project (build the outdated targets).}
 \usage{
 make(plan = drake_plan(), targets = drake::possible_targets(plan),
-  envir = parent.frame(), verbose = 1, hook = default_hook,
+  envir = parent.frame(), seed = NULL, verbose = 1, hook = default_hook,
   cache = drake::get_cache(verbose = verbose, force = force),
   fetch_cache = NULL, parallelism = drake::default_parallelism(),
   jobs = 1, packages = rev(.packages()), prework = character(0),
@@ -44,6 +44,22 @@ by \code{make}. The deep copy inherits from the global environment.
 Wherever necessary, objects and functions are imported
 from \code{envir} and the global environment and
 then reproducibly tracked as dependencies.}
+
+\item{seed}{integer, the root pseudo-random seed to use for your project.
+To ensure reproducibility across different R sessions,
+\code{set.seed()} and \code{.Random.seed} are ignored and have no affect on
+\code{drake} workflows. Conversely, \code{make()} does not change \code{.Random.seed},
+even when pseudo-random numbers are generated.
+
+On the first call to \code{make()} or \code{drake_config()}, \code{drake}
+uses the random number generator seed from the \code{seed} argument.
+Here, if the \code{seed} is \code{NULL} (default), \code{drake} uses a \code{seed} of \code{0}.
+On subsequent \code{make()}s for existing projects, the project's
+cached seed will be used in order to ensure reproducibility.
+Thus, the \code{seed} argument must either be \code{NULL} or the same
+seed from the project's cache (usually the \code{.drake/} folder).
+To reset the random number generator seed for a project,
+use \link{clean(destroy = TRUE)}.}
 
 \item{verbose}{logical or numeric, control printing to the console.
 \describe{

--- a/man/read_drake_seed.Rd
+++ b/man/read_drake_seed.Rd
@@ -34,24 +34,37 @@ this one central seed. That way, reproducibility is protected,
 even under randomness.
 }
 \examples{
-cache <- storr::storr_environment() # For the examples.
+cache <- storr::storr_environment() # Just for the examples.
 my_plan <- drake_plan(
   target1 = sqrt(1234),
   target2 = rnorm(n = 1, mean = target1)
 )
-digest::digest(.Random.seed) # Take the fingerprint of the current seed.
+tmp <- runif(1) # Make sure your R session has a pseudo-random number generator seed.
+digest::digest(.Random.seed) # Take the fingerprint of the current R session's seed.
 make(my_plan, cache = cache) # Run the project, build the targets.
-digest::digest(.Random.seed) # make() protects your R session's seed from being changed.
-# Drake takes the seed from the R session that originally created the cache.
-digest::digest(read_drake_seed(cache = cache))
-readd(target2, cache = cache) # Here is some randomly-generated data.
-clean(target2, cache = cache) # Oops, I removed the data.
-x <- runif(1) # Maybe I also changed the R session's seed.
-digest::digest(.Random.seed) # Different from before.
+digest::digest(.Random.seed) # Your session's seed did not change.
+# Drake uses a hard-coded seed if you do not supply one.
+read_drake_seed(cache = cache)
+readd(target2, cache = cache) # Randomly-generated target data.
+clean(target2, cache = cache) # Oops, I removed the data!
+tmp <- runif(1) # Maybe the R session's seed also changed.
 make(my_plan, cache = cache) # Rebuild target2.
 # Same as before:
-digest::digest(read_drake_seed(cache = cache))
-digest::digest(.Random.seed)
+read_drake_seed(cache = cache)
+readd(target2, cache = cache)
+# You can also supply a seed.
+# If your project already exists, it must agree with the project's
+# preexisting seed (default: 0)
+clean(target2, cache = cache)
+make(my_plan, cache = cache, seed = 0)
+read_drake_seed(cache = cache)
+readd(target2, cache = cache)
+# If you want to supply a different seed than 0,
+# you need to destroy the cache and start over first.
+clean(destroy = TRUE, cache = cache)
+cache <- storr::storr_environment() # Just for the examples.
+make(my_plan, cache = cache, seed = 1234)
+read_drake_seed(cache = cache)
 readd(target2, cache = cache)
 }
 \seealso{

--- a/tests/testthat/test-random.R
+++ b/tests/testthat/test-random.R
@@ -1,9 +1,5 @@
 drake_context("reproducible random numbers")
 
-test_with_dir("get_valid_seed() gets a valid seed", {
-  expect_true(is.integer(get_valid_seed(seed = NULL)))
-})
-
 test_with_dir("Random targets are reproducible", {
   scenario <- get_testing_scenario()
   env <- eval(parse(text = scenario$envir))

--- a/tests/testthat/test-random.R
+++ b/tests/testthat/test-random.R
@@ -18,6 +18,8 @@ test_with_dir("Random targets are reproducible", {
     my = mean(y),
     mz = mean(z)
   )
+  # Should not change the session's seed
+  seed0 <- .Random.seed
   con <- make(
     data,
     envir = env,
@@ -26,6 +28,7 @@ test_with_dir("Random targets are reproducible", {
     verbose = FALSE,
     session_info = FALSE
   )
+  expect_true(identical(seed0, .Random.seed))
   old_x <- readd(x)
   old_y <- readd(y)
   old_z <- readd(z)
@@ -70,51 +73,57 @@ test_with_dir("Random targets are reproducible", {
   expect_true(identical(readd(y), old_y))
   expect_true(identical(readd(my), old_my))
 
-  # Change the session's seed, destroy the cache.
-  # and check that the results are different.
+  # Set the same seed as in the cache
+  # and check that things are the same as before.
   tmp <- runif(1)
-  clean(destroy = TRUE)
+  clean(y)
   con4 <- make(
     data,
     envir = env,
+    seed = con2$seed,
     parallelism = parallelism,
     jobs = jobs,
     verbose = FALSE,
     session_info = FALSE
   )
-  expect_equal(sort(justbuilt(con4)), sort(con4$plan$target))
-  expect_false(identical(con$seed, con4$seed))
+  expect_equal(justbuilt(con4), "y")
+  expect_true(identical(con4$seed, con$seed))
+  expect_true(identical(readd(y), old_y))
+  expect_true(identical(readd(my), old_my))
+  
+  # Change the supplied seed, destroy the cache,
+  # and check that the results are different.
+  tmp <- runif(1)
+  clean(destroy = TRUE)
+  con5 <- make(
+    data,
+    envir = env,
+    seed = con2$seed + 1,
+    parallelism = parallelism,
+    jobs = jobs,
+    verbose = FALSE,
+    session_info = FALSE
+  )
+  expect_equal(sort(justbuilt(con5)), sort(con5$plan$target))
+  expect_false(identical(con$seed, con5$seed))
   expect_false(identical(readd(x), old_x))
   expect_false(identical(readd(y), old_y))
   expect_false(identical(readd(z), old_z))
   expect_false(identical(readd(mx), old_mx))
   expect_false(identical(readd(my), old_my))
   expect_false(identical(readd(mz), old_mz))
-})
-
-test_that("random seed can be read", {
-  cache <- storr::storr_environment()
-  my_plan <- drake_plan(
-    target1 = sqrt(1234),
-    target2 = rnorm(n = 1, mean = target1)
+  
+  # Cannot supply a conflicting seed.
+  expect_error(
+    make(
+      data,
+      envir = env,
+      seed = con5$seed + 1,
+      parallelism = parallelism,
+      jobs = jobs,
+      verbose = FALSE,
+      session_info = FALSE
+    ),
+    regexp = "already has a different seed"
   )
-  digest::digest(.Random.seed) # nolint
-  make(my_plan, cache = cache, session_info = FALSE)
-  rs0 <- digest::digest(.Random.seed) # nolint
-  ds0 <- digest::digest(read_drake_seed(cache = cache))
-  targ0 <- readd(target2, cache = cache)
-  clean(target2, cache = cache)
-  x <- runif(1) # Maybe I also changed the R session's seed.
-  rs1 <- digest::digest(.Random.seed) # nolint
-  make(my_plan, cache = cache, session_info = FALSE)
-  ds2 <- digest::digest(read_drake_seed(cache = cache))
-  rs2 <- digest::digest(.Random.seed) # nolint
-  targ2 <- readd(target2, cache = cache)
-
-  expect_equal(rs1, rs2)
-  expect_false(rs0 == rs1)
-  expect_equal(ds0, ds2)
-  expect_equal(targ0, targ2)
-  cache$del(key = "seed", namespace = "config")
-  expect_error(read_drake_seed(cache = cache), regexp = "seed not found")
 })

--- a/tests/testthat/test-random.R
+++ b/tests/testthat/test-random.R
@@ -15,7 +15,7 @@ test_with_dir("Random targets are reproducible", {
     mz = mean(z)
   )
   # Should not change the session's seed
-  seed0 <- .Random.seed
+  seed0 <- .Random.seed # nolint
   con <- make(
     data,
     envir = env,
@@ -24,7 +24,7 @@ test_with_dir("Random targets are reproducible", {
     verbose = FALSE,
     session_info = FALSE
   )
-  expect_true(identical(seed0, .Random.seed))
+  expect_true(identical(seed0, .Random.seed)) # nolint
   old_x <- readd(x)
   old_y <- readd(y)
   old_z <- readd(z)
@@ -86,7 +86,7 @@ test_with_dir("Random targets are reproducible", {
   expect_true(identical(con4$seed, con$seed))
   expect_true(identical(readd(y), old_y))
   expect_true(identical(readd(my), old_my))
-  
+
   # Change the supplied seed, destroy the cache,
   # and check that the results are different.
   tmp <- runif(1)
@@ -108,7 +108,7 @@ test_with_dir("Random targets are reproducible", {
   expect_false(identical(readd(mx), old_mx))
   expect_false(identical(readd(my), old_my))
   expect_false(identical(readd(mz), old_mz))
-  
+
   # Cannot supply a conflicting seed.
   expect_error(
     make(


### PR DESCRIPTION
The random seed of a `drake` project should not depend on the user's R session. This PR makes sure the seed is reproducible and stable.