### PR TITLE
Pass commands as language objects rather than text to run_command()

### DIFF
--- a/R/build.R
+++ b/R/build.R
@@ -127,7 +127,7 @@ conclude_build <- function(target, value, meta, start, config){
 }
 
 build_target <- function(target, meta, config) {
-  command <- command_as_expression(target = target, config = config)
+  command <- command_as_language(target = target, config = config)
   seed <- list(seed = config$seed, target = target) %>%
     seed_from_object
   run_command(

--- a/R/build.R
+++ b/R/build.R
@@ -127,7 +127,7 @@ conclude_build <- function(target, value, meta, start, config){
 }
 
 build_target <- function(target, meta, config) {
-  command <- get_evaluation_command(target = target, config = config)
+  command <- command_as_expression(target = target, config = config)
   seed <- list(seed = config$seed, target = target) %>%
     seed_from_object
   run_command(

--- a/R/cache.R
+++ b/R/cache.R
@@ -132,7 +132,7 @@ this_cache <- function(
   }
   fetch_cache <- as.character(fetch_cache)
   if (length(fetch_cache) && nchar(fetch_cache)){
-    cache <- eval(parse(text = functionize(fetch_cache)))
+    cache <- eval(parse(text = localize(fetch_cache)))
   } else {
     cache <- drake_fetch_rds(path)
   }

--- a/R/commands.R
+++ b/R/commands.R
@@ -27,11 +27,17 @@ extract_filenames <- function(command){
 # to protect the user's environment from side effects,
 # and (2) call rlang::expr() to enable tidy evaluation
 # features such as quasiquotation.
-get_evaluation_command <- function(target, config){
-  raw_command <- config$plan$command[config$plan$target == target] %>%
-    localize
-  unevaluated <- paste0("rlang::expr(", raw_command, ")")
-  eval(parse(text = unevaluated, keep.source = FALSE), envir = config$envir)
+command_as_expression <- function(target, config){
+  text <- config$plan$command[config$plan$target == target] %>%
+    localize %>%
+    add_tidy_eval
+  parse(text = text, keep.source = FALSE) %>%
+    eval(envir = config$envir)
+}
+
+# Use tidy evaluation to complete the contents of a command.
+add_tidy_eval <- function(command){
+  paste0("rlang::expr({\n", command, "\n})")
 }
 
 # Contain the side effects of commands.

--- a/R/commands.R
+++ b/R/commands.R
@@ -27,20 +27,21 @@ extract_filenames <- function(command){
 # to protect the user's environment from side effects,
 # and (2) call rlang::expr() to enable tidy evaluation
 # features such as quasiquotation.
-command_as_expression <- function(target, config){
+command_as_language <- function(target, config){
   text <- config$plan$command[config$plan$target == target] %>%
-    localize %>%
-    add_tidy_eval
+    preprocess_command
   parse(text = text, keep.source = FALSE) %>%
     eval(envir = config$envir)
 }
 
 # Use tidy evaluation to complete the contents of a command.
-add_tidy_eval <- function(command){
-  paste0("rlang::expr({\n", command, "\n})")
+preprocess_command <- function(command){
+  paste0("rlang::expr(local({\n", command, "\n}))")
 }
 
-# Contain the side effects of commands.
+# Can remove once we remove fetch_cache.
+# We can remove fetch_cache once we allow the master process
+# to optionally do all the caching.
 localize <- function(command) {
   paste0("local({\n", command, "\n})")
 }

--- a/R/run.R
+++ b/R/run.R
@@ -37,10 +37,12 @@ one_try <- function(target, command, seed, config){
 }
 
 with_timeout <- function(target, command, config){
-  env <- environment()
   timeouts <- resolve_timeouts(target = target, config = config)
   R.utils::withTimeout({
-      value <- eval(parse(text = command), envir = env)
+      value <- evaluate::try_capture_stack(
+        quoted_code = command,
+        env = config$envir
+      )
     },
     timeout = timeouts["timeout"],
     cpu = timeouts["cpu"],

--- a/vignettes/best-practices.Rmd
+++ b/vignettes/best-practices.Rmd
@@ -171,7 +171,7 @@ The R package structure is a great way to organize the files of your project. Wr
 
 For `drake`, there is one problem: nested functions. `Drake` always looks for imported functions nested in other imported functions, but only in your environment. When it sees a function from a package, it does not look in its body for other imports.
 
-To see this, consider the `digest()` function from the [`digest` package](https://github.com/eddelbuettel/digest). [`Digest` package](https://github.com/eddelbuettel/digest) is a utility for computing hashes, not a data science workflow, but I will use it to demonstrate how `drake` treats imports from pacakges.
+To see this, consider the `digest()` function from the [`digest` package](https://github.com/eddelbuettel/digest). [`Digest` package](https://github.com/eddelbuettel/digest) is a utility for computing hashes, not a data science workflow, but I will use it to demonstrate how `drake` treats imports from packages.
 
 
 ```{r nestingproblem}

--- a/vignettes/example-basic.Rmd
+++ b/vignettes/example-basic.Rmd
@@ -24,7 +24,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-This vignette is a walthrough of `drake`'s main functionality based on the basic example. It sets up the project and runs it repeatedly to demonstrate `drake`'s most important functionality.
+This vignette is a walkthrough of `drake`'s main functionality based on the basic example. It sets up the project and runs it repeatedly to demonstrate `drake`'s most important functionality.
 
 # Get the code.
 


### PR DESCRIPTION
Here, [`run_command()`](https://github.com/ropensci/drake/blob/62c235bd70e26e82b3544ce4308fdcf1818a5c00/R/run.R#L1) now accepts commands as language objects rather than text. The conversion from text to language objects is done by [`command_as_language()`](https://github.com/ropensci/drake/blob/62c235bd70e26e82b3544ce4308fdcf1818a5c00/R/commands.R#L30), which is called inside [`build_target()`](https://github.com/ropensci/drake/blob/62c235bd70e26e82b3544ce4308fdcf1818a5c00/R/build.R#L129).

We still should work with language objects earlier than [`build_target()`](https://github.com/ropensci/drake/blob/62c235bd70e26e82b3544ce4308fdcf1818a5c00/R/build.R#L129), and I am about to open an issue on that.

This is the first step towards proper computation on the language. I wanted to do it before #212 to make sure it did not interfere with the upcoming enhanced exception handling. And #212 precedes #237, which precedes #227. I promise, I really am working up to a better parallel scheduling algorithm! I just want to avoid surprises along the way.

It's too late at night to do any merging, so I will run some longer tests and merge tomorrow.