### PR TITLE
Fix #267

### DIFF
--- a/R/build.R
+++ b/R/build.R
@@ -114,8 +114,8 @@ announce_build <- function(target, meta, config){
 
 conclude_build <- function(target, value, meta, config){
   check_processed_file(target)
-  store_target(target = target, value = value, meta = meta, config = config)
   handle_build_exceptions(target = target, meta = meta, config = config)
+  store_target(target = target, value = value, meta = meta, config = config)
   invisible(value)
 }
 

--- a/R/handlers.R
+++ b/R/handlers.R
@@ -21,6 +21,7 @@ handle_build_exceptions <- function(target, meta, config){
       text <- paste("fail", target)
       finish_console(text = text, pattern = "fail", verbose = config$verbose)
     }
+    store_failure(target = target, meta = meta, config = config)
     stop(
       "Target '", target, "' failed. Use diagnose(", target,
       ") for details.",

--- a/R/store.R
+++ b/R/store.R
@@ -1,37 +1,30 @@
 store_target <- function(target, value, meta, config) {
-  # Need complete up-to-date metadata
-  # to store targets properly.
-  # Files must have up-to-date modification times and hashes,
-  # and any metadata postponed due to custom triggers
-  # must be collected now.
   meta <- finish_meta(
     target = target,
     meta = meta,
     config = config
   )
-  if (!inherits(meta$error, "error")){
-    if (is_file(target)) {
-      store_object(
-        target = target,
-        value = meta$file,
-        meta = meta,
-        config = config
-      )
-    } else if (is.function(value)) {
-      store_function(
-        target = target,
-        value = value,
-        meta = meta,
-        config = config
-      )
-    } else {
-      store_object(
-        target = target,
-        value = value,
-        meta = meta,
-        config = config
-      )
-    }
+  if (is_file(target)) {
+    store_object(
+      target = target,
+      value = meta$file,
+      meta = meta,
+      config = config
+    )
+  } else if (is.function(value)) {
+    store_function(
+      target = target,
+      value = value,
+      meta = meta,
+      config = config
+    )
+  } else {
+    store_object(
+      target = target,
+      value = value,
+      meta = meta,
+      config = config
+    )
   }
   finalize_storage(
     target = target,
@@ -48,10 +41,9 @@ finalize_storage <- function(target, value, meta, config){
     config = config
   )
   config$cache$set(key = target, value = meta, namespace = "meta")
-  progress <- ifelse(inherits(meta$error, "error"), "failed", "finished")
   set_progress(
     target = target,
-    value = progress,
+    value = "finished",
     config = config
   )
 }
@@ -85,4 +77,21 @@ store_function <- function(target, value, meta, config){
     value = string,
     namespace = "kernels"
   )
+}
+
+store_failure <- function(target, meta, config){
+  set_progress(
+    target = target,
+    value = "failed",
+    config = config
+  )
+  for (field in c("messages", "warnings", "error")){
+    set_in_subspace(
+      key = target,
+      value = meta[[field]],
+      subspace = field,
+      namespace = "meta",
+      cache = config$cache
+    )
+  }
 }

--- a/tests/testthat/test-edge-cases.R
+++ b/tests/testthat/test-edge-cases.R
@@ -6,21 +6,24 @@ test_with_dir("failed targets do not become up to date", {
     d = 3,
     a = {
       if (fail){
-        stop()
+        stop("my failure message")
       } else {
         d
       }
     },
     b = 5,
-    c = list(a, b)
+    c = list(a, b),
+    strings_in_dots = "literals"
   )
   con <- make(plan)
   expect_equal(sort(justbuilt(con)), sort(letters[1:4]))
   fail <- TRUE
   expect_error(make(plan))
   expect_error(make(plan))
+  meta <- diagnose(a)
+  expect_true(grepl("my failure message", meta$error$message))
   con <- drake_config(plan)
-  expect_equal(outdated(con), "a")
+  expect_equal(sort(outdated(con)), sort(c("a", "c")))
 })
 
 test_with_dir("drake_plan_override() quits correctly in error", {

--- a/tests/testthat/test-edge-cases.R
+++ b/tests/testthat/test-edge-cases.R
@@ -1,5 +1,28 @@
 drake_context("edge cases")
 
+test_with_dir("failed targets do not become up to date", {
+  fail <- FALSE
+  plan <- drake_plan(
+    d = 3,
+    a = {
+      if (fail){
+        stop()
+      } else {
+        d
+      }
+    },
+    b = 5,
+    c = list(a, b)
+  )
+  con <- make(plan)
+  expect_equal(sort(justbuilt(con)), sort(letters[1:4]))
+  fail <- TRUE
+  expect_error(make(plan))
+  expect_error(make(plan))
+  con <- drake_config(plan)
+  expect_equal(outdated(con), "a")
+})
+
 test_with_dir("drake_plan_override() quits correctly in error", {
   con <- dbug()
   con$plan$missing <- "nope"


### PR DESCRIPTION
#267: failed targets were deemed "up to date" on subsequent makes. I began the `i267-attempt2` branch by reproducing the bad behavior with a failing test at the top of `test-edge-cases.R`. Then, the  solution was to clean up the final steps of the build logic, which should have proceeded as follows anyway.

1. Call `handle_build_exceptions()` before `store_target()` in `conclude_build()`.
2. In `handle_build_exceptions()`, if the build failed, store the error log, warnings, messages, and build progress (set to "failed"). (`store_target()` already takes the analogous actions for successful builds.)
3. To prevent the target from becoming "up to date", `handle_build_exceptions()` does not modify any other existing metadata in the cache.
4. `handle_build_exceptions()` quits in error if the target failed to build.
5. If `handle_build_exceptions()` does not quit in error (i.e. if the build succeeded) call `store_target()` to store the target's value and the full updated metadata.