### PR TITLE
Tidyselect for build_times()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # Version 5.1.0
 
-- Implement `dplyr`-style `tidyselect` functionality in `loadd()` and `clean()`.
+- Implement `dplyr`-style `tidyselect` functionality in `loadd()`, `clean()`, and `build_times()`. For `build_times()`, there is an API change: for `tidyselect` to work, we needed to insert a new `...` argument as the first argument of `build_times()`.
 - Deprecate the single-quoting API for files. Users should now use
     - `file_in()` for file inputs to commands or imported functions (for imported functions, the input file needs to be an imported file, not a target).
     - `file_out()` for output file targets (ignored if used in imported functions).

--- a/R/build_times.R
+++ b/R/build_times.R
@@ -6,6 +6,9 @@
 #' @seealso [built()]
 #' @export
 #' @return A data frame of times, each from [system.time()].
+#' @param ... targets to load from the cache: as names (symbols),
+#'   character strings, or `dplyr`-style `tidyselect`
+#'   commands such as `starts_with()`.
 #' @param targets_only logical, whether to only return the
 #'   build times of the targets (exclude the imports).
 #' @param path Root directory of the drake project,
@@ -30,9 +33,11 @@
 #' load_basic_example() # Get the code with drake_example("basic").
 #' make(my_plan) # Build all the targets.
 #' build_times() # Show how long it took to build each target.
+#' build_times(starts_with("coef")) # `dplyr`-style `tidyselect`
 #' })
 #' }
 build_times <- function(
+  ...,
   path = getwd(),
   search = TRUE,
   digits = 3,
@@ -45,9 +50,13 @@ build_times <- function(
   if (is.null(cache)){
     return(empty_times())
   }
+  targets <- drake_select(cache = cache, ..., namespace = "meta")
+  if (!length(targets)){
+    targets <- cache$list(namespace = "meta")
+  }
   type <- match.arg(type)
   out <- lightly_parallelize(
-    X = cache$list(namespace = "meta"),
+    X = targets,
     FUN = fetch_runtime,
     jobs = 1,
     cache = cache,

--- a/man/build_times.Rd
+++ b/man/build_times.Rd
@@ -4,12 +4,16 @@
 \alias{build_times}
 \title{List the time it took to build each target/import.}
 \usage{
-build_times(path = getwd(), search = TRUE, digits = 3,
+build_times(..., path = getwd(), search = TRUE, digits = 3,
   cache = get_cache(path = path, search = search, verbose = verbose),
   targets_only = FALSE, verbose = TRUE, jobs = 1, type = c("build",
   "command"))
 }
 \arguments{
+\item{...}{targets to load from the cache: as names (symbols),
+character strings, or \code{dplyr}-style \code{tidyselect}
+commands such as \code{starts_with()}.}
+
 \item{path}{Root directory of the drake project,
 or if \code{search} is \code{TRUE}, either the
 project root or a subdirectory of the project.}
@@ -51,6 +55,7 @@ test_with_dir("Quarantine side effects.", {
 load_basic_example() # Get the code with drake_example("basic").
 make(my_plan) # Build all the targets.
 build_times() # Show how long it took to build each target.
+build_times(starts_with("coef")) # `dplyr`-style `tidyselect`
 })
 }
 }

--- a/tests/testthat/test-basic.R
+++ b/tests/testthat/test-basic.R
@@ -100,7 +100,7 @@ test_with_dir("basic example works", {
   loadd(starts_with("coef"), envir = e)
   expect_equal(sort(ls(envir = e)), coefs)
 
-  # build_times()
+  # build_times() # nolint
   all_times <- build_times()
   expect_true(nrow(all_times) >= nrow(config$plan))
   some_times <- build_times(starts_with("coef"))

--- a/tests/testthat/test-basic.R
+++ b/tests/testthat/test-basic.R
@@ -95,10 +95,16 @@ test_with_dir("basic example works", {
   # Take this opportunity to test tidyselect API. Saves test time that way.
   # loadd() # nolint
   e <- new.env(parent = globalenv())
-  coefs <- c("coef_regression1_large", "coef_regression1_small",
-             "coef_regression2_large", "coef_regression2_small")
+  coefs <- sort(c("coef_regression1_large", "coef_regression1_small",
+             "coef_regression2_large", "coef_regression2_small"))
   loadd(starts_with("coef"), envir = e)
-  expect_equal(sort(ls(envir = e)), sort(coefs))
+  expect_equal(sort(ls(envir = e)), coefs)
+
+  # build_times()
+  all_times <- build_times()
+  expect_true(nrow(all_times) >= nrow(config$plan))
+  some_times <- build_times(starts_with("coef"))
+  expect_equal(sort(some_times$item), coefs)
 
   # clean() # nolint
   x <- sort(cached())

--- a/vignettes/timing.Rmd
+++ b/vignettes/timing.Rmd
@@ -32,6 +32,9 @@ make(my_plan, jobs = 2, verbose = FALSE) # See also max_useful_jobs(my_plan).
 
 build_times(digits = 8) # From the cache.
 
+# `dplyr`-style `tidyselect` commands
+build_times(starts_with("coef"), digits = 8)
+
 build_times(digits = 8, targets_only = TRUE)
 ```
 


### PR DESCRIPTION
# Summary

- Add and document a new `...` argument as the first argument of `build_times()`.
- Add examples in the help file of `build_times()` and the `timing.Rmd` vignette.
- Add a test at the end of `tests/testthat/test-basic.R`
- Update `NEWS.md`.

# GitHub issues fixed

- Ref: #209

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review and/or merge.

cc @dapperjapper and @krlmlr. Kirill, what are your thoughts about the API change? What kind of version bump does it require? I was planning to use 5.1.0 for the next CRAN version.
