### PR TITLE
Fix #291

### DIFF
--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -223,6 +223,9 @@ command_dependencies <- function(command){
   # TODO: remove this bit when we're confident
   # users have totally switched to `knitr_in()`.
   # Turn it off right away if users elect for the new file API.
+  # I know strings_in_dots is not really meant to do this,
+  # but pkgconfig is only a temporary solution to manage
+  # the deprecation anyway.
   if (!use_new_file_api){
     deps$loadd <- base::union(
       deps$loadd, knitr_deps(find_knitr_doc(command))

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -203,7 +203,11 @@ command_dependencies <- function(command){
 
   # TODO: this block can go away when `drake`
   # stops supporting single-quoted file names.
-  if (identical(pkgconfig::get_config("drake::strings_in_dots"), "literals")){
+  use_new_file_api <- identical(
+    pkgconfig::get_config("drake::strings_in_dots"),
+    "literals"
+  )
+  if (use_new_file_api){
     files <- character(0)
   } else {
     files <- extract_filenames(command)
@@ -218,10 +222,13 @@ command_dependencies <- function(command){
 
   # TODO: remove this bit when we're confident
   # users have totally switched to `knitr_in()`.
-  deps$loadd <- base::union(
-    deps$loadd, knitr_deps(find_knitr_doc(command))
-  ) %>%
-    unique
+  # Turn it off right away if users elect for the new file API.
+  if (!use_new_file_api){
+    deps$loadd <- base::union(
+      deps$loadd, knitr_deps(find_knitr_doc(command))
+    ) %>%
+      unique
+  }
 
   # This bit stays the same.
   deps[purrr::map_int(deps, length) > 0]

--- a/tests/testthat/test-deprecate.R
+++ b/tests/testthat/test-deprecate.R
@@ -1,5 +1,20 @@
 drake_context("deprecation")
 
+test_with_dir("pkgconfig::get_config(\"drake::strings_in_dots\")", {
+  old_strings_in_dots <- pkgconfig::get_config("drake::strings_in_dots")
+  on.exit(
+    pkgconfig::set_config("drake::strings_in_dots" = old_strings_in_dots)
+  )
+  cmd <- "readRDS('my_file.rds')"
+  pkgconfig::set_config("drake::strings_in_dots" = "literals")
+  expect_equal(command_dependencies(cmd), list(globals = "readRDS"))
+  pkgconfig::set_config("drake::strings_in_dots" = "garbage")
+  expect_equal(
+    expect_warning(command_dependencies(cmd)),
+    list(globals = "readRDS", file_in = "\"my_file.rds\"")
+  )
+})
+
 test_with_dir("deprecation: future", {
   expect_warning(backend())
 })


### PR DESCRIPTION
# Summary

If the user sets `pkgconfig::get_config(drake::strings_in_dots = "literals")`, enforce the new file API. That means

1. Ignore single-quoted file names not in `file_in()`, `file_out()`, or `knitr_in()`.
2. Ignore `knitr` report source files not in `knitr_in()`.

# GitHub issues fixed

- Ref: #291

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review and/or merge.
