### PR TITLE
add arg 'sanitize_targets' to 'build_drake_graph()'

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -394,7 +394,7 @@ drake_config <- function(
   if (is.null(graph)){
     graph <- build_drake_graph(plan = plan, targets = targets,
       envir = envir, verbose = verbose, jobs = jobs,
-      sanitize_plan = FALSE)
+      sanitize_plan = FALSE, sanitize_targets = FALSE)
   } else {
     graph <- prune_drake_graph(graph = graph, to = targets, jobs = jobs)
   }

--- a/R/graph.R
+++ b/R/graph.R
@@ -27,7 +27,7 @@ build_drake_graph <- function(
   envir = parent.frame(),
   verbose = drake::default_verbose(),
   jobs = 1,
-  sanitize_plan = TRUE, 
+  sanitize_plan = TRUE,
   sanitize_targets = TRUE
 ){
   force(envir)

--- a/R/graph.R
+++ b/R/graph.R
@@ -11,6 +11,7 @@
 #'   the workflow plan dependency network.
 #' @inheritParams drake_config
 #' @param sanitize_plan logical, whether to sanitize the workflow plan first.
+#' @param sanitize_targets logical, whether to sanitize the targets first.
 #' @examples
 #' \dontrun{
 #' test_with_dir("Quarantine side effects.", {
@@ -26,13 +27,16 @@ build_drake_graph <- function(
   envir = parent.frame(),
   verbose = drake::default_verbose(),
   jobs = 1,
-  sanitize_plan = TRUE
+  sanitize_plan = TRUE, 
+  sanitize_targets = TRUE
 ){
   force(envir)
   if (sanitize_plan){
     plan <- sanitize_plan(plan)
   }
-  targets <- sanitize_targets(plan, targets)
+  if (sanitize_targets){
+    targets <- sanitize_targets(plan, targets)
+  }
   imports <- as.list(envir)
   assert_unique_names(
     imports = names(imports),

--- a/man/build_drake_graph.Rd
+++ b/man/build_drake_graph.Rd
@@ -6,7 +6,8 @@
 \usage{
 build_drake_graph(plan = read_drake_plan(),
   targets = drake::possible_targets(plan), envir = parent.frame(),
-  verbose = drake::default_verbose(), jobs = 1, sanitize_plan = TRUE)
+  verbose = drake::default_verbose(), jobs = 1, sanitize_plan = TRUE,
+  sanitize_targets = TRUE)
 }
 \arguments{
 \item{plan}{workflow plan data frame.
@@ -84,6 +85,8 @@ most 4 jobs for targets, run
 \code{make(..., parallelism = "Makefile", jobs = 2, args = "--jobs=4")}.}
 
 \item{sanitize_plan}{logical, whether to sanitize the workflow plan first.}
+
+\item{sanitize_targets}{logical, whether to sanitize the targets first.}
 }
 \value{
 An igraph object representing


### PR DESCRIPTION
# Summary

When function `drake_config()` is called, the targets get sanitized at the top of the function with `targets <- sanitize_targets(plan, targets)`. If arg `graph = NULL`, then the targets end up getting sanitized a second time at the top of function `build_drake_graph()`. To avoid running the targets through `sanitize_targets()` twice, I've added arg `sanitize_targets` to function `build_drake_graph()` (default value is `TRUE`). Then if `build_drake_graph()` is called within `drake_config()`, it's called with `sanitize_target = FALSE`.

The new arg operates the same way as existing arg `sanitize_path`.

# GitHub issues fixed

- No associated issue.

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
- [ ] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [ ] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.

All tests passed locally after making these edits:
```r
devtools::test()
```
```r
Loading drake
Use suppressPackageStartupMessages() to eliminate package startup messages like this one.
Testing drake
√ | OK F W S | Context
√ | 36       | local_parLapply_1: basic [19.1 s]
√ | 118       | local_parLapply_1: cache [7.4 s]
√ |  8       | local_parLapply_1: command changes [5.7 s]
√ | 35       | local_parLapply_1: console [0.8 s]
√ | 45       | local_parLapply_1: custom caches [2.0 s]
√ |  7       | local_parLapply_1: dbi cache [3.4 s]
√ | 41       | local_parLapply_1: dependencies [2.9 s]
√ | 59       | local_parLapply_1: deprecation [2.2 s]
√ | 32       | local_parLapply_1: edge cases [9.8 s]
√ |  6       | local_parLapply_1: envir [2.1 s]
√ | 32       | local_parLapply_1: examples [2.2 s]
√ |  3       | local_parLapply_1: expose imports [2.1 s]
√ | 39       | local_parLapply_1: full build [3.3 s]
√ | 13       | local_parLapply_1: future [16.2 s]
√ | 36       | local_parLapply_1: generate [3.4 s]
√ | 41       | local_parLapply_1: graph [18.9 s]
√ | 19       | local_parLapply_1: hash [1.6 s]
√ |  9       | local_parLapply_1: import file [3.7 s]
√ | 10       | local_parLapply_1: import object [7.2 s]
√ |  6       | local_parLapply_1: intermediate file [3.0 s]
√ | 51       | local_parLapply_1: knitr [1.6 s]
√ | 19       | local_parLapply_1: lazy load [7.1 s]
√ | 46       | local_parLapply_1: Makefile [5.3 s]
√ | 52       | local_parLapply_1: memory cache [4.5 s]
√ | 32       | local_parLapply_1: migrate [13.0 s]
√ |  9       | local_parLapply_1: namespaced [1.0 s]
√ | 94       | local_parLapply_1: other features [5.8 s]
√ | 36       | local_parLapply_1: parallel [7.6 s]
√ | 29       | local_parLapply_1: queue [0.2 s]
√ | 26       | local_parLapply_1: reproducible random numbers [2.8 s]
√ | 14       | local_parLapply_1: retries and timeouts [4.2 s]
√ | 12       | local_parLapply_1: strings
√ | 58       | local_parLapply_1: testing [0.9 s]
√ |  3       | local_parLapply_1: tidy eval [0.5 s]
√ | 49       | local_parLapply_1: time [16.3 s]
√ | 41       | local_parLapply_1: triggers [22.1 s]
√ | 83       | local_parLapply_1: workflow plan [3.4 s]

== Results =====================================================================
Duration: 214.1 s

OK:       1249
Failed:   0
Warnings: 0
Skipped:  0
```