### PR TITLE
Revert "Set use_cache = FALSE in readd()"

### DIFF
--- a/R/read.R
+++ b/R/read.R
@@ -52,7 +52,7 @@ readd <- function(
   cache$get(
     standardize_filename(target),
     namespace = namespace,
-    use_cache = FALSE
+    use_cache = TRUE
   )
 }
 


### PR DESCRIPTION
This reverts commit de353924e0dec55d37ba5ee9ffd1e8a2adaa31d4.

I think caching here is as important as for `loadd(lazy = "bind")`.