### PR TITLE
Make `drake_build()` more convenient to use.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # Version 5.1.0
 
+- Move `drake_build()` to be an exclusively user-side function.
+- Add a `replace` argument to `loadd()` so that objects already in the user's environment need not be replaced.
 - When the graph cyclic, print out all the cycles.
 - Prune self-referential loops (and duplicate edges) from the workflow graph. That way, recursive functions are allowed.
 - Add a `seed` argument to `make()`, `drake_config()`, and `load_basic_example()`. Also hard-code a default seed of `0`. That way, the pseudo-randomness in projects should be reproducible

--- a/R/distributed.R
+++ b/R/distributed.R
@@ -56,7 +56,7 @@ build_distributed <- function(target, meta_list, cache_path){
       return(invisible())
     }
   }
-  drake_build(
+  build_and_store(
     target = target,
     meta = meta_list[[target]],
     config = config

--- a/R/read.R
+++ b/R/read.R
@@ -123,6 +123,11 @@ readd <- function(
 #'   [delayedAssign()] rather than the more eager
 #'   [assign()].
 #'
+#' @param graph optional igraph object, representation
+#'   of the workflow network for getting dependencies
+#'   if `deps` is `TRUE`. If none is supplied,
+#'   it will be read from the cache.
+#'
 #' @examples
 #' \dontrun{
 #' test_with_dir("Quarantine side effects.", {
@@ -154,7 +159,8 @@ loadd <- function(
   jobs = 1,
   verbose = 1,
   deps = FALSE,
-  lazy = FALSE
+  lazy = FALSE,
+  graph = NULL
 ){
   if (is.null(cache)){
     stop("cannot find drake cache.")
@@ -173,8 +179,10 @@ loadd <- function(
     stop("no targets to load.")
   }
   if (deps){
-    config <- read_drake_config(cache = cache)
-    targets <- dependencies(targets = targets, config = config)
+    if (is.null(graph)){
+      graph <- read_drake_graph(cache = cache)
+    }
+    targets <- dependencies(targets = targets, config = list(graph = graph))
     exists <- lightly_parallelize(
       X = targets,
       FUN = cache$exists,

--- a/R/read.R
+++ b/R/read.R
@@ -128,6 +128,10 @@ readd <- function(
 #'   if `deps` is `TRUE`. If none is supplied,
 #'   it will be read from the cache.
 #'
+#' @param replace logical. If `FALSE`,
+#'   items already in your enviroment
+#'   will not be replaced.
+#'
 #' @examples
 #' \dontrun{
 #' test_with_dir("Quarantine side effects.", {
@@ -160,7 +164,8 @@ loadd <- function(
   verbose = 1,
   deps = FALSE,
   lazy = FALSE,
-  graph = NULL
+  graph = NULL,
+  replace = TRUE
 ){
   if (is.null(cache)){
     stop("cannot find drake cache.")
@@ -190,6 +195,9 @@ loadd <- function(
     ) %>%
       unlist
     targets <- targets[exists]
+  }
+  if (!replace){
+    targets <- setdiff(targets, ls(envir, all.names = TRUE))
   }
   lightly_parallelize(
     X = targets, FUN = load_target, cache = cache,

--- a/R/staged_parallelism.R
+++ b/R/staged_parallelism.R
@@ -162,7 +162,7 @@ next_stage <- function(config){
 }
 
 drake_build_worker <- function(target, meta_list, config){
-  drake_build(
+  build_and_store(
     target = target,
     meta = meta_list[[target]],
     config = config

--- a/man/drake_build.Rd
+++ b/man/drake_build.Rd
@@ -4,7 +4,8 @@
 \alias{drake_build}
 \title{Build/process a single target or import.}
 \usage{
-drake_build(target, config, meta = NULL)
+drake_build(target, config = NULL, meta = NULL, character_only = FALSE,
+  envir = parent.frame(), jobs = 1, replace = FALSE)
 }
 \arguments{
 \item{target}{name of the target}
@@ -13,6 +14,19 @@ drake_build(target, config, meta = NULL)
 
 \item{meta}{list of metadata that tell which
 targets are up to date (from \code{\link[=drake_meta]{drake_meta()}}).}
+
+\item{envir}{environment to load objects into. Defaults to the
+calling environment (current workspace).}
+
+\item{jobs}{number of parallel jobs for loading objects. On
+non-Windows systems, the loading process for multiple objects
+can be lightly parallelized via \code{parallel::mclapply()}.
+just set jobs to be an integer greater than 1. On Windows,
+\code{jobs} is automatically demoted to 1.}
+
+\item{replace}{logical. If \code{FALSE},
+items already in your enviroment
+will not be replaced.}
 }
 \value{
 The value of the target right after it is built.
@@ -32,19 +46,17 @@ test_with_dir("Quarantine side effects.", {
 load_basic_example() # Get the code with drake_example("basic").
 # Create the master internal configuration list.
 config <- drake_config(my_plan)
-# Optionally, compute metadata on 'small',
-# including a hash/fingerprint
-# of the dependencies. If meta is not supplied,
-# drake_build() computes it automatically.
-meta <- drake_meta(target = "small", config = config)
-# Should not yet include 'small'.
+out <- drake_build(small, config = config)
+# Now includes `small`.
 cached()
-# Build 'small'.
-# Equivalent to just drake_build(target = "small", config = config).
-drake_build(target = "small", config = config, meta = meta)
-# Should now include 'small'
-cached()
-readd(small)
+head(readd(small))
+# `small` was invisibly returned.
+head(out)
+# If you previously called make(),
+# `config` is just read from the cache.
+make(my_plan, verbose = FALSE)
+result <- drake_build(small)
+head(result)
 })
 }
 }

--- a/man/loadd.Rd
+++ b/man/loadd.Rd
@@ -7,7 +7,7 @@
 loadd(..., list = character(0), imported_only = FALSE, path = getwd(),
   search = TRUE, cache = drake::get_cache(path = path, search = search,
   verbose = verbose), namespace = NULL, envir = parent.frame(), jobs = 1,
-  verbose = 1, deps = FALSE, lazy = FALSE)
+  verbose = 1, deps = FALSE, lazy = FALSE, graph = NULL)
 }
 \arguments{
 \item{...}{targets to load from the cache, as names (unquoted)
@@ -62,6 +62,11 @@ if you set \code{deps} to \code{TRUE}.}
 \item{lazy}{logical, whether to lazy load with
 \code{\link[=delayedAssign]{delayedAssign()}} rather than the more eager
 \code{\link[=assign]{assign()}}.}
+
+\item{graph}{optional igraph object, representation
+of the workflow network for getting dependencies
+if \code{deps} is \code{TRUE}. If none is supplied,
+it will be read from the cache.}
 }
 \value{
 \code{NULL}

--- a/man/loadd.Rd
+++ b/man/loadd.Rd
@@ -7,7 +7,8 @@
 loadd(..., list = character(0), imported_only = FALSE, path = getwd(),
   search = TRUE, cache = drake::get_cache(path = path, search = search,
   verbose = verbose), namespace = NULL, envir = parent.frame(), jobs = 1,
-  verbose = 1, deps = FALSE, lazy = FALSE, graph = NULL)
+  verbose = 1, deps = FALSE, lazy = FALSE, graph = NULL,
+  replace = TRUE)
 }
 \arguments{
 \item{...}{targets to load from the cache, as names (unquoted)
@@ -67,6 +68,10 @@ if you set \code{deps} to \code{TRUE}.}
 of the workflow network for getting dependencies
 if \code{deps} is \code{TRUE}. If none is supplied,
 it will be read from the cache.}
+
+\item{replace}{logical. If \code{FALSE},
+items already in your enviroment
+will not be replaced.}
 }
 \value{
 \code{NULL}

--- a/tests/testthat/test-deprecate.R
+++ b/tests/testthat/test-deprecate.R
@@ -85,3 +85,9 @@ test_with_dir("deprecated example(s)_drake functions", {
 test_with_dir("deprecate misc utilities", {
   expect_warning(as_file("x"))
 })
+
+test_with_dir("deprecated arguments", {
+  pl <- drake_plan(a = 1, b = a)
+  con <- drake_config(plan = pl, session_info = FALSE)
+  expect_warning(drake_build(a, config = con, meta = list()))
+})

--- a/tests/testthat/test-other-features.R
+++ b/tests/testthat/test-other-features.R
@@ -6,7 +6,7 @@ test_with_dir("build_target() does not need to access cache", {
   expect_equal(1, build_target(target = "x", config = config))
   expect_error(
     drake_build(target = "x", config = config),
-    regexp = "non-function"
+    regexp = "cannot find drake cache"
   )
 })
 
@@ -22,14 +22,52 @@ test_with_dir("cache log files and make()", {
   expect_true(file.exists("my.log"))
 })
 
-test_with_dir("drake_build can build a target by itself w/o input metadata", {
-  pl <- drake_plan(a = 1, b = 2)
-  con <- drake_config(plan = pl, session_info = FALSE)
-  o <- drake_build(target = "b", config = con)
+test_with_dir("drake_build works as expected", {
+  scenario <- get_testing_scenario()
+  e <- eval(parse(text = scenario$envir))
+  pl <- drake_plan(a = 1, b = a)
+  con <- drake_config(plan = pl, session_info = FALSE, envir = e)
+
+  # can run before any make()
+  o <- drake_build(
+    target = "a", character_only = TRUE, config = con, envir = e)
   x <- cached()
-  expect_equal(x, "b")
-  o <- make(pl)
-  expect_equal(justbuilt(o), "a")
+  expect_equal(x, "a")
+  o <- make(pl, envir = e)
+  expect_true("a" %in% ls(envir = e))
+  expect_equal(justbuilt(o), "b")
+  remove(list = "a", envir = e)
+  expect_false("a" %in% ls(envir = e))
+
+  # Can run without config
+  o <- drake_build(b, envir = e)
+  expect_equal(o, e$b)
+  expect_equal(o, readd(b))
+  expect_true("a" %in% ls(envir = e))
+
+  # Replacing deps in environment
+  expect_equal(e$a, 1)
+  e$a <- 2
+  o <- drake_build(b, envir = e)
+  expect_equal(e$a, 2)
+  expect_equal(readd(a), 1)
+  o <- drake_build(b, envir = e, replace = FALSE)
+  expect_equal(e$a, 2)
+  expect_equal(readd(a), 1)
+  e$a <- 3
+  o <- drake_build(b, envir = e, replace = TRUE)
+  expect_equal(e$a, 1)
+
+  # `replace` in loadd()
+  expect_equal(e$b, 1)
+  e$b <- 5
+  loadd(b, envir = e, replace = FALSE)
+  expect_equal(e$b, 5)
+  loadd(b, envir = e, replace = TRUE)
+  expect_equal(e$b, 1)
+  e$b <- 5
+  loadd(b, envir = e)
+  expect_equal(e$b, 1)
 })
 
 test_with_dir("colors and shapes", {

--- a/vignettes/debug.Rmd
+++ b/vignettes/debug.Rmd
@@ -255,8 +255,9 @@ diagnose(verbose = FALSE)
 
 f <- function(x){
   if (x < 0){
-    stop("unusual error")
+    stop("`x` cannot be negative.")
   }
+  x
 }
 bad_plan <- drake_plan(
   a = 12,
@@ -282,7 +283,7 @@ str(error)
 error$calls # View the traceback.
 ```
 
-To figure out what went wrong, you could try to build the failed target interactively. To do that, you must load the target's dependencies in your workspace, which you can easily do with `loadd(my_target, deps = TRUE)`. Then, build it on its own with `drake_build()`.
+To figure out what went wrong, you could try to build the failed target interactively. To do that, simply call `drake_build()`. This function first calls `loadd(deps = TRUE)` to load any missing dependencies (see the `replace` argument here) and then builds your target.
 
 ```{r loaddeps}
 # Pretend we just opened a new R session.
@@ -294,23 +295,38 @@ config <- drake_config(plan = bad_plan)
 # my_target depends on b.
 "b" %in% ls()
 
-loadd(my_target, deps = TRUE)
-
-"b" %in% ls()
-
 # Try to build my_target until the error is fixed.
 # Skip all that pesky work checking dependencies.
-drake_build(target = "my_target", config = config)
+drake_build(my_target, config = config)
 
+# The target failed, but the dependency was loaded.
+"b" %in% ls()
+
+# What was `b` again?
+b
+
+# How was `b` used?
 diagnose(my_target)$message
+
+diagnose(my_target)$call
 
 f
 
 # Aha! The error was in f(). Let's fix it and try again.
 f <- function(x){
-  return(x)
+  x <- abs(x)
+  if (x < 0){
+    stop("`x` cannot be negative.")
+  }
+  x
 }
-drake_build(target = "my_target", config = config)
+
+# Now it works!
+# Since you called make() previously, `config` is read from the cache
+# if you do not supply it.
+drake_build(my_target)
+
+readd(my_target)
 ```
 
 ## Tidy evaluation: a caveat to diagnosing interactively


### PR DESCRIPTION
Users like `drake_build()` to build individual targets interactively. This PR makes it easier. Other changes:

- Split up the build functions into `build_and_store()` and `just_build()` in preparation for #227, #236, and #237.
- Add a `replace` argument to `drake_build()` and `loadd()` so that objects already in the user's environment need not be replaced. Defaults: `FALSE` in `drake_build()` and `TRUE` in `loadd()`. Yes, the defaults do not agree, but I think this is the right thing to do.
- Update the docs and news.

