### PR TITLE
Resist loading imported functions with loadd()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 # Version 5.1.0
 
+- Deprecate the `imported_only` argument in `loadd()`.
+- Warn about imported functions loaded with `loadd()`.
 - Change `loadd()` so that only targets (not imports) are loaded if the `...` and `list` arguments are empty.
+- Exclude imports from `loadd(deps = TRUE)`.
 - Add check to drake_plan() to check for duplicate targets
 - Add a `.gitignore` file containing `"*"` to the default `.drake/` cache folder every time `new_cache()` is called. This means the cache will not be automatically committed to git. Users need to remove `.gitignore` file to allow unforced commits, and then subsequent `make()`s on the same cache will respect the user's wishes and not add another `.gitignore`. this only works for the default cache. Not supported for manual `storr`s.
 - Add a new experimental `"future"` backend with a manual scheduler.
@@ -29,7 +32,6 @@ across R sessions.
 - Preprocess workflow plan commands with `rlang::expr()` before evaluating them. That means you can use the quasiquotation operator `!!` in your commands, and `make()` will evaluate them according to the tidy evaluation paradigm.
 - Restructure `drake_example("basic")`, `drake_example("gsp")`, and `drake_example("packages")` to demonstrate how to set up the files for serious `drake` projects. More guidance was needed in light of [this issue](https://github.com/ropensci/drake/issues/193).
 - Improve the examples of `drake_plan()` in the help file (`?drake_plan`).
-- Warn if double quotes appear in target names.
 
 # Version 5.0.0
 

--- a/R/cache_ui.R
+++ b/R/cache_ui.R
@@ -236,16 +236,6 @@ targets_only <- function(targets, cache, jobs) {
   )
 }
 
-imported_only <- function(targets, cache, jobs) {
-  parallel_filter(
-    x = targets,
-    f = function(target){
-      is_imported(target = target, cache = cache)
-    },
-    jobs = jobs
-  )
-}
-
 no_imported_objects <- function(targets, cache, jobs) {
   parallel_filter(
     x = targets,

--- a/R/cache_ui.R
+++ b/R/cache_ui.R
@@ -226,6 +226,16 @@ targets_from_dots <- function(dots, list) {
   standardize_filename(targets)
 }
 
+targets_only <- function(targets, cache, jobs) {
+  parallel_filter(
+    x = targets,
+    f = function(target){
+      !is_imported(target = target, cache = cache)
+    },
+    jobs = jobs
+  )
+}
+
 imported_only <- function(targets, cache, jobs) {
   parallel_filter(
     x = targets,

--- a/man/loadd.Rd
+++ b/man/loadd.Rd
@@ -18,8 +18,10 @@ commands such as \code{starts_with()}.}
 \item{list}{character vector naming targets to be loaded from the
 cache. Similar to the \code{list} argument of \code{\link[=remove]{remove()}}.}
 
-\item{imported_only}{logical, whether only imported objects
-should be loaded.}
+\item{imported_only}{deprecated logical. Loading imported functions
+into your workspace may interfere with dependency detection
+and put some targets out of date. Use \code{\link[=readd]{readd()}} to get
+imported functions and use different names where possible.}
 
 \item{path}{Root directory of the drake project,
 or if \code{search} is \code{TRUE}, either the
@@ -54,6 +56,8 @@ instead of the targets themselves.
 This is useful if you know your
 target failed and you want to debug the command in an interactive
 session with the dependencies in your workspace.
+Imports are excluded here. In other words, only targets in the workflow
+plan are loaded.
 One caveat: to find the dependencies,
 \code{\link[=loadd]{loadd()}} uses information that was stored
 in a \code{\link[=drake_config]{drake_config()}} list and cached
@@ -106,9 +110,6 @@ loadd(starts_with("summ"))
 ls()
 # Load the dependencies of the target, coef_regression2_small
 loadd(coef_regression2_small, deps = TRUE)
-ls()
-# Load all the imported objects/functions.
-loadd(imported_only = TRUE)
 ls()
 # Load all the targets listed in the workflow plan
 # of the previous `make()`.

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -218,19 +218,16 @@ test_with_dir("cache functions work", {
   # load and read stuff
   list <- intersect(c(imported(), built()), ls(envir = envir))
   rm(list = list, envir = envir)
-  expect_error(h(1))
   expect_true(is.numeric(readd(final, search = FALSE)))
-  expect_error(loadd(yourinput, myinput, search = FALSE, imported_only = TRUE))
-  loadd(h, i, j, c, jobs = 2, search = FALSE, envir = envir)
-  expect_true(is.numeric(h(1)))
-  rm(h, i, j, c, envir = envir)
-  expect_error(h(1))
+
+  e <- new.env()
+  loadd(yourinput, myinput, jobs = 2, search = FALSE, envir = e)
+  expect_true(is.numeric(e$yourinput))
+  expect_true(is.numeric(e$myinput))
 
   # test loadd imported_only and loadd() everything
-  loadd(imported_only = TRUE)
-  expect_true(all(imported(search = FALSE) %in% ls()))
   loadd(search = FALSE)
-  expect_true(all(config$cache$list() %in% ls()))
+  expect_true(all(built(cache = config$cache) %in% ls()))
   rm(list = intersect(all, ls()))
 
   # search from a different directory
@@ -289,7 +286,10 @@ test_with_dir("cache functions work", {
   expect_true(is.numeric(readd(a, path = s, search = TRUE)))
   expect_error(h(1))
   expect_error(j(1))
-  loadd(h, i, j, c, path = s, search = TRUE, envir = envir)
+  expect_warning(
+    loadd(h, i, j, c, path = s, search = TRUE, envir = envir),
+    regexp = "Loaded imported functions"
+  )
   expect_true(is.numeric(h(1)))
   rm(h, i, j, c, envir = envir)
   expect_error(h(1))

--- a/tests/testthat/test-deprecate.R
+++ b/tests/testthat/test-deprecate.R
@@ -15,6 +15,7 @@ test_with_dir("deprecation: cache functions", {
   plan <- drake_plan(x = 1)
   expect_error(expect_warning(tmp <- read_drake_meta(search = FALSE)))
   expect_silent(make(plan, verbose = FALSE, session_info = FALSE))
+  expect_warning(loadd(imported_only = TRUE))
   expect_true(is.numeric(readd(x, search = FALSE)))
   expect_equal(cached(), "x")
   expect_warning(read_config())
@@ -114,8 +115,6 @@ test_with_dir("old file API", {
   expect_equal(readd("'file.csv'"), readd("\"file.csv\""))
   expect_true(is.character(readd("'file.csv'")))
   expect_error(is.character(`"file.csv"`))
-  expect_silent(loadd("'file.csv'", verbose = FALSE))
-  expect_true(is.character(`"file.csv"`))
   expect_equal(
     z,
     tibble::tibble(


### PR DESCRIPTION
# Summary

- Deprecate the `imported_only` argument in `loadd()`.
- Warn about imported functions loaded with `loadd()`.
- Exclude imports from `loadd(deps = TRUE)`.
- Still allow imported functions to be loaded with `loadd()` because this may still be desirable for `knitr` reports.

# GitHub issues fixed

- Ref: #303

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review and/or merge.
