### PR TITLE
Catch worker crashes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,7 @@ Please explain the context and purpose of your contribution and list the changes
 - [ ] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
 - [ ] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
 - [ ] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
+- [ ] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
 - [ ] I have tested this pull request locally with `devtools::check()`
 - [ ] This pull request is ready for review and/or merge.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # Version 5.1.0
 
+- Add a new experimental `"future"` backend with a manual scheduler.
 - Implement `dplyr`-style `tidyselect` functionality in `loadd()`, `clean()`, and `build_times()`. For `build_times()`, there is an API change: for `tidyselect` to work, we needed to insert a new `...` argument as the first argument of `build_times()`.
 - Deprecate the single-quoting API for files. Users should now use
     - `file_in()` for file inputs to commands or imported functions (for imported functions, the input file needs to be an imported file, not a target).

--- a/R/build.R
+++ b/R/build.R
@@ -67,7 +67,7 @@ drake_build <- function(
   build_and_store(target = target, config = config)
 }
 
-build_and_store <- function(target, config, meta = NULL){
+build_and_store <- function(target, config, meta = NULL, announce = TRUE){
   # The environment should have been pruned by now.
   # For staged parallelism, this was already done in bulk
   # for the whole stage.
@@ -77,7 +77,9 @@ build_and_store <- function(target, config, meta = NULL){
       meta <- drake_meta(target = target, config = config)
     }
     meta$start <- proc.time()
-    announce_build(target = target, meta = meta, config = config)
+    if (announce){
+      announce_build(target = target, meta = meta, config = config)
+    }
     build <- just_build(target = target, meta = meta, config = config)
     conclude_build(
       target = target,

--- a/R/build.R
+++ b/R/build.R
@@ -121,7 +121,6 @@ conclude_build <- function(target, value, meta, config){
   invisible(value)
 }
 
-
 check_processed_file <- function(target){
   if (!is_file(target)){
     return()

--- a/R/future.R
+++ b/R/future.R
@@ -201,6 +201,9 @@ conclude_worker <- function(worker, config, queue){
 }
 
 get_worker_value <- function(worker){
+  
+  browser()
+  
   tryCatch(
     future::value(worker),
     error = function(e){

--- a/R/future.R
+++ b/R/future.R
@@ -173,7 +173,7 @@ decrease_revdep_keys <- function(worker, config, queue){
 # Currently only needed for "future_commands" workers
 # since "future_total" workers already conclude the build
 # and store the results.
-conclude_worker <- function(target, worker, config, queue){
+conclude_worker <- function(worker, config, queue){
   decrease_revdep_keys(
     worker = worker,
     queue = queue,
@@ -188,7 +188,7 @@ conclude_worker <- function(target, worker, config, queue){
   if (config$caching == "worker"){
     return(out)
   }
-  build <- get_worker_value(target = target, worker = worker)
+  build <- get_worker_value(worker = worker)
   config$hook({
     conclude_build(
       target = build$target,
@@ -200,7 +200,7 @@ conclude_worker <- function(target, worker, config, queue){
   out
 }
 
-get_worker_value <- function(target, worker){
+get_worker_value <- function(worker){
   tryCatch(
     future::value(worker),
     error = function(e){
@@ -209,7 +209,7 @@ get_worker_value <- function(target, worker){
         "Is something wrong with your system or job scheduler?"
       )
       list(
-        target = target,
+        target = attr(worker, "target"),
         value = e,
         meta = list(error = e)
       )

--- a/R/future.R
+++ b/R/future.R
@@ -201,9 +201,6 @@ conclude_worker <- function(worker, config, queue){
 }
 
 get_worker_value <- function(worker){
-  
-  browser()
-  
   tryCatch(
     future::value(worker),
     error = function(e){

--- a/R/future.R
+++ b/R/future.R
@@ -200,7 +200,7 @@ conclude_worker <- function(target, worker, config, queue){
   out
 }
 
-get_worker_value = function(target, worker){
+get_worker_value <- function(target, worker){
   tryCatch(
     future::value(worker),
     error = function(e){
@@ -214,5 +214,5 @@ get_worker_value = function(target, worker){
         meta = list(error = e)
       )
     }
-  ) 
+  )
 }

--- a/R/future.R
+++ b/R/future.R
@@ -188,7 +188,7 @@ conclude_worker <- function(target, worker, config, queue){
   if (config$caching == "worker"){
     return(out)
   }
-  build <- get_future_build(target = target, worker = worker)
+  build <- get_worker_value(target = target, worker = worker)
   config$hook({
     conclude_build(
       target = build$target,
@@ -200,13 +200,13 @@ conclude_worker <- function(target, worker, config, queue){
   out
 }
 
-get_future_build = function(target, worker){
+get_worker_value = function(target, worker){
   tryCatch(
     future::value(worker),
     error = function(e){
       e$message <- paste0(
         "Worker terminated unexpectedly before the target could complete. ",
-        "Is something wrong with your job scheduler?"
+        "Is something wrong with your system or job scheduler?"
       )
       list(
         target = target,

--- a/tests/testthat/test-future.R
+++ b/tests/testthat/test-future.R
@@ -62,20 +62,24 @@ test_with_dir("prepare_distributed() writes cache folder if nonexistent", {
 })
 
 test_with_dir("can gracefully conclude a crashed worker", {
-  con <- dbug()
-  con$caching <- "master"
-  worker <- list()
-  class(worker) <- "Future"
-  expect_false(is_empty_worker(worker))
-  expect_error(future::value(worker))
-  expect_error(
-    conclude_worker(
-      target = "myinput",
-      worker = worker,
-      config = con,
-      queue = new_target_queue(config = con)
+  for(caching in c("master", "worker")){
+    con <- dbug()
+    con$caching <- caching
+    con$execution_graph <- con$graph
+    worker <- structure(list(), target = "myinput")
+    class(worker) <- "Future"
+    expect_false(is_empty_worker(worker))
+    expect_error(future::value(worker))
+    expect_error(
+      conclude_worker(
+        worker = worker,
+        config = con,
+        queue = new_target_queue(config = con)
+      ),
+      regexp = "failed. Use diagnose"
     )
-  )
-  meta <- diagnose(myinput)
-  expect_true(grepl("Worker terminated unexpectedly", meta$error$message))
+    meta <- diagnose(myinput)
+    expect_true(grepl("Worker terminated unexpectedly", meta$error$message))
+    clean(destroy = TRUE)
+  }
 })

--- a/tests/testthat/test-future.R
+++ b/tests/testthat/test-future.R
@@ -60,3 +60,22 @@ test_with_dir("prepare_distributed() writes cache folder if nonexistent", {
   prepare_distributed(config)
   expect_true(file.exists("nope"))
 })
+
+test_with_dir("can properly conclude a worker that can't get a value", {
+  con <- dbug()
+  con$caching <- "master"
+  worker <- list()
+  class(worker) <- "Future"
+  expect_false(is_empty_worker(worker))
+  expect_error(future::value(worker))
+  expect_error(
+    conclude_worker(
+      target = "myinput",
+      worker = worker,
+      config = con,
+      queue = new_target_queue(config = con)
+    )
+  )
+  meta <- diagnose(myinput)
+  expect_true(grepl("Worker terminated unexpectedly", meta$error$message))
+})

--- a/tests/testthat/test-future.R
+++ b/tests/testthat/test-future.R
@@ -61,7 +61,7 @@ test_with_dir("prepare_distributed() writes cache folder if nonexistent", {
   expect_true(file.exists("nope"))
 })
 
-test_with_dir("can properly conclude a worker that can't get a value", {
+test_with_dir("can gracefully conclude a crashed worker", {
   con <- dbug()
   con$caching <- "master"
   worker <- list()

--- a/tests/testthat/test-future.R
+++ b/tests/testthat/test-future.R
@@ -62,7 +62,7 @@ test_with_dir("prepare_distributed() writes cache folder if nonexistent", {
 })
 
 test_with_dir("can gracefully conclude a crashed worker", {
-  for(caching in c("master", "worker")){
+  for (caching in c("master", "worker")){
     con <- dbug()
     con$caching <- caching
     con$execution_graph <- con$graph

--- a/tests/testthat/test-queue.R
+++ b/tests/testthat/test-queue.R
@@ -1,6 +1,6 @@
 drake_context("queue")
 
-test_that("the priority queue works", {
+test_with_dir("the priority queue works", {
   names <- c("foo", "bar", "baz", "Bob", "Amy", "Joe", "soup", "spren")
   priorities <- c(8, 2, 3, 7, 4, 1, 7, 5)
   priorities[4] <- priorities[7]


### PR DESCRIPTION
# Summary

- More gracefully handle workers that crash: if `future::resolved(f)` returns an error, simply wrap the error into the target's metadata and make it available for `diagnose()`.

```r
plan <- drake_plan(target = Sys.sleep(Inf))
# Does not yet work for multicore: https://github.com/HenrikBengtsson/future/issues/199
future::plan(future::multisession)
# Works with caching = "worker" or "master"
make(plan, parallelism = "future", keep_going = TRUE)
# Now kill the worker process. I could not add a proper unit test for this,
# but I spoof it at the end of tests/testthat/test-future.R
# with both kinds of caching.
diagnose(target)$error$message
## [1] "Worker terminated unexpectedly before the target could complete.
##  Is something wrong with your system or job scheduler?"
```

- Print green `target x` messages, without duplication, regardless of whether `caching` is `"master"` or `"worker`". Depending on the `future::plan()`, it is not always possible to print out load/unload messages.
- Update `NEWS.md`: totally forgot to mention the manual scheduler in #259.
- Update `PULL_REQUEST_TEMPLATE.md` to ask that contributors write tests for substantially new/changed functionality.

# GitHub issues fixed

- Ref: #270 

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review and/or merge.
