### PR TITLE
Update expand() [deprecated] to expand_plan() in instructional commen…

### DIFF
--- a/inst/examples/basic/R/plan.R
+++ b/inst/examples/basic/R/plan.R
@@ -7,7 +7,7 @@ my_datasets <- drake_plan(
   large = simulate(64)
 )
 
-# Optionally, get replicates with expand(my_datasets,
+# Optionally, get replicates with expand_plan(my_datasets,
 #   values = c("rep1", "rep2")).
 # Bootstrapping involves randomness, so this is good practice
 # in real life. But this is a miniaturized workflow,

--- a/inst/examples/basic/interactive-tutorial.R
+++ b/inst/examples/basic/interactive-tutorial.R
@@ -99,7 +99,7 @@ my_datasets <- drake_plan(
   large = simulate(64)
 )
 
-# Optionally, get replicates with expand(my_datasets,
+# Optionally, get replicates with expand_plan(my_datasets,
 #   values = c("rep1", "rep2")).
 # Bootstrapping involves randomness, so this is good practice
 # in real life. But this is a miniaturized workflow,


### PR DESCRIPTION
# Summary

This PR is a tiny update to the `basic example` vignette and R code. 

In the comments, the user encouraged to expand the analysis plan. `expand()` is suggested, but if the user does so, it throws a deprecation warning; I've updated it to `expand_plan()` so that users following the suggestion will use the correct function.