### PR TITLE
More debugging and tweaking for futures

### DIFF
--- a/R/future_lapply.R
+++ b/R/future_lapply.R
@@ -14,6 +14,7 @@ worker_future_lapply <- function(targets, meta_list, config){
     x = targets,
     FUN = build_distributed,
     cache_path = config$cache$driver$path,
-    meta_list = meta_list
+    meta_list = meta_list,
+    future.globals = FALSE
   )
 }

--- a/inst/testing/scenarios.csv
+++ b/inst/testing/scenarios.csv
@@ -15,5 +15,5 @@ envir,parallelism,jobs,backend,caching
 "global","Makefile",2,,
 "global","future_lapply",1,"future::multicore",
 "global","future_lapply",1,"future::multisession",
-"local","future",2,"future::multicore","worker"
-"local","future",9,"future::multisession","master"
+"global","future",2,"future::multicore","worker"
+"global","future",9,"future::multisession","master"


### PR DESCRIPTION
# Summary

- Make sure the "future"/globalenv() testing scenario actually uses the global environment.
- Repair a testing scenario: "future" backend with globalenv(). Need to pass globals explicitly in a named list rather than let `future` just guess at the values.
- Use a clumsy workaround to make sure globals passed to the "future" backend do not conflict with anything `drake` needs. When #296 is solved, the point will be moot.
- Set future.globals = FALSE in `future_lapply()` to reduce overhead. This is possible since the "future_lapply" backend assumes file system access and relies completely on the cache.

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
