### PR TITLE
Fix #305 raise error on duplicate target names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # Version 5.1.0
 
+- Add check to drake_plan() to check for duplicate targets
 - Add a `.gitignore` file containing `"*"` to the default `.drake/` cache folder every time `new_cache()` is called. This means the cache will not be automatically committed to git. Users need to remove `.gitignore` file to allow unforced commits, and then subsequent `make()`s on the same cache will respect the user's wishes and not add another `.gitignore`. this only works for the default cache. Not supported for manual `storr`s.
 - Add a new experimental `"future"` backend with a manual scheduler.
 - Implement `dplyr`-style `tidyselect` functionality in `loadd()`, `clean()`, and `build_times()`. For `build_times()`, there is an API change: for `tidyselect` to work, we needed to insert a new `...` argument as the first argument of `build_times()`.

--- a/R/workplan.R
+++ b/R/workplan.R
@@ -135,6 +135,9 @@ drake_plan <- function(
   }
   commands <- complete_target_names(commands)
   targets <- names(commands)
+  if ( any(duplicated(targets)) ) {
+    stop("Duplicate target names '", paste(targets[duplicated(targets)], collapse = ", "), "' detected! The target names have to be unique!")
+  }
   commands <- as.character(commands)
   plan <- tibble(
     target = targets,


### PR DESCRIPTION
# Summary
Raise error when duplictate target names are detected in targets

# GitHub issues fixed

- Closes #305 

# Checklist
Only the testhat test is missing - can add it later when this change is OK

- [X] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [X] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
- [X] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).

- [ ] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [X] I have tested this pull request locally with `devtools::check()`
- [X] This pull request is ready for review and/or merge.
