### PR TITLE
Use nzchar and 'fixed = TRUE' in regex calls

### DIFF
--- a/R/Makefile.R
+++ b/R/Makefile.R
@@ -77,11 +77,11 @@ build_recipe <- function(target, recipe_command,
   }
   r_recipe <- paste0("drake::mk(target = ", target,
     ", cache_path = \"", cache_path, "\")")
-  if (!safe_grepl(r_recipe_wildcard(), recipe_command)){
+  if (!safe_grepl(r_recipe_wildcard(), recipe_command, fixed = TRUE)){
     recipe_command <- paste0(recipe_command, " '",
       r_recipe_wildcard(), "'")
   }
-  gsub(r_recipe_wildcard(), r_recipe, recipe_command)
+  gsub(r_recipe_wildcard(), r_recipe, recipe_command, fixed = TRUE)
 }
 
 #' @title Build a target inside a `Makefile`

--- a/R/cache.R
+++ b/R/cache.R
@@ -124,7 +124,7 @@ this_cache <- function(
     console_cache(path = path, verbose = verbose)
   }
   fetch_cache <- as.character(fetch_cache)
-  if (length(fetch_cache) && nchar(fetch_cache)){
+  if (length(fetch_cache) && nzchar(fetch_cache)){
     cache <- eval(parse(text = localize(fetch_cache)))
   } else {
     cache <- drake_fetch_rds(path)

--- a/R/commands.R
+++ b/R/commands.R
@@ -9,7 +9,7 @@ is_parsable <- Vectorize(function(x){
 "x")
 
 extract_filenames <- function(command){
-  if (!safe_grepl("'", command)){
+  if (!safe_grepl("'", command, fixed = TRUE)){
     return(character(0))
   }
   splits <- stringi::stri_split_fixed(command, "'")[[1]]

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -411,7 +411,7 @@ unnamed_in_list <- function(x){
   if (!length(names(x))){
     out <- x
   } else {
-    out <- x[!nchar(names(x))]
+    out <- x[!nzchar(names(x))]
   }
   unlist(out)
 }

--- a/R/deprecate.R
+++ b/R/deprecate.R
@@ -333,7 +333,7 @@ doc_of_function_call <- function(expr){
   if (!is.null(args$input)){
     as.character(args$input)
   } else {
-    unnamed <- which(!nchar(names(args)))
+    unnamed <- which(!nzchar(names(args)))
     if (!length(unnamed)){
       return(character(0))
     }

--- a/R/sanitize.R
+++ b/R/sanitize.R
@@ -15,7 +15,7 @@ sanitize_plan <- function(plan){
   }
   plan <- file_outs_to_targets(plan)
   plan$target <- repair_target_names(plan$target)
-  plan[nchar(plan$target) > 0, ]
+  plan[nzchar(plan$target), ]
 }
 
 drake_plan_non_factors <- function(){
@@ -80,12 +80,12 @@ repair_target_names <- function(x){
   x <- stringi::stri_trim_both(x)
   x[is_not_file(x)] <- gsub(illegals, "_", x[is_not_file(x)])
   x <- gsub("^_", "", x)
-  x[!nchar(x)] <- "X"
+  x[!nzchar(x)] <- "X"
   make.unique(x, sep = "_")
 }
 
 file_outs_to_targets <- function(plan){
-  index <- grepl("file_out", plan$command)
+  index <- grepl("file_out", plan$command, fixed = TRUE)
   plan$target[index] <- vapply(
     plan$command[index],
     single_file_out,

--- a/R/test_scenarios.R
+++ b/R/test_scenarios.R
@@ -16,13 +16,13 @@ testing_scenarios <- function(){
     gsub(pattern = "_*$", replacement = "")
   x$backend <- backend_code(x$backend)
   x$envir <- envir_code(x$envir)
-  x$caching[!nchar(x$caching)] <- "worker"
+  x$caching[!nzchar(x$caching)] <- "worker"
   apply_skip_os(x)
 }
 
 backend_code <- function(x){
   ifelse(
-    nchar(x),
+    nzchar(x),
     paste0("future::plan(", x, ")"),
     x
   )

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,5 +1,5 @@
-safe_grepl <- function(pattern, x){
-  tryCatch(grepl(pattern, x), error = error_false)
+safe_grepl <- function(pattern, x, ...){
+  tryCatch(grepl(pattern, x, ...), error = error_false)
 }
 
 is_file <- function(x){

--- a/R/workplan.R
+++ b/R/workplan.R
@@ -203,7 +203,7 @@ complete_target_names <- function(commands_list){
     # Should not actually happen, but it's better to have anyway.
     names(commands_list) <- paste0("drake_target_", seq_along(commands_list)) # nocov # nolint
   }
-  index <- !nchar(names(commands_list))
+  index <- !nzchar(names(commands_list))
   names(commands_list)[index] <- paste0("drake_target_", seq_len(sum(index)))
   commands_list
 }
@@ -404,7 +404,7 @@ warn_arrows <- function(dots){
     names(dots) <- rep("", length(dots)) # nocov
   }
   check_these <- purrr::map_lgl(names(dots), function(x){
-    nchar(x) < 1
+    !nzchar(x)
   }) %>%
     which
   offending_commands <- lapply(dots[check_these], detect_arrow) %>%

--- a/tests/testthat/test-Makefile.R
+++ b/tests/testthat/test-Makefile.R
@@ -39,7 +39,7 @@ test_with_dir("prepend arg works", {
   store_drake_config(config = config)
   run_Makefile(config, run = FALSE)
   lines <- readLines("Makefile")
-  expect_true(grepl("# add", lines[1]))
+  expect_true(grepl("# add", lines[1], fixed = TRUE))
 })
 
 test_with_dir("files inside directories can be timestamped", {

--- a/tests/testthat/test-custom-caches.R
+++ b/tests/testthat/test-custom-caches.R
@@ -197,6 +197,6 @@ test_with_dir("use two differnt file system caches", {
     con2$cache$driver$hash_algorithm,
     "murmur32"
   )
-  expect_true(grepl("my_new_cache", con2$cache$driver$path))
-  expect_true(grepl("my_new_cache", cache_path(cache2)))
+  expect_true(grepl("my_new_cache", con2$cache$driver$path, fixed = TRUE))
+  expect_true(grepl("my_new_cache", cache_path(cache2), fixed = TRUE))
 })

--- a/tests/testthat/test-edge-cases.R
+++ b/tests/testthat/test-edge-cases.R
@@ -58,7 +58,7 @@ test_with_dir("failed targets do not become up to date", {
   expect_error(make(plan))
   expect_error(make(plan))
   meta <- diagnose(a)
-  expect_true(grepl("my failure message", meta$error$message))
+  expect_true(grepl("my failure message", meta$error$message, fixed = TRUE))
   con <- drake_config(plan)
   expect_equal(sort(outdated(con)), sort(c("a", "c")))
 })

--- a/tests/testthat/test-future.R
+++ b/tests/testthat/test-future.R
@@ -79,7 +79,7 @@ test_with_dir("can gracefully conclude a crashed worker", {
       regexp = "failed."
     )
     meta <- diagnose(myinput)
-    expect_true(grepl("Worker terminated unexpectedly", meta$error$message))
+    expect_true(grepl("Worker terminated unexpectedly", meta$error$message, fixed = TRUE))
     clean(destroy = TRUE)
   }
 })

--- a/tests/testthat/test-other-features.R
+++ b/tests/testthat/test-other-features.R
@@ -121,7 +121,7 @@ test_with_dir("in_progress() works and errors are handled correctly", {
   expect_equal(failed(), "x")
   expect_equal(in_progress(), character(0))
   expect_is(e <- diagnose(x)$error, "error")
-  expect_true(grepl(pattern = "function_doesnt_exist", x = e$message))
+  expect_true(grepl(pattern = "function_doesnt_exist", x = e$message, fixed = TRUE))
   expect_error(diagnose("notfound"))
   expect_true(inherits(diagnose(x)$error, "error"))
   y <- "x"
@@ -140,10 +140,10 @@ test_with_dir("warnings and messages are caught", {
   bad_plan <- drake_plan(x = f(), y = x)
   expect_warning(make(bad_plan, verbose = TRUE, session_info = FALSE))
   x <- diagnose(x)
-  expect_true(grepl("my first warn", x$warnings[1]))
-  expect_true(grepl("my second warn", x$warnings[2]))
-  expect_true(grepl("my first mess", x$messages[1]))
-  expect_true(grepl("my second mess", x$messages[2]))
+  expect_true(grepl("my first warn", x$warnings[1], fixed = TRUE))
+  expect_true(grepl("my second warn", x$warnings[2], fixed = TRUE))
+  expect_true(grepl("my first mess", x$messages[1], fixed = TRUE))
+  expect_true(grepl("my second mess", x$messages[2], fixed = TRUE))
 })
 
 test_with_dir("missed() works", {

--- a/tests/testthat/test-testing.R
+++ b/tests/testthat/test-testing.R
@@ -88,7 +88,7 @@ test_with_dir("test_scenarios()", {
   expect_equal(old_scenario, getOption(test_option_name))
 
   # Check if we tested with all the options
-  loggings <- grepl("logged scenario", log)
+  loggings <- grepl("logged scenario", log, fixed = TRUE)
   expect_true(any(loggings))
   log <- log[loggings]
   log <- gsub("logged scenario ", "", log)
@@ -104,7 +104,7 @@ test_with_dir("test_scenarios()", {
   )
   log <- c(log$output, log$messages)
 
-  loggings <- grepl("logged scenario", log)
+  loggings <- grepl("logged scenario", log, fixed = TRUE)
   expect_false(any(loggings))
-  expect_true(any(grepl("skip", log)))
+  expect_true(any(grepl("skip", log, fixed = TRUE)))
 })

--- a/tests/testthat/test-time.R
+++ b/tests/testthat/test-time.R
@@ -57,8 +57,8 @@ test_with_dir("build time the same after superfluous make", {
 
 test_with_dir("empty time predictions", {
   min_df <- function(df){
-    df <- df[!grepl("covr", df$item), ]
-    df <- df[!grepl(":::", df$item), ]
+    df <- df[!grepl("covr", df$item, fixed = TRUE), ]
+    df <- df[!grepl(":::", df$item, fixed = TRUE), ]
     df
   }
 
@@ -91,8 +91,8 @@ test_with_dir("empty time predictions", {
 
 test_with_dir("time predictions: incomplete targets", {
   min_df <- function(df){
-    df <- df[!grepl("covr", df$item), ]
-    df <- df[!grepl(":::", df$item), ]
+    df <- df[!grepl("covr", df$item, fixed = TRUE), ]
+    df <- df[!grepl(":::", df$item, fixed = TRUE), ]
     df
   }
 
@@ -192,8 +192,8 @@ test_with_dir("time predictions: incomplete targets", {
 
 test_with_dir("timing predictions with realistic build", {
   min_df <- function(df){
-    df <- df[!grepl("covr", df$item), ]
-    df <- df[!grepl(":::", df$item), ]
+    df <- df[!grepl("covr", df$item, fixed = TRUE), ]
+    df <- df[!grepl(":::", df$item, fixed = TRUE), ]
     df
   }
 


### PR DESCRIPTION
# Summary

Two small code edits across many files that provide minor speed improvements.
- In spots where `nchar()` is used to produce a logical value/vector, replace `nchar()` with `nzchar()`.
- Add `fixed = TRUE` to `grepl()` calls where possible.

# GitHub issues fixed

- No associated issue.

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
- [ ] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [ ] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.

All tests passed locally after making these edits:
```r
devtools::test()
```
```r
Loading drake
Loading required package: testthat
Testing drake
√ | OK F W S | Context
√ | 36       | local_parLapply_1: basic [19.5 s]
√ | 118       | local_parLapply_1: cache [6.8 s]
√ |  8       | local_parLapply_1: command changes [5.8 s]
√ | 35       | local_parLapply_1: console [0.9 s]
√ | 45       | local_parLapply_1: custom caches [2.0 s]
√ |  7       | local_parLapply_1: dbi cache [3.9 s]
√ | 41       | local_parLapply_1: dependencies [3.0 s]
√ | 59       | local_parLapply_1: deprecation [2.5 s]
√ | 32       | local_parLapply_1: edge cases [10.0 s]
√ |  6       | local_parLapply_1: envir [2.1 s]
√ | 32       | local_parLapply_1: examples [2.4 s]
√ |  3       | local_parLapply_1: expose imports [2.0 s]
√ | 39       | local_parLapply_1: full build [3.3 s]
√ | 13       | local_parLapply_1: future [17.2 s]
√ | 36       | local_parLapply_1: generate [3.4 s]
√ | 41       | local_parLapply_1: graph [19.4 s]
√ | 19       | local_parLapply_1: hash [1.8 s]
√ |  9       | local_parLapply_1: import file [3.6 s]
√ | 10       | local_parLapply_1: import object [7.2 s]
√ |  6       | local_parLapply_1: intermediate file [3.1 s]
√ | 51       | local_parLapply_1: knitr [1.7 s]
√ | 19       | local_parLapply_1: lazy load [7.3 s]
√ | 46       | local_parLapply_1: Makefile [5.5 s]
√ | 52       | local_parLapply_1: memory cache [4.6 s]
√ | 32       | local_parLapply_1: migrate [13.6 s]
√ |  9       | local_parLapply_1: namespaced [1.0 s]
√ | 94       | local_parLapply_1: other features [5.9 s]
√ | 36       | local_parLapply_1: parallel [7.9 s]
√ | 29       | local_parLapply_1: queue [0.2 s]
√ | 26       | local_parLapply_1: reproducible random numbers [2.8 s]
√ | 14       | local_parLapply_1: retries and timeouts [4.9 s]
√ | 12       | local_parLapply_1: strings
√ | 58       | local_parLapply_1: testing [0.9 s]
√ |  3       | local_parLapply_1: tidy eval [0.5 s]
√ | 49       | local_parLapply_1: time [17.1 s]
√ | 41       | local_parLapply_1: triggers [22.5 s]
√ | 83       | local_parLapply_1: workflow plan [3.4 s]

== Results =====================================================================
Duration: 220.6 s

OK:       1249
Failed:   0
Warnings: 0
Skipped:  0
```