### PR TITLE
Allow different sets of jobs for imports and targets

### DIFF
--- a/R/Makefile.R
+++ b/R/Makefile.R
@@ -147,7 +147,7 @@ mk <- function(
 #' default_Makefile_args(jobs = 2, verbose = FALSE)
 #' default_Makefile_args(jobs = 4, verbose = TRUE)
 default_Makefile_args <- function(jobs, verbose){
-  out <- paste0("--jobs=", jobs)
+  out <- paste0("--jobs=", jobs_targets(jobs))
   if (!verbose){
     out <- c(out, "--silent")
   }

--- a/R/check.R
+++ b/R/check.R
@@ -116,8 +116,8 @@ check_jobs <- function(jobs){
   stopifnot(length(jobs) > 0)
   stopifnot(is.numeric(jobs) || is.integer(jobs))
   stopifnot(all(jobs > 0))
-  if(!is.null(names(jobs))){
-    if(!identical(sort(names(jobs)), sort(c("imports", "targets")))){
+  if (!is.null(names(jobs))){
+    if (!identical(sort(names(jobs)), sort(c("imports", "targets")))){
       stop(
         "In the `jobs` argument, you must either give an unnamed numeric ",
         "or a named numeric with names 'imports' and 'targets'.",

--- a/R/check.R
+++ b/R/check.R
@@ -111,3 +111,18 @@ check_drake_graph <- function(graph){
     multiline_message(cycles)
   )
 }
+
+check_jobs <- function(jobs){
+  stopifnot(length(jobs) > 0)
+  stopifnot(is.numeric(jobs) || is.integer(jobs))
+  stopifnot(all(jobs > 0))
+  if(!is.null(names(jobs))){
+    if(!identical(sort(names(jobs)), sort(c("imports", "targets")))){
+      stop(
+        "In the `jobs` argument, you must either give an unnamed numeric ",
+        "or a named numeric with names 'imports' and 'targets'.",
+        call. = FALSE
+      )
+    }
+  }
+}

--- a/R/config.R
+++ b/R/config.R
@@ -89,6 +89,13 @@
 #'   who use `parallelism = "Makefile"` will need to
 #'   download and install Rtools.
 #'
+#'   Imports and targets are processed separately, and they usually
+#'   have different parallelism needs. To use at most 2 jobs at a time
+#'   for imports and at most 4 jobs at a time for targets, call
+#'   `make(..., jobs = c(imports = 2, targets = 4))`,
+#'   `make(..., jobs = c(targets = 4, imports = 2))`,
+#'   or `make(..., jobs = c(2, 4))`.
+#'
 #'   For `"future_lapply"` parallelism, `jobs`
 #'   only applies to the imports.
 #'   To set the max number of jobs for `"future_lapply"`
@@ -106,7 +113,8 @@
 #'   for your system and uses the number of jobs you give to the `jobs`
 #'   argument to [make()]. To use at most 2 jobs for imports and at
 #'   most 4 jobs for targets, run
-#'   `make(..., parallelism = "Makefile", jobs = 2, args = "--jobs=4")`
+#'   `make(..., parallelism = "Makefile", jobs = c(imports = 2, targets = 4))` or
+#'   `make(..., parallelism = "Makefile", jobs = 2, args = "--jobs=4")`.
 #'
 #' @param packages character vector packages to load, in the order
 #'   they should be loaded. Defaults to `rev(.packages())`, so you

--- a/R/make.R
+++ b/R/make.R
@@ -224,6 +224,7 @@ make_with_config <- function(config){
 #' }
 make_imports <- function(config){
   config$execution_graph <- imports_graph(config = config)
+  config$jobs <- jobs_imports(jobs = config$jobs)
   config$parallelism <- use_default_parallelism(config$parallelism)
   run_parallel_backend(config = config)
   invisible(config)
@@ -272,6 +273,7 @@ imports_graph <- function(config){
 #' }
 make_targets <- function(config){
   config$execution_graph <- targets_graph(config = config)
+  config$jobs <- jobs_targets(jobs = config$jobs)
   run_parallel_backend(config = config)
   console_up_to_date(config = config)
   invisible(config)

--- a/R/parallel.R
+++ b/R/parallel.R
@@ -27,8 +27,30 @@ lightly_parallelize_atomic <- function(X, FUN, jobs = 1, ...){
   values[index]
 }
 
+jobs_imports <- function(jobs){
+  check_jobs(jobs)
+  if (length(jobs) < 2){
+    jobs
+  } else if (is.null(names(jobs))){
+    jobs[1]
+  } else {
+    jobs["imports"]
+  }
+}
+
+jobs_targets <- function(jobs){
+  check_jobs(jobs)
+  if (length(jobs) < 2){
+    jobs
+  } else if (is.null(names(jobs))){
+    jobs[2]
+  } else {
+    jobs["targets"]
+  }
+}
+
 safe_jobs <- function(jobs){
-  ifelse(on_windows(), 1, jobs)
+  ifelse(on_windows(), 1, jobs_imports(jobs = jobs))
 }
 
 on_windows <- function(){

--- a/R/parallel.R
+++ b/R/parallel.R
@@ -34,7 +34,7 @@ jobs_imports <- function(jobs){
   } else if (is.null(names(jobs))){
     jobs[1]
   } else {
-    jobs["imports"]
+    unname(jobs["imports"])
   }
 }
 
@@ -45,7 +45,7 @@ jobs_targets <- function(jobs){
   } else if (is.null(names(jobs))){
     jobs[2]
   } else {
-    jobs["targets"]
+    unname(jobs["targets"])
   }
 }
 

--- a/man/drake_config.Rd
+++ b/man/drake_config.Rd
@@ -102,6 +102,13 @@ Windows users should not set \code{jobs > 1} if
 who use \code{parallelism = "Makefile"} will need to
 download and install Rtools.
 
+Imports and targets are processed separately, and they usually
+have different parallelism needs. To use at most 2 jobs at a time
+for imports and at most 4 jobs at a time for targets, call
+\code{make(..., jobs = c(imports = 2, targets = 4))},
+\code{make(..., jobs = c(targets = 4, imports = 2))},
+or \code{make(..., jobs = c(2, 4))}.
+
 For \code{"future_lapply"} parallelism, \code{jobs}
 only applies to the imports.
 To set the max number of jobs for \code{"future_lapply"}
@@ -119,7 +126,8 @@ process imported objects and files, drake selects the best parallel backend
 for your system and uses the number of jobs you give to the \code{jobs}
 argument to \code{\link[=make]{make()}}. To use at most 2 jobs for imports and at
 most 4 jobs for targets, run
-\code{make(..., parallelism = "Makefile", jobs = 2, args = "--jobs=4")}}
+\code{make(..., parallelism = "Makefile", jobs = c(imports = 2, targets = 4))} or
+\code{make(..., parallelism = "Makefile", jobs = 2, args = "--jobs=4")}.}
 
 \item{packages}{character vector packages to load, in the order
 they should be loaded. Defaults to \code{rev(.packages())}, so you

--- a/man/make.Rd
+++ b/man/make.Rd
@@ -101,6 +101,13 @@ Windows users should not set \code{jobs > 1} if
 who use \code{parallelism = "Makefile"} will need to
 download and install Rtools.
 
+Imports and targets are processed separately, and they usually
+have different parallelism needs. To use at most 2 jobs at a time
+for imports and at most 4 jobs at a time for targets, call
+\code{make(..., jobs = c(imports = 2, targets = 4))},
+\code{make(..., jobs = c(targets = 4, imports = 2))},
+or \code{make(..., jobs = c(2, 4))}.
+
 For \code{"future_lapply"} parallelism, \code{jobs}
 only applies to the imports.
 To set the max number of jobs for \code{"future_lapply"}
@@ -118,7 +125,8 @@ process imported objects and files, drake selects the best parallel backend
 for your system and uses the number of jobs you give to the \code{jobs}
 argument to \code{\link[=make]{make()}}. To use at most 2 jobs for imports and at
 most 4 jobs for targets, run
-\code{make(..., parallelism = "Makefile", jobs = 2, args = "--jobs=4")}}
+\code{make(..., parallelism = "Makefile", jobs = c(imports = 2, targets = 4))} or
+\code{make(..., parallelism = "Makefile", jobs = 2, args = "--jobs=4")}.}
 
 \item{packages}{character vector packages to load, in the order
 they should be loaded. Defaults to \code{rev(.packages())}, so you

--- a/tests/testthat/test-parallel.R
+++ b/tests/testthat/test-parallel.R
@@ -1,5 +1,21 @@
 drake_context("parallel")
 
+test_with_dir("check_jobs()", {
+  expect_error(check_jobs(NULL), regexp = "length")
+  expect_error(check_jobs(-1), regexp = "jobs > 0")
+  expect_error(check_jobs(c(-1, 1)), regexp = "jobs > 0")
+  expect_error(check_jobs(c(a = 1, targets = 5)), regexp = "targets")
+  expect_silent(check_jobs(1))
+  expect_silent(check_jobs(1:2))
+  expect_silent(check_jobs(c(targets = 5, imports = 6)))
+  expect_silent(check_jobs(c(imports = 5, targets = 6)))
+})
+
+test_with_dir("targets_imports()", {
+  
+  
+})
+
 test_with_dir("parallelism not found for testrun()", {
   config <- list(parallelism = "not found", verbose = FALSE)
   suppressWarnings(expect_error(testrun(config)))

--- a/tests/testthat/test-parallel.R
+++ b/tests/testthat/test-parallel.R
@@ -11,7 +11,7 @@ test_with_dir("check_jobs()", {
   expect_silent(check_jobs(c(imports = 5, targets = 6)))
 })
 
-test_with_dir("targets_imports()", {
+test_with_dir("jobs_imports() and jobs_targets()", {
   
   
 })

--- a/tests/testthat/test-parallel.R
+++ b/tests/testthat/test-parallel.R
@@ -11,9 +11,20 @@ test_with_dir("check_jobs()", {
   expect_silent(check_jobs(c(imports = 5, targets = 6)))
 })
 
-test_with_dir("jobs_imports() and jobs_targets()", {
-  
-  
+test_with_dir("jobs_imports()", {
+  expect_equal(jobs_imports(8), 8)
+  expect_equal(jobs_imports(c(8, 12)), 8)
+  expect_equal(jobs_imports(c(8, 1)), 8)
+  expect_equal(jobs_imports(c(targets = 8, imports = 12)), 12)
+  expect_equal(jobs_imports(c(imports = 8, targets = 12)), 8)
+})
+
+test_with_dir("jobs_targets()", {
+  expect_equal(jobs_targets(8), 8)
+  expect_equal(jobs_targets(c(8, 12)), 12)
+  expect_equal(jobs_targets(c(8, 1)), 1)
+  expect_equal(jobs_targets(c(targets = 8, imports = 12)), 8)
+  expect_equal(jobs_targets(c(imports = 8, targets = 12)), 12)
 })
 
 test_with_dir("parallelism not found for testrun()", {


### PR DESCRIPTION
# Summary

Optionally set a different number of jobs for targets vs imports. Seems to work as expected on an old project I keep around for testing.

```r
# Impose a max of 4 jobs at a time for each of targets and imports.
make(..., jobs = 4)

# Max of 2 jobs at a time for imports, max of 4 jobs at a time for targets
make(..., jobs = c(imports = 2, targets = 4))

# Same
make(..., jobs = c(2, 4))
```

# GitHub issues fixed

- Ref: #251

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review and/or merge.
