### PR TITLE
Fix #303

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # Version 5.1.0
 
+- Force `drake` to only look for imports in environments inheriting from `envir` in `make()` (plus explicitly namespaced functions).
+- Force `loadd()` to ignore foreign imports (imports not explicitly found in `envir` when `make()` last imported them).
 - Reduce default verbosity. Only targets are printed out by default. Verbosity levels are integers ranging from 0 through 4.
 - Change `loadd()` so that only targets (not imports) are loaded if the `...` and `list` arguments are empty.
 - Add check to drake_plan() to check for duplicate targets

--- a/R/build.R
+++ b/R/build.R
@@ -161,7 +161,7 @@ process_import <- function(target, meta, config) {
     value <- config$envir[[target]]
   } else {
     value <- tryCatch(
-      flexible_get(target),
+      flexible_get(target, envir = config$envir),
       error = function(e)
         console(imported = NA, target = target, config = config))
   }

--- a/R/dataframes_graph_utils.R
+++ b/R/dataframes_graph_utils.R
@@ -211,7 +211,7 @@ legend_nodes <- function(font_size = 20) {
 
 missing_import <- function(x, envir) {
   missing_object <- !is_file(x) & is.null(envir[[x]]) & tryCatch({
-    flexible_get(x)
+    flexible_get(x, envir = envir)
     FALSE
   },
   error = function(e) TRUE)

--- a/R/envir.R
+++ b/R/envir.R
@@ -70,15 +70,16 @@ prune_envir <- function(targets, config, downstream = NULL){
   invisible()
 }
 
-flexible_get <- function(target) {
+flexible_get <- function(target, envir) {
   stopifnot(length(target) == 1)
   parsed <- parse(text = target) %>%
     as.call %>%
     as.list
   lang <- parsed[[1]]
   is_namespaced <- length(lang) > 1
-  if (!is_namespaced)
-    return(get(target))
+  if (!is_namespaced){
+    return(get(x = target, envir = envir))
+  }
   stopifnot(deparse(lang[[1]]) %in% c("::", ":::"))
   pkg <- deparse(lang[[2]])
   fun <- deparse(lang[[3]])

--- a/R/meta.R
+++ b/R/meta.R
@@ -64,7 +64,7 @@ drake_meta <- function(target, config = drake::read_drake_config()) {
   meta <- list(
     target = target,
     imported = !(target %in% config$plan$target),
-    foreign = !(target %in% ls(config$envir)),
+    foreign = !(exists(x = target, envir = config$envir, inherits = FALSE)),
     missing = !target_exists(target = target, config = config),
     seed = seed_from_object(list(seed = config$seed, target = target))
   )

--- a/R/meta.R
+++ b/R/meta.R
@@ -64,6 +64,7 @@ drake_meta <- function(target, config = drake::read_drake_config()) {
   meta <- list(
     target = target,
     imported = !(target %in% config$plan$target),
+    foreign = !(target %in% ls(config$envir)),
     missing = !target_exists(target = target, config = config),
     seed = seed_from_object(list(seed = config$seed, target = target))
   )

--- a/R/read.R
+++ b/R/read.R
@@ -234,6 +234,9 @@ exclude_foreign_imports <- function(targets, cache, jobs){
 }
 
 is_not_foreign_import_obj <- function(target, cache){
+  if (is_file(target)){
+    return(TRUE)
+  }
   if (!cache$exists(key = target, namespace = "meta")){
     return(FALSE)
   }
@@ -243,9 +246,7 @@ is_not_foreign_import_obj <- function(target, cache){
     character_only = TRUE,
     verbose = FALSE
   )
-  identical(meta$imported, FALSE) ||
-    identical(meta$foreign, FALSE) ||
-    is_file(target)
+  identical(meta$imported, FALSE) || identical(meta$foreign, FALSE)
 }
 
 parse_lazy_arg <- function(lazy){

--- a/R/read.R
+++ b/R/read.R
@@ -61,7 +61,11 @@ readd <- function(
 #' current workspace (or environment `envir` if given). Defaults
 #' to loading the entire cache if you do not supply anything
 #' to arguments `...` or `list`.
-#' @seealso [cached()], [built()],
+#' @details `loadd()` excludes foreign imports:
+#'   R objects not originally defined in `envir`
+#'   when [make()] last imported them.
+#'   To get these objects, use [readd()].
+#' @seealso [readd()], [cached()], [built()],
 #'   [imported()], [drake_plan()], [make()],
 #' @export
 #' @return `NULL`
@@ -141,6 +145,9 @@ readd <- function(
 #' loadd(coef_regression2_small, deps = TRUE)
 #' ls()
 #' # Load all the imported objects/functions.
+#' # Note: loadd() excludes foreign imports
+#' # (R objects not originally defined in `envir`
+#' # when `make()` last imported them).
 #' loadd(imported_only = TRUE)
 #' ls()
 #' # Load all the targets listed in the workflow plan
@@ -179,12 +186,10 @@ loadd <- function(
   }
   targets <- drake_select(
     cache = cache, ..., namespaces = namespace, list = list)
-  if (!length(targets) && !imported_only){
-    targets <- built(cache = cache, jobs = jobs)
-  } else if (imported_only){
-    if (!length(targets)){
-      targets <- cache$list()
-    }
+  if (!length(targets)){
+    targets <- cache$list()
+  }
+  if (imported_only){
     targets <- imported_only(targets = targets, cache = cache, jobs = jobs)
   }
   if (!length(targets)){
@@ -206,12 +211,41 @@ loadd <- function(
   if (!replace){
     targets <- setdiff(targets, ls(envir, all.names = TRUE))
   }
+  targets <- exclude_foreign_imports(
+    targets = targets,
+    cache = cache,
+    jobs = jobs
+  )
   lightly_parallelize(
     X = targets, FUN = load_target, cache = cache,
     namespace = namespace, envir = envir,
     verbose = verbose, lazy = lazy
   )
   invisible()
+}
+
+exclude_foreign_imports <- function(targets, cache, jobs){
+  parallel_filter(
+    x = targets,
+    f = is_not_foreign_import_obj,
+    jobs = jobs,
+    cache = cache
+  )
+}
+
+is_not_foreign_import_obj <- function(target, cache){
+  if (!cache$exists(key = target, namespace = "meta")){
+    return(FALSE)
+  }
+  meta <- diagnose(
+    target = target,
+    cache = cache,
+    character_only = TRUE,
+    verbose = FALSE
+  )
+  identical(meta$imported, FALSE) ||
+    identical(meta$foreign, FALSE) ||
+    is_file(target)
 }
 
 parse_lazy_arg <- function(lazy){

--- a/man/loadd.Rd
+++ b/man/loadd.Rd
@@ -90,6 +90,12 @@ current workspace (or environment \code{envir} if given). Defaults
 to loading the entire cache if you do not supply anything
 to arguments \code{...} or \code{list}.
 }
+\details{
+\code{loadd()} excludes foreign imports:
+R objects not originally defined in \code{envir}
+when \code{\link[=make]{make()}} last imported them.
+To get these objects, use \code{\link[=readd]{readd()}}.
+}
 \examples{
 \dontrun{
 test_with_dir("Quarantine side effects.", {
@@ -108,6 +114,9 @@ ls()
 loadd(coef_regression2_small, deps = TRUE)
 ls()
 # Load all the imported objects/functions.
+# Note: loadd() excludes foreign imports
+# (R objects not originally defined in `envir`
+# when `make()` last imported them).
 loadd(imported_only = TRUE)
 ls()
 # Load all the targets listed in the workflow plan
@@ -123,6 +132,6 @@ get(file_store("report.md"))
 }
 }
 \seealso{
-\code{\link[=cached]{cached()}}, \code{\link[=built]{built()}},
+\code{\link[=readd]{readd()}}, \code{\link[=cached]{cached()}}, \code{\link[=built]{built()}},
 \code{\link[=imported]{imported()}}, \code{\link[=drake_plan]{drake_plan()}}, \code{\link[=make]{make()}},
 }

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -226,12 +226,21 @@ test_with_dir("cache functions work", {
   rm(h, i, j, c, envir = envir)
   expect_error(h(1))
 
-  # test loadd imported_only and loadd() everything
-  loadd(imported_only = TRUE)
-  expect_true(all(imported(search = FALSE) %in% ls()))
-  loadd(search = FALSE)
-  expect_true(all(config$cache$list() %in% ls()))
-  rm(list = intersect(all, ls()))
+  # test loadd imported_only and loadd() everything safe
+  e <- new.env()
+  loadd(imported_only = TRUE, envir = e)
+  should_have_loaded <- setdiff(
+    imported(search = FALSE),
+    c("readRDS", "saveRDS")
+  )
+  expect_true(all(should_have_loaded %in% ls(envir = e)))
+  e <- new.env()
+  loadd(search = FALSE, envir = e)
+  should_have_loaded <- setdiff(
+    config$cache$list(),
+    c("readRDS", "saveRDS")
+  )
+  expect_true(all(should_have_loaded %in% ls(envir = e)))
 
   # search from a different directory
   if (!file.exists("searchfrom")) {


### PR DESCRIPTION
# Summary

- In `loadd()`, exclude foreign imports: i.e., imports that were not explicitly taken from `envir`. Foreign imports can come from a package or an ancestor of `envir`.
- in `flexible_get()`, don't just `get(target)`. Use `get(target, envir)` to be sure that `flexible_get()` searches for `target` in `envir`, an ancestor of `envir`, or possibly a package. That way, `drake` does not creep into the global environment uninvited. This change could invalidate targets for strangely-configured workflows, and most users are not likely to notice it.

# GitHub issues fixed

- Ref: #303

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review and/or merge.
