### PR TITLE
Append original error message to warning

### DIFF
--- a/R/knitr.R
+++ b/R/knitr.R
@@ -71,7 +71,8 @@ safe_get_tangled_frags <- function(target){
   error = function(e){
     warning(
       "Could not parse file '", file,
-      "'. Drake dependencies could not be extracted from code chunks."
+      "'. Drake dependencies could not be extracted from code chunks: ",
+      conditionMessage(e)
     )
     character(0)
   })


### PR DESCRIPTION
when resolving `knitr_in()` dependencies fails.