### PR TITLE
Fix doc link and typo

### DIFF
--- a/R/cache_log.R
+++ b/R/cache_log.R
@@ -21,20 +21,18 @@
 #' @export
 #' @return There is no return value, but a log file is generated.
 #' @param file character scalar, name of the flat text log file.
-#' @param cache drake cache. See [new_cache()].
-#'   If supplied, `path` and `search` are ignored.
-#' @param path Root directory of the drake project,
-#'   or if `search` is `TRUE`, either the
-#'   project root or a subdirectory of the project.
-#' @param search logical. If `TRUE`, search parent directories
-#'   to find the nearest drake cache. Otherwise, look in the
-#'   current working directory only.
+#'
+#' @inheritParams cached
+#'
 #' @param verbose whether to print console messages
+#'
 #' @param jobs number of jobs/workers for parallel processing
+#'
 #' @param targets_only logical, whether to output information
 #'   only on the targets in your workflow plan data frame.
 #'   If `targets_only` is `FALSE`, the output will
 #'   include the hashes of both targets and imports.
+#'
 #' @examples
 #' \dontrun{
 #' test_with_dir("Quarantine side effects.", {
@@ -116,20 +114,18 @@ drake_cache_log_file <- function(
 #' @export
 #' @return Data frame of the hash keys of the targets and imports
 #'   in the cache
-#' @param cache drake cache. See [new_cache()].
-#'   If supplied, `path` and `search` are ignored.
-#' @param path Root directory of the drake project,
-#'   or if `search` is `TRUE`, either the
-#'   project root or a subdirectory of the project.
-#' @param search logical. If `TRUE`, search parent directories
-#'   to find the nearest drake cache. Otherwise, look in the
-#'   current working directory only.
+#'
+#' @inheritParams cached
+#'
 #' @param verbose whether to print console messages
+#'
 #' @param jobs number of jobs/workers for parallel processing
+#'
 #' @param targets_only logical, whether to output information
 #'   only on the targets in your workflow plan data frame.
 #'   If `targets_only` is `FALSE`, the output will
 #'   include the hashes of both targets and imports.
+#'
 #' @examples
 #' \dontrun{
 #' test_with_dir("Quarantine side effects.", {

--- a/R/cache_ui.R
+++ b/R/cache_ui.R
@@ -131,16 +131,13 @@ list_cache <- function(no_imported_objects, cache, namespace, jobs){
 #'   \code{link{imported}}
 #' @export
 #' @return Character vector naming the built targets in the cache.
-#' @param cache drake cache. See [new_cache()].
-#'   If supplied, `path` and `search` are ignored.
-#' @param path Root directory of the drake project,
-#'   or if `search` is `TRUE`, either the
-#'   project root or a subdirectory of the project.
-#' @param search logical. If `TRUE`, search parent directories
-#'   to find the nearest drake cache. Otherwise, look in the
-#'   current working directory only.
+#'
+#' @inheritParams cached
+#'
 #' @param verbose whether to print console messages
+#'
 #' @param jobs number of jobs/workers for parallel processing
+#'
 #' @examples
 #' \dontrun{
 #' test_with_dir("Quarantine side effects.", {
@@ -178,20 +175,18 @@ built <- function(
 #'   [built()]
 #' @export
 #' @return Character vector naming the imports in the cache.
+#'
+#' @inheritParams cached
+#'
 #' @param files_only logical, whether to show imported files only
 #'   and ignore imported objects. Since all your functions and
 #'   all their global variables are imported, the full list of
 #'   imported objects could get really cumbersome.
-#' @param cache drake cache. See [new_cache()].
-#'   If supplied, `path` and `search` are ignored.
-#' @param path Root directory of the drake project,
-#'   or if `search` is `TRUE`, either the
-#'   project root or a subdirectory of the project.
-#' @param search logical. If `TRUE`, search parent directories
-#'   to find the nearest drake cache. Otherwise, look in the
-#'   current working directory only.
+#'
 #' @param verbose whether to print console messages
+#'
 #' @param jobs number of jobs/workers for parallel processing
+#'
 #' @examples
 #' \dontrun{
 #' test_with_dir("Quarantine side effects.", {

--- a/R/check.R
+++ b/R/check.R
@@ -9,7 +9,7 @@
 #'   [drake_plan()].
 #' @param targets character vector of targets to make
 #' @param envir environment containing user-defined functions
-#' @param cache optional drake cache. See [new_cache()]
+#' @param cache optional drake cache. See [new_cache()].
 #' @param verbose same as for [make()]
 #' @param jobs number of jobs/workers for light parallelism
 #' @examples

--- a/R/clean.R
+++ b/R/clean.R
@@ -20,6 +20,8 @@
 #' @export
 #' @return Invisibly return `NULL`.
 #'
+#' @inheritParams cached
+#'
 #' @param ... targets to remove from the cache, as names (unquoted)
 #'   or character strings (quoted). Similar to `...` in
 #'   \code{\link{remove}(...)}.
@@ -36,18 +38,6 @@
 #'   from `make()`
 #'   are removed. If `TRUE`, the whole cache is removed, including
 #'   session metadata, etc.
-#'
-#' @param cache optional drake cache. See code{\link{new_cache}()}. If
-#'   If `cache` is supplied,
-#'   the `path` and `search` arguments are ignored.
-#'
-#' @param path Root directory of the drake project,
-#'   or if `search` is `TRUE`, either the
-#'   project root or a subdirectory of the project.
-#'
-#' @param search logical. If `TRUE`, search parent directories
-#'   to find the nearest drake cache. Otherwise, look in the
-#'   current working directory only.
 #'
 #' @param verbose whether to print console messages
 #'

--- a/R/deprecate.R
+++ b/R/deprecate.R
@@ -757,20 +757,17 @@ read_graph <- function(
 #' @export
 #' @return The cached master internal configuration list
 #'   of the last [make()].
+#'
+#' @inheritParams cached
+#'
 #' @param targets character vector, names of the targets
 #'   to get metadata. If `NULL`, all metadata is collected.
-#' @param cache optional drake cache. See code{\link{new_cache}()}.
-#'   If `cache` is supplied,
-#'   the `path` and `search` arguments are ignored.
-#' @param path Root directory of the drake project,
-#'   or if `search` is `TRUE`, either the
-#'   project root or a subdirectory of the project.
-#' @param search logical. If `TRUE`, search parent directories
-#'   to find the nearest drake cache. Otherwise, look in the
-#'   current working directory only.
+#'
 #' @param verbose whether to print console messages
+#'
 #' @param jobs number of jobs for light parallelism.
 #'   Supports 1 job only on Windows.
+#'
 #' @examples
 #' # See ?diagnose() for examples.
 read_drake_meta <- function(

--- a/R/diagnose.R
+++ b/R/diagnose.R
@@ -9,6 +9,8 @@
 #' @return Either a character vector of target names or an object
 #'   of class `"error"`.
 #'
+#' @inheritParams cached
+#'
 #' @param target name of the target of the error to get.
 #'   Can be a symbol if `character_only` is `FALSE`,
 #'   must be a character if `character_only` is `TRUE`.
@@ -16,18 +18,6 @@
 #' @param character_only logical, whether `target` should be treated
 #'   as a character or a symbol.
 #'   Just like `character.only` in [library()].
-#'
-#' @param cache optional drake cache. See [new_cache()].
-#'   If `cache` is supplied,
-#'   the `path` and `search` arguments are ignored.
-#'
-#' @param path Root directory of the drake project,
-#'   or if `search` is `TRUE`, either the
-#'   project root or a subdirectory of the project.
-#'
-#' @param search If `TRUE`, search parent directories
-#'   to find the nearest drake cache. Otherwise, look in the
-#'   current working directory only.
 #'
 #' @param verbose whether to print console messages
 #'

--- a/R/progress.R
+++ b/R/progress.R
@@ -8,16 +8,11 @@
 #' @export
 #' @return [sessionInfo()] of the last
 #'   call to [make()]
-#' @param cache optional drake cache. See code{\link{new_cache}()}.
-#'   If `cache` is supplied,
-#'   the `path` and `search` arguments are ignored.
-#' @param path Root directory of the drake project,
-#'   or if `search` is `TRUE`, either the
-#'   project root or a subdirectory of the project.
-#' @param search If `TRUE`, search parent directories
-#'   to find the nearest drake cache. Otherwise, look in the
-#'   current working directory only.
+#'
+#' @inheritParams cached
+#'
 #' @param verbose whether to print console messages
+#'
 #' @examples
 #' \dontrun{
 #' test_with_dir("Quarantine side effects.", {
@@ -45,16 +40,11 @@ drake_session <- function(path = getwd(), search = TRUE,
 #'   [readd()], [drake_plan()], [make()]
 #' @export
 #' @return A character vector of target names.
-#' @param cache optional drake cache. See code{\link{new_cache}()}.
-#'   If `cache` is supplied,
-#'   the `path` and `search` arguments are ignored.
-#' @param path Root directory of the drake project,
-#'   or if `search` is `TRUE`, either the
-#'   project root or a subdirectory of the project.
-#' @param search If `TRUE`, search parent directories
-#'   to find the nearest drake cache. Otherwise, look in the
-#'   current working directory only.
+#'
+#' @inheritParams cached
+#'
 #' @param verbose whether to print console messages
+#'
 #' @examples
 #' \dontrun{
 #' test_with_dir("Quarantine side effects.", {
@@ -84,16 +74,11 @@ in_progress <- function(path = getwd(), search = TRUE,
 #'   [readd()], [drake_plan()], [make()]
 #' @export
 #' @return A character vector of target names.
-#' @param cache optional drake cache. See code{\link{new_cache}()}.
-#'   If `cache` is supplied,
-#'   the `path` and `search` arguments are ignored.
-#' @param path Root directory of the drake project,
-#'   or if `search` is `TRUE`, either the
-#'   project root or a subdirectory of the project.
-#' @param search If `TRUE`, search parent directories
-#'   to find the nearest drake cache. Otherwise, look in the
-#'   current working directory only.
+#'
+#' @inheritParams cached
+#'
 #' @param verbose whether to print console messages
+#'
 #' @examples
 #' \dontrun{
 #' test_with_dir("Quarantine side effects.", {
@@ -130,6 +115,8 @@ failed <- function(path = getwd(), search = TRUE,
 #' @return The build progress of each target reached by
 #'   the current [make()] so far.
 #'
+#' @inheritParams cached
+#'
 #' @param ... objects to load from the cache, as names (unquoted)
 #'   or character strings (quoted). Similar to `...` in
 #'   \code{\link{remove}(...)}.
@@ -144,18 +131,6 @@ failed <- function(path = getwd(), search = TRUE,
 #' @param imported_files_only logical, deprecated. Same as
 #'   `no_imported_objects`.  Use the `no_imported_objects` argument
 #'   instead.
-#'
-#' @param cache optional drake cache. See code{\link{new_cache}()}.
-#'   If `cache` is supplied,
-#'   the `path` and `search` arguments are ignored.
-#'
-#' @param path Root directory of the drake project,
-#'   or if `search` is `TRUE`, either the
-#'   project root or a subdirectory of the project.
-#'
-#' @param search If `TRUE`, search parent directories
-#'   to find the nearest drake cache. Otherwise, look in the
-#'   current working directory only.
 #'
 #' @param verbose whether to print console messages
 #'

--- a/R/read.R
+++ b/R/read.R
@@ -5,6 +5,9 @@
 #'   [make()]
 #' @export
 #' @return The cached value of the `target`.
+#'
+#' @inheritParams cached
+#'
 #' @param target If `character_only` is `TRUE`,
 #'   `target` is a character string naming the object to read.
 #'   Otherwise, `target` is an unquoted symbol with the name of the
@@ -12,15 +15,6 @@
 #' @param character_only logical, whether `name` should be treated
 #'   as a character or a symbol
 #'   (just like `character.only` in [library()]).
-#' @param path Root directory of the drake project,
-#'   or if `search` is `TRUE`, either the
-#'   project root or a subdirectory of the project.
-#' @param search logical. If `TRUE`, search parent directories
-#'   to find the nearest drake cache. Otherwise, look in the
-#'   current working directory only.
-#' @param cache optional drake cache. See code{\link{new_cache}()}.
-#'   If `cache` is supplied,
-#'   the `path` and `search` arguments are ignored.
 #' @param namespace character scalar,
 #'   name of an optional storr namespace to read from.
 #' @param verbose whether to print console messages
@@ -70,6 +64,8 @@ readd <- function(
 #' @export
 #' @return `NULL`
 #'
+#' @inheritParams cached
+#'
 #' @param ... targets to load from the cache, as names (unquoted)
 #'   or character strings (quoted). Similar to `...` in
 #'   \code{\link{remove}(...)}.
@@ -79,18 +75,6 @@ readd <- function(
 #'
 #' @param imported_only logical, whether only imported objects
 #'   should be loaded.
-#'
-#' @param cache optional drake cache. See code{\link{new_cache}()}.
-#'   If `cache` is supplied,
-#'   the `path` and `search` arguments are ignored.
-#'
-#' @param path Root directory of the drake project,
-#'   or if `search` is `TRUE`, either the
-#'   project root or a subdirectory of the project.
-#'
-#' @param search logical. If `TRUE`, search parent directories
-#'   to find the nearest drake cache. Otherwise, look in the
-#'   current working directory only.
 #'
 #' @param namespace character scalar,
 #'   name of an optional storr namespace to load from.
@@ -318,20 +302,17 @@ bind_load_target <- function(target, cache, namespace, envir, verbose){
 #' @export
 #' @return The cached master internal configuration list
 #'   of the last [make()].
-#' @param cache optional drake cache. See code{\link{new_cache}()}.
-#'   If `cache` is supplied,
-#'   the `path` and `search` arguments are ignored.
-#' @param path Root directory of the drake project,
-#'   or if `search` is `TRUE`, either the
-#'   project root or a subdirectory of the project.
-#' @param search logical. If `TRUE`, search parent directories
-#'   to find the nearest drake cache. Otherwise, look in the
-#'   current working directory only.
+#'
+#' @inheritParams cached
+#'
 #' @param verbose whether to print console messages
+#'
 #' @param jobs number of jobs for light parallelism.
 #'   Supports 1 job only on Windows.
+#'
 #' @param envir Optional environment to fill in if
 #'   `config$envir` was not cached. Defaults to your workspace.
+#'
 #' @examples
 #' \dontrun{
 #' test_with_dir("Quarantine side effects.", {
@@ -383,18 +364,14 @@ read_drake_config <- function(
 #' @export
 #' @return An `igraph` object representing the dependency
 #'   network of the workflow.
-#' @param cache optional drake cache. See code{\link{new_cache}()}.
-#'   If `cache` is supplied,
-#'   the `path` and `search` arguments are ignored.
-#' @param path Root directory of the drake project,
-#'   or if `search` is `TRUE`, either the
-#'   project root or a subdirectory of the project.
-#' @param search logical. If `TRUE`, search parent directories
-#'   to find the nearest drake cache. Otherwise, look in the
-#'   current working directory only.
+#'
+#' @inheritParams cached
+#'
 #' @param verbose logical, whether to print console messages
+#'
 #' @param ... arguments to [visNetwork()] via
 #'   [vis_drake_graph()]
+#'
 #' @examples
 #' \dontrun{
 #' test_with_dir("Quarantine side effects.", {
@@ -431,16 +408,11 @@ read_drake_graph <- function(
 #' @seealso [read_drake_config()]
 #' @export
 #' @return A workflow plan data frame.
-#' @param cache optional drake cache. See code{\link{new_cache}()}.
-#'   If `cache` is supplied,
-#'   the `path` and `search` arguments are ignored.
-#' @param path Root directory of the drake project,
-#'   or if `search` is `TRUE`, either the
-#'   project root or a subdirectory of the project.
-#' @param search logical. If `TRUE`, search parent directories
-#'   to find the nearest drake cache. Otherwise, look in the
-#'   current working directory only.
+#'
+#' @inheritParams cached
+#'
 #' @param verbose whether to print console messages
+#'
 #' @examples
 #' \dontrun{
 #' test_with_dir("Quarantine side effects.", {
@@ -477,17 +449,12 @@ read_drake_plan <- function(
 #' even under randomness.
 #' @seealso [read_drake_config()]
 #' @export
-#' @return A workflow plan data frame.
-#' @param cache optional drake cache. See code{\link{new_cache}()}.
-#'   If `cache` is supplied,
-#'   the `path` and `search` arguments are ignored.
-#' @param path Root directory of the drake project,
-#'   or if `search` is `TRUE`, either the
-#'   project root or a subdirectory of the project.
-#' @param search logical. If `TRUE`, search parent directories
-#'   to find the nearest drake cache. Otherwise, look in the
-#'   current working directory only.
+#' @return An integer vector.
+#'
+#' @inheritParams cached
+#'
 #' @param verbose whether to print console messages
+#'
 #' @examples
 #' cache <- storr::storr_environment() # Just for the examples.
 #' my_plan <- drake_plan(

--- a/man/built.Rd
+++ b/man/built.Rd
@@ -10,11 +10,13 @@ built(path = getwd(), search = TRUE, cache = drake::get_cache(path = path,
 \arguments{
 \item{path}{Root directory of the drake project,
 or if \code{search} is \code{TRUE}, either the
-project root or a subdirectory of the project.}
+project root or a subdirectory of the project.
+Ignored if a \code{cache} is supplied.}
 
 \item{search}{logical. If \code{TRUE}, search parent directories
 to find the nearest drake cache. Otherwise, look in the
-current working directory only.}
+current working directory only.
+Ignored if a \code{cache} is supplied.}
 
 \item{cache}{drake cache. See \code{\link[=new_cache]{new_cache()}}.
 If supplied, \code{path} and \code{search} are ignored.}

--- a/man/check_plan.Rd
+++ b/man/check_plan.Rd
@@ -16,7 +16,7 @@ check_plan(plan = drake_plan(), targets = drake::possible_targets(plan),
 
 \item{envir}{environment containing user-defined functions}
 
-\item{cache}{optional drake cache. See \code{\link[=new_cache]{new_cache()}}}
+\item{cache}{optional drake cache. See \code{\link[=new_cache]{new_cache()}}.}
 
 \item{verbose}{same as for \code{\link[=make]{make()}}}
 

--- a/man/clean.Rd
+++ b/man/clean.Rd
@@ -28,15 +28,16 @@ session metadata, etc.}
 
 \item{path}{Root directory of the drake project,
 or if \code{search} is \code{TRUE}, either the
-project root or a subdirectory of the project.}
+project root or a subdirectory of the project.
+Ignored if a \code{cache} is supplied.}
 
 \item{search}{logical. If \code{TRUE}, search parent directories
 to find the nearest drake cache. Otherwise, look in the
-current working directory only.}
+current working directory only.
+Ignored if a \code{cache} is supplied.}
 
-\item{cache}{optional drake cache. See code{\link{new_cache}()}. If
-If \code{cache} is supplied,
-the \code{path} and \code{search} arguments are ignored.}
+\item{cache}{drake cache. See \code{\link[=new_cache]{new_cache()}}.
+If supplied, \code{path} and \code{search} are ignored.}
 
 \item{verbose}{whether to print console messages}
 

--- a/man/diagnose.Rd
+++ b/man/diagnose.Rd
@@ -19,15 +19,16 @@ Just like \code{character.only} in \code{\link[=library]{library()}}.}
 
 \item{path}{Root directory of the drake project,
 or if \code{search} is \code{TRUE}, either the
-project root or a subdirectory of the project.}
+project root or a subdirectory of the project.
+Ignored if a \code{cache} is supplied.}
 
-\item{search}{If \code{TRUE}, search parent directories
+\item{search}{logical. If \code{TRUE}, search parent directories
 to find the nearest drake cache. Otherwise, look in the
-current working directory only.}
+current working directory only.
+Ignored if a \code{cache} is supplied.}
 
-\item{cache}{optional drake cache. See \code{\link[=new_cache]{new_cache()}}.
-If \code{cache} is supplied,
-the \code{path} and \code{search} arguments are ignored.}
+\item{cache}{drake cache. See \code{\link[=new_cache]{new_cache()}}.
+If supplied, \code{path} and \code{search} are ignored.}
 
 \item{verbose}{whether to print console messages}
 }

--- a/man/drake_cache_log.Rd
+++ b/man/drake_cache_log.Rd
@@ -11,11 +11,13 @@ drake_cache_log(path = getwd(), search = TRUE,
 \arguments{
 \item{path}{Root directory of the drake project,
 or if \code{search} is \code{TRUE}, either the
-project root or a subdirectory of the project.}
+project root or a subdirectory of the project.
+Ignored if a \code{cache} is supplied.}
 
 \item{search}{logical. If \code{TRUE}, search parent directories
 to find the nearest drake cache. Otherwise, look in the
-current working directory only.}
+current working directory only.
+Ignored if a \code{cache} is supplied.}
 
 \item{cache}{drake cache. See \code{\link[=new_cache]{new_cache()}}.
 If supplied, \code{path} and \code{search} are ignored.}

--- a/man/drake_cache_log_file.Rd
+++ b/man/drake_cache_log_file.Rd
@@ -14,11 +14,13 @@ drake_cache_log_file(file = "drake_cache.log", path = getwd(),
 
 \item{path}{Root directory of the drake project,
 or if \code{search} is \code{TRUE}, either the
-project root or a subdirectory of the project.}
+project root or a subdirectory of the project.
+Ignored if a \code{cache} is supplied.}
 
 \item{search}{logical. If \code{TRUE}, search parent directories
 to find the nearest drake cache. Otherwise, look in the
-current working directory only.}
+current working directory only.
+Ignored if a \code{cache} is supplied.}
 
 \item{cache}{drake cache. See \code{\link[=new_cache]{new_cache()}}.
 If supplied, \code{path} and \code{search} are ignored.}

--- a/man/drake_session.Rd
+++ b/man/drake_session.Rd
@@ -11,15 +11,16 @@ drake_session(path = getwd(), search = TRUE, cache = drake::get_cache(path
 \arguments{
 \item{path}{Root directory of the drake project,
 or if \code{search} is \code{TRUE}, either the
-project root or a subdirectory of the project.}
+project root or a subdirectory of the project.
+Ignored if a \code{cache} is supplied.}
 
-\item{search}{If \code{TRUE}, search parent directories
+\item{search}{logical. If \code{TRUE}, search parent directories
 to find the nearest drake cache. Otherwise, look in the
-current working directory only.}
+current working directory only.
+Ignored if a \code{cache} is supplied.}
 
-\item{cache}{optional drake cache. See code{\link{new_cache}()}.
-If \code{cache} is supplied,
-the \code{path} and \code{search} arguments are ignored.}
+\item{cache}{drake cache. See \code{\link[=new_cache]{new_cache()}}.
+If supplied, \code{path} and \code{search} are ignored.}
 
 \item{verbose}{whether to print console messages}
 }

--- a/man/eager_load_target.Rd
+++ b/man/eager_load_target.Rd
@@ -7,9 +7,8 @@
 eager_load_target(target, cache, namespace, envir, verbose)
 }
 \arguments{
-\item{cache}{optional drake cache. See code{\link{new_cache}()}.
-If \code{cache} is supplied,
-the \code{path} and \code{search} arguments are ignored.}
+\item{cache}{drake cache. See \code{\link[=new_cache]{new_cache()}}.
+If supplied, \code{path} and \code{search} are ignored.}
 
 \item{namespace}{character scalar,
 name of an optional storr namespace to load from.}

--- a/man/failed.Rd
+++ b/man/failed.Rd
@@ -11,15 +11,16 @@ failed(path = getwd(), search = TRUE, cache = drake::get_cache(path =
 \arguments{
 \item{path}{Root directory of the drake project,
 or if \code{search} is \code{TRUE}, either the
-project root or a subdirectory of the project.}
+project root or a subdirectory of the project.
+Ignored if a \code{cache} is supplied.}
 
-\item{search}{If \code{TRUE}, search parent directories
+\item{search}{logical. If \code{TRUE}, search parent directories
 to find the nearest drake cache. Otherwise, look in the
-current working directory only.}
+current working directory only.
+Ignored if a \code{cache} is supplied.}
 
-\item{cache}{optional drake cache. See code{\link{new_cache}()}.
-If \code{cache} is supplied,
-the \code{path} and \code{search} arguments are ignored.}
+\item{cache}{drake cache. See \code{\link[=new_cache]{new_cache()}}.
+If supplied, \code{path} and \code{search} are ignored.}
 
 \item{verbose}{whether to print console messages}
 }

--- a/man/imported.Rd
+++ b/man/imported.Rd
@@ -16,11 +16,13 @@ imported objects could get really cumbersome.}
 
 \item{path}{Root directory of the drake project,
 or if \code{search} is \code{TRUE}, either the
-project root or a subdirectory of the project.}
+project root or a subdirectory of the project.
+Ignored if a \code{cache} is supplied.}
 
 \item{search}{logical. If \code{TRUE}, search parent directories
 to find the nearest drake cache. Otherwise, look in the
-current working directory only.}
+current working directory only.
+Ignored if a \code{cache} is supplied.}
 
 \item{cache}{drake cache. See \code{\link[=new_cache]{new_cache()}}.
 If supplied, \code{path} and \code{search} are ignored.}

--- a/man/in_progress.Rd
+++ b/man/in_progress.Rd
@@ -12,15 +12,16 @@ in_progress(path = getwd(), search = TRUE, cache = drake::get_cache(path =
 \arguments{
 \item{path}{Root directory of the drake project,
 or if \code{search} is \code{TRUE}, either the
-project root or a subdirectory of the project.}
+project root or a subdirectory of the project.
+Ignored if a \code{cache} is supplied.}
 
-\item{search}{If \code{TRUE}, search parent directories
+\item{search}{logical. If \code{TRUE}, search parent directories
 to find the nearest drake cache. Otherwise, look in the
-current working directory only.}
+current working directory only.
+Ignored if a \code{cache} is supplied.}
 
-\item{cache}{optional drake cache. See code{\link{new_cache}()}.
-If \code{cache} is supplied,
-the \code{path} and \code{search} arguments are ignored.}
+\item{cache}{drake cache. See \code{\link[=new_cache]{new_cache()}}.
+If supplied, \code{path} and \code{search} are ignored.}
 
 \item{verbose}{whether to print console messages}
 }

--- a/man/loadd.Rd
+++ b/man/loadd.Rd
@@ -23,15 +23,16 @@ should be loaded.}
 
 \item{path}{Root directory of the drake project,
 or if \code{search} is \code{TRUE}, either the
-project root or a subdirectory of the project.}
+project root or a subdirectory of the project.
+Ignored if a \code{cache} is supplied.}
 
 \item{search}{logical. If \code{TRUE}, search parent directories
 to find the nearest drake cache. Otherwise, look in the
-current working directory only.}
+current working directory only.
+Ignored if a \code{cache} is supplied.}
 
-\item{cache}{optional drake cache. See code{\link{new_cache}()}.
-If \code{cache} is supplied,
-the \code{path} and \code{search} arguments are ignored.}
+\item{cache}{drake cache. See \code{\link[=new_cache]{new_cache()}}.
+If supplied, \code{path} and \code{search} are ignored.}
 
 \item{namespace}{character scalar,
 name of an optional storr namespace to load from.}

--- a/man/progress.Rd
+++ b/man/progress.Rd
@@ -28,15 +28,16 @@ instead.}
 
 \item{path}{Root directory of the drake project,
 or if \code{search} is \code{TRUE}, either the
-project root or a subdirectory of the project.}
+project root or a subdirectory of the project.
+Ignored if a \code{cache} is supplied.}
 
-\item{search}{If \code{TRUE}, search parent directories
+\item{search}{logical. If \code{TRUE}, search parent directories
 to find the nearest drake cache. Otherwise, look in the
-current working directory only.}
+current working directory only.
+Ignored if a \code{cache} is supplied.}
 
-\item{cache}{optional drake cache. See code{\link{new_cache}()}.
-If \code{cache} is supplied,
-the \code{path} and \code{search} arguments are ignored.}
+\item{cache}{drake cache. See \code{\link[=new_cache]{new_cache()}}.
+If supplied, \code{path} and \code{search} are ignored.}
 
 \item{verbose}{whether to print console messages}
 

--- a/man/read_drake_config.Rd
+++ b/man/read_drake_config.Rd
@@ -11,15 +11,16 @@ read_drake_config(path = getwd(), search = TRUE, cache = NULL,
 \arguments{
 \item{path}{Root directory of the drake project,
 or if \code{search} is \code{TRUE}, either the
-project root or a subdirectory of the project.}
+project root or a subdirectory of the project.
+Ignored if a \code{cache} is supplied.}
 
 \item{search}{logical. If \code{TRUE}, search parent directories
 to find the nearest drake cache. Otherwise, look in the
-current working directory only.}
+current working directory only.
+Ignored if a \code{cache} is supplied.}
 
-\item{cache}{optional drake cache. See code{\link{new_cache}()}.
-If \code{cache} is supplied,
-the \code{path} and \code{search} arguments are ignored.}
+\item{cache}{drake cache. See \code{\link[=new_cache]{new_cache()}}.
+If supplied, \code{path} and \code{search} are ignored.}
 
 \item{verbose}{whether to print console messages}
 

--- a/man/read_drake_graph.Rd
+++ b/man/read_drake_graph.Rd
@@ -11,15 +11,16 @@ read_drake_graph(path = getwd(), search = TRUE, cache = NULL,
 \arguments{
 \item{path}{Root directory of the drake project,
 or if \code{search} is \code{TRUE}, either the
-project root or a subdirectory of the project.}
+project root or a subdirectory of the project.
+Ignored if a \code{cache} is supplied.}
 
 \item{search}{logical. If \code{TRUE}, search parent directories
 to find the nearest drake cache. Otherwise, look in the
-current working directory only.}
+current working directory only.
+Ignored if a \code{cache} is supplied.}
 
-\item{cache}{optional drake cache. See code{\link{new_cache}()}.
-If \code{cache} is supplied,
-the \code{path} and \code{search} arguments are ignored.}
+\item{cache}{drake cache. See \code{\link[=new_cache]{new_cache()}}.
+If supplied, \code{path} and \code{search} are ignored.}
 
 \item{verbose}{logical, whether to print console messages}
 

--- a/man/read_drake_meta.Rd
+++ b/man/read_drake_meta.Rd
@@ -13,15 +13,16 @@ to get metadata. If \code{NULL}, all metadata is collected.}
 
 \item{path}{Root directory of the drake project,
 or if \code{search} is \code{TRUE}, either the
-project root or a subdirectory of the project.}
+project root or a subdirectory of the project.
+Ignored if a \code{cache} is supplied.}
 
 \item{search}{logical. If \code{TRUE}, search parent directories
 to find the nearest drake cache. Otherwise, look in the
-current working directory only.}
+current working directory only.
+Ignored if a \code{cache} is supplied.}
 
-\item{cache}{optional drake cache. See code{\link{new_cache}()}.
-If \code{cache} is supplied,
-the \code{path} and \code{search} arguments are ignored.}
+\item{cache}{drake cache. See \code{\link[=new_cache]{new_cache()}}.
+If supplied, \code{path} and \code{search} are ignored.}
 
 \item{verbose}{whether to print console messages}
 

--- a/man/read_drake_plan.Rd
+++ b/man/read_drake_plan.Rd
@@ -11,15 +11,16 @@ read_drake_plan(path = getwd(), search = TRUE, cache = NULL,
 \arguments{
 \item{path}{Root directory of the drake project,
 or if \code{search} is \code{TRUE}, either the
-project root or a subdirectory of the project.}
+project root or a subdirectory of the project.
+Ignored if a \code{cache} is supplied.}
 
 \item{search}{logical. If \code{TRUE}, search parent directories
 to find the nearest drake cache. Otherwise, look in the
-current working directory only.}
+current working directory only.
+Ignored if a \code{cache} is supplied.}
 
-\item{cache}{optional drake cache. See code{\link{new_cache}()}.
-If \code{cache} is supplied,
-the \code{path} and \code{search} arguments are ignored.}
+\item{cache}{drake cache. See \code{\link[=new_cache]{new_cache()}}.
+If supplied, \code{path} and \code{search} are ignored.}
 
 \item{verbose}{whether to print console messages}
 }

--- a/man/read_drake_seed.Rd
+++ b/man/read_drake_seed.Rd
@@ -10,20 +10,21 @@ read_drake_seed(path = getwd(), search = TRUE, cache = NULL,
 \arguments{
 \item{path}{Root directory of the drake project,
 or if \code{search} is \code{TRUE}, either the
-project root or a subdirectory of the project.}
+project root or a subdirectory of the project.
+Ignored if a \code{cache} is supplied.}
 
 \item{search}{logical. If \code{TRUE}, search parent directories
 to find the nearest drake cache. Otherwise, look in the
-current working directory only.}
+current working directory only.
+Ignored if a \code{cache} is supplied.}
 
-\item{cache}{optional drake cache. See code{\link{new_cache}()}.
-If \code{cache} is supplied,
-the \code{path} and \code{search} arguments are ignored.}
+\item{cache}{drake cache. See \code{\link[=new_cache]{new_cache()}}.
+If supplied, \code{path} and \code{search} are ignored.}
 
 \item{verbose}{whether to print console messages}
 }
 \value{
-A workflow plan data frame.
+An integer vector.
 }
 \description{
 When a project is created with \code{\link[=make]{make()}}

--- a/man/readd.Rd
+++ b/man/readd.Rd
@@ -20,15 +20,16 @@ as a character or a symbol
 
 \item{path}{Root directory of the drake project,
 or if \code{search} is \code{TRUE}, either the
-project root or a subdirectory of the project.}
+project root or a subdirectory of the project.
+Ignored if a \code{cache} is supplied.}
 
 \item{search}{logical. If \code{TRUE}, search parent directories
 to find the nearest drake cache. Otherwise, look in the
-current working directory only.}
+current working directory only.
+Ignored if a \code{cache} is supplied.}
 
-\item{cache}{optional drake cache. See code{\link{new_cache}()}.
-If \code{cache} is supplied,
-the \code{path} and \code{search} arguments are ignored.}
+\item{cache}{drake cache. See \code{\link[=new_cache]{new_cache()}}.
+If supplied, \code{path} and \code{search} are ignored.}
 
 \item{namespace}{character scalar,
 name of an optional storr namespace to read from.}


### PR DESCRIPTION
Using `@inheritParams` for the `cache`, `path` and `search` arguments, inheriting from `cached()`. Also fixes return type documentation for `read_drake_seed()`.