### PR TITLE
Change verbosity levels

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -49,11 +49,10 @@
 #' @param verbose logical or numeric, control printing to the console.
 #'   \describe{
 #'     \item{0 or `FALSE`:}{print nothing.}
-#'     \item{1 or `TRUE`:}{print checks and targets to build.}
-#'     \item{2:}{print checks, targets, to build,
-#'       and any potentially missing items.}
-#'     \item{3:}{full verbosity: print checks, targets to build, potentially
-#'       missing items, and imports.}
+#'     \item{1 or `TRUE`:}{print only targets to build.}
+#'     \item{2:}{in addition, print checks and cache info.}
+#'     \item{3:}{in addition, print any potentially missing items.}
+#'     \item{4:}{in addition, print imports. Full verbosity.}
 #'   }
 #'
 #' @param hook function with at least one argument.

--- a/R/console.R
+++ b/R/console.R
@@ -9,7 +9,7 @@ console <- function(imported, target, config) {
 }
 
 console_missing <- function(target, config){
-  if (config$verbose < 2){
+  if (config$verbose < 3){
     return()
   }
   pattern <- "missing"
@@ -22,7 +22,7 @@ console_missing <- function(target, config){
 }
 
 console_import <- function(target, config){
-  if (config$verbose < 3){
+  if (config$verbose < 4){
     return()
   }
   pattern <- "import"
@@ -51,6 +51,9 @@ console_target <- function(target, config){
 }
 
 console_cache <- function(path, verbose){
+  if (verbose < 2){
+    return()
+  }
   if (!length(path)){
     path <- default_cache_path()
   }
@@ -61,6 +64,9 @@ console_cache <- function(path, verbose){
 console_many_targets <- function(
   targets, pattern, config, color = color_of(pattern), type = "item"
 ){
+  if (config$verbose < 2){
+    return()
+  }
   n <- length(targets)
   if (n < 1){
     return(invisible())

--- a/man/drake_config.Rd
+++ b/man/drake_config.Rd
@@ -52,11 +52,10 @@ then reproducibly tracked as dependencies.}
 \item{verbose}{logical or numeric, control printing to the console.
 \describe{
 \item{0 or \code{FALSE}:}{print nothing.}
-\item{1 or \code{TRUE}:}{print checks and targets to build.}
-\item{2:}{print checks, targets, to build,
-and any potentially missing items.}
-\item{3:}{full verbosity: print checks, targets to build, potentially
-missing items, and imports.}
+\item{1 or \code{TRUE}:}{print only targets to build.}
+\item{2:}{in addition, print checks and cache info.}
+\item{3:}{in addition, print any potentially missing items.}
+\item{4:}{in addition, print imports. Full verbosity.}
 }}
 
 \item{hook}{function with at least one argument.

--- a/man/make.Rd
+++ b/man/make.Rd
@@ -51,11 +51,10 @@ then reproducibly tracked as dependencies.}
 \item{verbose}{logical or numeric, control printing to the console.
 \describe{
 \item{0 or \code{FALSE}:}{print nothing.}
-\item{1 or \code{TRUE}:}{print checks and targets to build.}
-\item{2:}{print checks, targets, to build,
-and any potentially missing items.}
-\item{3:}{full verbosity: print checks, targets to build, potentially
-missing items, and imports.}
+\item{1 or \code{TRUE}:}{print only targets to build.}
+\item{2:}{in addition, print checks and cache info.}
+\item{3:}{in addition, print any potentially missing items.}
+\item{4:}{in addition, print imports. Full verbosity.}
 }}
 
 \item{hook}{function with at least one argument.

--- a/tests/testthat/test-console.R
+++ b/tests/testthat/test-console.R
@@ -50,9 +50,9 @@ test_with_dir("console", {
   expect_silent(console(imported = TRUE, target = "myinput",
     config = config))
   config$verbose <- 3
-  expect_silent(console(imported = FALSE, target = "myinput",
+  expect_message(console(imported = FALSE, target = "myinput",
     config = config))
-  expect_message(console(imported = TRUE, target = "myinput",
+  expect_silent(console(imported = TRUE, target = "myinput",
     config = config))
   expect_message(console(imported = NA, target = "myinput",
     config = config))
@@ -96,7 +96,7 @@ test_with_dir("console_many_targets() works", {
   config <- list(verbose = TRUE)
   expect_silent(console_many_targets(
     targets = character(0), pattern = "check", config = config))
-  expect_message(console_many_targets(
+  expect_silent(console_many_targets(
     targets = "my_target", pattern = "check", config = config))
   tmp <- evaluate_promise(
     console_many_targets(

--- a/tests/testthat/test-console.R
+++ b/tests/testthat/test-console.R
@@ -1,8 +1,10 @@
 drake_context("console")
 
 test_with_dir("console_cache", {
-  expect_message(console_cache("12345", verbose = TRUE))
-  expect_message(console_cache(NULL, verbose = TRUE))
+  expect_silent(console_cache("12345", verbose = TRUE))
+  expect_message(console_cache("12345", verbose = 2))
+  expect_silent(console_cache(NULL, verbose = TRUE))
+  expect_message(console_cache(NULL, verbose = 2))
 })
 
 test_with_dir("console_up_to_date", {
@@ -48,7 +50,7 @@ test_with_dir("console", {
   expect_silent(console(imported = TRUE, target = "myinput",
     config = config))
   config$verbose <- 3
-  expect_message(console(imported = FALSE, target = "myinput",
+  expect_silent(console(imported = FALSE, target = "myinput",
     config = config))
   expect_message(console(imported = TRUE, target = "myinput",
     config = config))


### PR DESCRIPTION
All existing levels are increased by one, existing code will be less chatty in general. The new level 1 only shows targ
ets.

I have reviewed changes to the website, looks good, but I didn't carry out a comprehensive test. The "drake-pitch" slides also have much less log info now.

Closes #165.