### PR TITLE
Multiple output files per target

### DIFF
--- a/R/Makefile.R
+++ b/R/Makefile.R
@@ -38,11 +38,11 @@ makefile_head <- function(config){
 }
 
 makefile_rules <- function(config){
-  targets <- intersect(config$plan$target, V(config$graph)$name)
+  config$graph <- targets_graph(config$schedule)
+  targets <- V(config$graph)$name
   cache_path <- cache_path(config$cache)
   for (target in targets){
     deps <- dependencies(target, config) %>%
-      intersect(y = config$plan$target) %>%
       time_stamp_target(config = config)
     breaker <- ifelse(length(deps), " \\\n", "\n")
     cat(

--- a/R/basic_example.R
+++ b/R/basic_example.R
@@ -158,9 +158,8 @@ load_basic_example <- function(
   # skip 'gather' (drake_plan my_plan is more readable)
   results <- plan_summaries(summary_types, analyses, datasets, gather = NULL)
 
-  report <- tibble(
-    target = "",
-    command = 'knit(knitr_in("report.Rmd"), file_out("report.md"), quiet = TRUE)', # nolint  
+  report <- drake_plan(
+    knit(knitr_in("report.Rmd"), file_out("report.md"), quiet = TRUE)
   )
 
   # Row order doesn't matter in the drake_plan my_plan.

--- a/R/build.R
+++ b/R/build.R
@@ -112,20 +112,27 @@ announce_build <- function(target, meta, config){
 }
 
 conclude_build <- function(target, value, meta, config){
-  check_processed_files(target)
+  outputs <- V(config$graph)$name[V(config$graph)$job == target]
+  check_processed_files(outputs)
   handle_build_exceptions(target = target, meta = meta, config = config)
-  store_target(target = target, value = value, meta = meta, config = config)
+  store_outputs(
+    target = target,
+    outputs = outputs,
+    value = value,
+    meta = meta,
+    config = config
+  )
   invisible(value)
 }
 
-check_processed_files <- function(target){
-  if (!is_file(target)){
-    return()
-  }
-  if (!file.exists(drake::drake_unquote(target))){
+check_processed_files <- function(outputs){
+  bad <- Filter(x = outputs, f = function(x){
+    is_file(x) && !file.exists(drake::drake_unquote(x))
+  })
+  if (length(bad)){
     warning(
-      "File ", target, " was built or processed,\n",
-      "but the file itself does not exist.",
+      "Missing output files:\n",
+      multiline_message(bad),
       call. = FALSE
     )
   }

--- a/R/build.R
+++ b/R/build.R
@@ -112,13 +112,13 @@ announce_build <- function(target, meta, config){
 }
 
 conclude_build <- function(target, value, meta, config){
-  check_processed_file(target)
+  check_processed_files(target)
   handle_build_exceptions(target = target, meta = meta, config = config)
   store_target(target = target, value = value, meta = meta, config = config)
   invisible(value)
 }
 
-check_processed_file <- function(target){
+check_processed_files <- function(target){
   if (!is_file(target)){
     return()
   }

--- a/R/check.R
+++ b/R/check.R
@@ -72,8 +72,7 @@ assert_standard_columns <- function(config){
 }
 
 missing_input_files <- function(config) {
-  missing_files <- V(config$graph)$name %>%
-    setdiff(y = config$plan$target) %>%
+  missing_files <- V(config$graph)$name[V(config$graph)$imported] %>%
     parallel_filter(f = is_file, jobs = config$jobs) %>%
     drake_unquote %>%
     parallel_filter(f = function(x) !file.exists(x), jobs = config$jobs)

--- a/R/config.R
+++ b/R/config.R
@@ -398,6 +398,7 @@ drake_config <- function(
   } else {
     graph <- prune_drake_graph(graph = graph, to = targets, jobs = jobs)
   }
+  schedule <- schedule_graph(graph)
   cache_path <- force_cache_path(cache)
   lazy_load <- parse_lazy_arg(lazy_load)
   list(
@@ -406,6 +407,7 @@ drake_config <- function(
     parallelism = parallelism, jobs = jobs, verbose = verbose, hook = hook,
     prepend = prepend, prework = prework, command = command,
     args = args, recipe_command = recipe_command, graph = graph,
+    schedule = schedule,
     short_hash_algo = cache$get("short_hash_algo", namespace = "config"),
     long_hash_algo = cache$get("long_hash_algo", namespace = "config"),
     seed = seed, trigger = trigger,

--- a/R/config.R
+++ b/R/config.R
@@ -479,7 +479,10 @@ do_prework <- function(config, verbose_packages) {
 #' }
 possible_targets <- function(plan = read_drake_plan()) {
   plan <- sanitize_plan(plan)
-  as.character(plan$target)
+  purrr::map(plan$command, command_dependencies) %>%
+    purrr::map("file_out") %>%
+    c(plan$target) %>%
+    clean_dependency_list
 }
 
 #' @title Store an internal configuration list

--- a/R/config.R
+++ b/R/config.R
@@ -224,10 +224,9 @@
 #'   about your setup is not quite right: for example, if you are using
 #'   a version of drake that is not back compatible with your project's cache.
 #'
-#' @param graph An `igraph` object from the previous `make()`.
-#'   Supplying a pre-built graph could save time.
+#' @param graph An optional `igraph` object, the dependency graph.
+#'   Supplying a pre-built dependency graph could save time.
 #'   The graph is constructed by [build_drake_graph()].
-#'   You can also get one from \code{\link{config}(my_plan)$graph}.
 #'   Overrides `skip_imports`.
 #'
 #' @param trigger Name of the trigger to apply to all targets.

--- a/R/dataframes_graph.R
+++ b/R/dataframes_graph.R
@@ -134,10 +134,7 @@ dataframes_graph <- function(
   )
   config$graph <- subset_graph(graph = config$graph, subset = subset)
   if (targets_only){
-    config$graph <- subset_graph(
-      graph = config$graph,
-      subset = config$plan$target
-    )
+    config$graph <- targets_graph(config$graph)
   }
   network_data <- visNetwork::toVisNetworkData(config$graph)
   config$nodes <- network_data$nodes

--- a/R/dataframes_graph_utils.R
+++ b/R/dataframes_graph_utils.R
@@ -117,7 +117,7 @@ function_hover_text <- Vectorize(function(function_name, envir){
 get_raw_node_category_data <- function(config){
   all_labels <- V(config$graph)$name
   config$outdated <- resolve_graph_outdated(config = config)
-  config$imports <- setdiff(all_labels, config$plan$target)
+  config$imports <- V(imports_graph(config$graph))$name
   config$in_progress <- in_progress(cache = config$cache)
   config$failed <- failed(cache = config$cache)
   config$files <- parallel_filter(
@@ -230,7 +230,7 @@ null_graph <- function() {
 
 resolve_graph_outdated <- function(config){
   if (config$from_scratch){
-    config$outdated <- config$plan$target
+    config$outdated <- V(targets_graph(config$graph))$name
   } else {
     config$outdated <- outdated(
       config = config,

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -118,7 +118,7 @@ dependency_profile <- function(target, config = drake::read_drake_config()){
       file.mtime(drake::drake_unquote(target))
     ),
     cached_file_hash = meta$file,
-    current_file_hash = file_out_hash(target = target, config = config),
+    current_file_hash = file_hash(target = target, config = config),
     cached_dependency_hash = meta$depends,
     current_dependency_hash = current_dependency_hash,
     hashes_of_dependencies = hashes_of_dependencies

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -178,7 +178,7 @@ dependencies <- function(targets, config, reverse = FALSE){
 nonfile_target_dependencies <- function(targets, config){
   deps <- dependencies(targets = targets, config = config)
   out <- parallel_filter(x = deps, f = is_not_file, jobs = config$jobs)
-  intersect(out, config$plan$target)
+  intersect(out, V(targets_graph(config$graph))$name)
 }
 
 import_dependencies <- function(expr){

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -118,7 +118,7 @@ dependency_profile <- function(target, config = drake::read_drake_config()){
       file.mtime(drake::drake_unquote(target))
     ),
     cached_file_hash = meta$file,
-    current_file_hash = file_hash(target = target, config = config),
+    current_file_hash = file_out_hash(target = target, config = config),
     cached_dependency_hash = meta$depends,
     current_dependency_hash = current_dependency_hash,
     hashes_of_dependencies = hashes_of_dependencies

--- a/R/envir.R
+++ b/R/envir.R
@@ -16,7 +16,7 @@ assign_to_envir <- function(targets, values, config){
 assign_to_envir_single <- function(index, targets, values, config){
   target <- targets[index]
   value <- values[[index]]
-  if (is_file(target) | !(target %in% config$plan$target)){
+  if (is_file(target) | !(target %in% V(targets_graph(config$graph))$name)){
     return()
   }
   assign(x = target, value = value, envir = config$envir)
@@ -32,7 +32,7 @@ prune_envir <- function(targets, config, downstream = NULL){
     )
   }
   already_loaded <- ls(envir = config$envir, all.names = TRUE) %>%
-    intersect(y = config$plan$target)
+    intersect(y = V(targets_graph(config$graph))$name)
   target_deps <- nonfile_target_dependencies(
     targets = targets,
     config = config
@@ -45,7 +45,8 @@ prune_envir <- function(targets, config, downstream = NULL){
     setdiff(y = already_loaded)
   load_these <- exclude_unloadable(targets = load_these, config = config)
   keep_these <- c(target_deps, downstream_deps)
-  discard_these <- setdiff(x = config$plan$target, y = keep_these) %>%
+  discard_these <- setdiff(
+    x = V(targets_graph(config$graph))$name, y = keep_these) %>%
     parallel_filter(f = is_not_file, jobs = config$jobs) %>%
     intersect(y = already_loaded)
   if (length(discard_these)){

--- a/R/future.R
+++ b/R/future.R
@@ -73,6 +73,7 @@ new_worker <- function(id, target, config, protect){
   # Avoid potential name conflicts with other globals.
   # When we solve #296, the need for such a clumsy workaround
   # should go away.
+  DRAKE_GLOBALS__ <- NULL # Avoids warnings about undefined global symbols.
   globals <- list(
     DRAKE_GLOBALS__ = list(
       target = target,

--- a/R/future_lapply.R
+++ b/R/future_lapply.R
@@ -5,7 +5,7 @@ run_future_lapply <- function(config){
 }
 
 worker_future_lapply <- function(targets, meta_list, config){
-  targets <- intersect(targets, config$plan$target)
+  targets <- intersect(targets, V(targets_graph(config$schedule))$name)
   # Probably will not encounter this, but it is better to have:
   if (!length(targets)){ # nocov # nolint
     return()             # nocov

--- a/R/graph.R
+++ b/R/graph.R
@@ -273,13 +273,9 @@ exclude_imports_if <- function(config){
   if (!config$skip_imports){
     return(config)
   }
-  delete_these <- setdiff(
-    V(config$execution_graph)$name,
-    config$plan$target
-  )
   config$execution_graph <- delete_vertices(
     graph = config$execution_graph,
-    v = delete_these
+    v = V(imports_graph(config$graph))$name
   )
   config
 }

--- a/R/graph.R
+++ b/R/graph.R
@@ -87,12 +87,12 @@ imports_edges <- function(name, value){
 
 code_deps_to_edges <- function(target, deps){
   inputs <- clean_dependency_list(deps[setdiff(names(deps), "file_out")])
-  edges <- NULL
+  outputs <- c(target, deps$file_out)
   if (length(inputs)){
-    data.frame(from = inputs, to = target, stringsAsFactors = FALSE)
+    expand.grid(from = inputs, to = outputs, stringsAsFactors = FALSE)
   } else {
     # Loops will be removed.
-    data.frame(from = target, to = target, stringsAsFactors = FALSE)
+    data.frame(from = outputs, to = outputs, stringsAsFactors = FALSE)
   }
 }
 

--- a/R/graph.R
+++ b/R/graph.R
@@ -121,13 +121,13 @@ code_deps_to_edges <- function(target, deps){
 
 imports_graph <- function(graph){
   vertices <- V(graph)
-  delete_these <- vertices$name[vertices$imported]
+  delete_these <- vertices$name[!vertices$imported]
   delete_vertices(graph, v = delete_these)
 }
 
 targets_graph <- function(graph){
   vertices <- V(graph)
-  delete_these <- vertices$name[!vertices$imported]
+  delete_these <- vertices$name[vertices$imported]
   delete_vertices(graph, v = delete_these)
 }
 

--- a/R/make.R
+++ b/R/make.R
@@ -228,17 +228,11 @@ make_with_config <- function(config = drake::read_drake_config()){
 #' })
 #' }
 make_imports <- function(config = drake::read_drake_config()){
-  config$execution_graph <- imports_graph(config = config)
+  config$execution_graph <- imports_graph(graph = config$graph)
   config$jobs <- jobs_imports(jobs = config$jobs)
   config$parallelism <- use_default_parallelism(config$parallelism)
   run_parallel_backend(config = config)
   invisible(config)
-}
-
-imports_graph <- function(config){
-  vertices <- V(config$graph)
-  delete_these <- vertices$name[!is.na(vertices$command_group)]
-  delete_vertices(config$graph, v = delete_these)
 }
 
 #' @title Just build the targets.
@@ -278,17 +272,11 @@ imports_graph <- function(config){
 #' })
 #' }
 make_targets <- function(config = drake::read_drake_config()){
-  config$execution_graph <- targets_graph(config = config)
+  config$execution_graph <- targets_graph(graph = config$graph)
   config$jobs <- jobs_targets(jobs = config$jobs)
   run_parallel_backend(config = config)
   console_up_to_date(config = config)
   invisible(config)
-}
-
-targets_graph <- function(config){
-  vertices <- V(config$graph)
-  delete_these <- vertices$name[is.na(vertices$command_group)]
-  delete_vertices(config$graph, v = delete_these)
 }
 
 initialize_session <- function(config){

--- a/R/make.R
+++ b/R/make.R
@@ -236,7 +236,8 @@ make_imports <- function(config = drake::read_drake_config()){
 }
 
 imports_graph <- function(config){
-  delete_these <- intersect(config$plan$target, V(config$graph)$name)
+  vertices <- V(config$graph)
+  delete_these <- vertices$name[!is.na(vertices$command_group)]
   delete_vertices(config$graph, v = delete_these)
 }
 
@@ -285,7 +286,8 @@ make_targets <- function(config = drake::read_drake_config()){
 }
 
 targets_graph <- function(config){
-  delete_these <- setdiff(V(config$graph)$name, config$plan$target)
+  vertices <- V(config$graph)
+  delete_these <- vertices$name[is.na(vertices$command_group)]
   delete_vertices(config$graph, v = delete_these)
 }
 

--- a/R/make.R
+++ b/R/make.R
@@ -228,7 +228,7 @@ make_with_config <- function(config = drake::read_drake_config()){
 #' })
 #' }
 make_imports <- function(config = drake::read_drake_config()){
-  config$execution_graph <- imports_graph(graph = config$graph)
+  config$execution_graph <- imports_graph(graph = config$schedule)
   config$jobs <- jobs_imports(jobs = config$jobs)
   config$parallelism <- use_default_parallelism(config$parallelism)
   run_parallel_backend(config = config)
@@ -272,7 +272,7 @@ make_imports <- function(config = drake::read_drake_config()){
 #' })
 #' }
 make_targets <- function(config = drake::read_drake_config()){
-  config$execution_graph <- targets_graph(graph = config$graph)
+  config$execution_graph <- targets_graph(graph = config$schedule)
   config$jobs <- jobs_targets(jobs = config$jobs)
   run_parallel_backend(config = config)
   console_up_to_date(config = config)

--- a/R/meta.R
+++ b/R/meta.R
@@ -73,7 +73,7 @@ drake_meta <- function(target, config = drake::read_drake_config()) {
     meta$depends <- dependency_hash(target = target, config = config)
   }
   if (trigger %in% triggers_with_file()){
-    meta$file <- file_out_hash(target = target, config = config)
+    meta$file <- file_hash(target = target, config = config)
   }
   meta
 }
@@ -104,7 +104,7 @@ finish_meta <- function(target, meta, config){
   # Empty fields need to be filled so that the target
   # can appear up to date in the next make().
   if (is.null(meta$file)){
-    meta$file <- file_out_hash(target = target, config = config)
+    meta$file <- file_hash(target = target, config = config)
   }
   if (is.null(meta$command)){
     meta$command <- get_standardized_command(target = target, config = config)
@@ -118,7 +118,7 @@ finish_meta <- function(target, meta, config){
 concomitant_output_meta <- function(output, meta, config){
   new_meta <- meta_stub(target = output, config = config)
   carry_over <- c(
-    "command", "depends", "file", "seed", "start", "time_command"
+    "command", "depends", "seed", "start", "time_command"
   )
   new_meta[carry_over] <- meta[carry_over]
   new_meta

--- a/R/meta.R
+++ b/R/meta.R
@@ -100,7 +100,12 @@ finish_meta <- function(target, meta, config){
   # Empty fields need to be filled so that the target
   # can appear up to date in the next make().
   if (is.null(meta$file)){
+    ####### TODO: meta$file needs to be the file_out_hash(),
+    ####### a hash of the hashes of all the output files.
     meta$file <- file_hash(target = target, config = config)
+    
+    or file_out_hash()? # intentional bug to remind me to pick up here.
+    
   }
   if (is.null(meta$command)){
     meta$command <- get_standardized_command(target = target, config = config)
@@ -118,7 +123,7 @@ full_meta <- function(target, config){
 
 concomitant_output_meta <- function(output, meta, config){
   new_meta <- full_meta(target = output, config = config)
-  carry_over <- c("seed", "command", "start", "time_command")
+  carry_over <- c("seed", "command", "file", "start", "time_command")
   new_meta[carry_over] <- meta[carry_over]
   new_meta
 }

--- a/R/meta.R
+++ b/R/meta.R
@@ -193,19 +193,3 @@ file_hash <- function(target, config, size_cutoff = 1e5) {
     config$cache$get(key = target, namespace = "kernels")
   }
 }
-
-file_out_hash <- function(target, config){
-  job <- igraph::vertex_attr(
-    graph = config$graph,
-    name = "job",
-    index = target
-  )
-  files <- V(config$graph)$name[V(config$graph)$job == job] %>%
-    Filter(f = is_file)
-  if (length(files)){
-    purrr::map_chr(.x = files, .f = file_hash, config = config) %>%
-    digest::digest(algo = config$long_hash_algo)
-  } else {
-    as.character(NA)
-  }
-}

--- a/R/meta.R
+++ b/R/meta.R
@@ -110,6 +110,11 @@ finish_meta <- function(target, meta, config){
   meta
 }
 
+full_meta <- function(target, config){
+  meta <- drake_meta(target = target, config = config)
+  finish_meta(target = target, meta = meta, config = config)
+}
+
 dependency_hash <- function(target, config) {
   dependencies(target, config) %>%
     self_hash(config = config) %>%

--- a/R/meta.R
+++ b/R/meta.R
@@ -195,7 +195,12 @@ file_hash <- function(target, config, size_cutoff = 1e5) {
 }
 
 file_out_hash <- function(target, config){
-  files <- V(config$graph)$name[V(config$graph)$job == meta$job] %>%
+  job <- igraph::vertex_attr(
+    graph = config$graph,
+    name = "job",
+    index = target
+  )
+  files <- V(config$graph)$name[V(config$graph)$job == job] %>%
     Filter(f = is_file) %>%
     file_hash(config = config) %>%
     digest::digest(algo = config$long_hash_algo)

--- a/R/meta.R
+++ b/R/meta.R
@@ -63,6 +63,7 @@ meta_list <- function(targets, config) {
 drake_meta <- function(target, config = drake::read_drake_config()) {
   meta <- list(
     target = target,
+    job = V(config$graph)$job[V(config$graph)$name == target],
     imported = target %in% V(imports_graph(config$graph))$name,
     foreign = !exists(x = target, envir = config$envir, inherits = FALSE),
     missing = !target_exists(target = target, config = config),
@@ -113,6 +114,13 @@ finish_meta <- function(target, meta, config){
 full_meta <- function(target, config){
   meta <- drake_meta(target = target, config = config)
   finish_meta(target = target, meta = meta, config = config)
+}
+
+concomitant_output_meta <- function(output, meta, config){
+  new_meta <- full_meta(target = output, config = config)
+  carry_over <- c("seed", "command", "start", "time_command")
+  new_meta[carry_over] <- meta[carry_over]
+  new_meta
 }
 
 dependency_hash <- function(target, config) {

--- a/R/meta.R
+++ b/R/meta.R
@@ -96,7 +96,7 @@ finish_meta <- function(target, meta, config){
     # If the target is a file output, then we know
     # it needs to be rehashed.
     if (!meta$imported){
-      meta$file <- rehash_file(target = target, config = config)
+      meta$file <- safe_rehash_file(target = target, config = config)
     }
   }
   # If the user selected a non-default trigger,
@@ -146,6 +146,15 @@ rehash_file <- function(target, config) {
     file = TRUE,
     serialize = FALSE
   )
+}
+
+safe_rehash_file <- function(target, config){
+  if (file.exists(drake_unquote(target))){
+    rehash_file(target = target, config = config)
+  } else {
+    warning("File does not exist: ", target, call. = FALSE)
+    as.character(NA)
+  }
 }
 
 should_rehash_file <- function(filename, new_mtime, old_mtime,

--- a/R/meta.R
+++ b/R/meta.R
@@ -63,7 +63,7 @@ meta_list <- function(targets, config) {
 drake_meta <- function(target, config = drake::read_drake_config()) {
   meta <- list(
     target = target,
-    imported = !(target %in% config$plan$target),
+    imported = target %in% V(imports_graph(config$graph))$name,
     foreign = !exists(x = target, envir = config$envir, inherits = FALSE),
     missing = !target_exists(target = target, config = config),
     seed = seed_from_object(list(seed = config$seed, target = target))

--- a/R/meta.R
+++ b/R/meta.R
@@ -73,7 +73,7 @@ drake_meta <- function(target, config = drake::read_drake_config()) {
     meta$depends <- dependency_hash(target = target, config = config)
   }
   if (trigger %in% triggers_with_file()){
-    meta$file <- file_hash(target = target, config = config)
+    meta$file <- file_out_hash(target = target, config = config)
   }
   meta
 }
@@ -194,9 +194,12 @@ file_hash <- function(target, config, size_cutoff = 1e5) {
   }
 }
 
-file_out_hash <- function(target, config, size_cutoff = 1e5){
+file_out_hash <- function(target, config){
   files <- V(config$graph)$name[V(config$graph)$job == meta$job] %>%
     Filter(f = is_file) %>%
-    file_hash(config = config, size_cutoff = size_cutoff) %>%
+    file_hash(config = config) %>%
     digest::digest(algo = config$long_hash_algo)
 }
+
+
+

--- a/R/meta.R
+++ b/R/meta.R
@@ -201,7 +201,11 @@ file_out_hash <- function(target, config){
     index = target
   )
   files <- V(config$graph)$name[V(config$graph)$job == job] %>%
-    Filter(f = is_file) %>%
-    file_hash(config = config) %>%
+    Filter(f = is_file)
+  if (length(files)){
+    purrr::map_chr(.x = files, .f = file_hash, config = config) %>%
     digest::digest(algo = config$long_hash_algo)
+  } else {
+    as.character(NA)
+  }
 }

--- a/R/meta.R
+++ b/R/meta.R
@@ -200,6 +200,3 @@ file_out_hash <- function(target, config){
     file_hash(config = config) %>%
     digest::digest(algo = config$long_hash_algo)
 }
-
-
-

--- a/R/outdated.R
+++ b/R/outdated.R
@@ -83,7 +83,7 @@ outdated <-  function(
 #' })
 #' }
 missed <- function(config = drake::read_drake_config()){
-  imports <- setdiff(V(config$graph)$name, config$plan$target)
+  imports <- V(imports_graph(config$graph))$name
   is_missing <- lightly_parallelize(
     X = imports,
     FUN = function(x){

--- a/R/predict_runtime.R
+++ b/R/predict_runtime.R
@@ -187,7 +187,7 @@ rate_limiting_times <- function(
   ) %>%
     as.data.frame
   keys <- V(config$graph)$name
-  import_keys <- setdiff(keys, config$plan$target)
+  import_keys <- V(imports_graph(config$graph))$name
   items <- intersect(keys, times$item)
   not_timed <- setdiff(keys, items)
   warn_not_timed(not_timed)

--- a/R/queue.R
+++ b/R/queue.R
@@ -1,6 +1,6 @@
 new_target_queue <- function(config){
-  config$graph <- config$execution_graph
-  targets <- V(config$graph)$name
+  config$schedule <- config$execution_graph
+  targets <- V(config$schedule)$name
   priorities <- lightly_parallelize(
     X = targets,
     FUN = function(target){

--- a/R/read.R
+++ b/R/read.R
@@ -113,10 +113,9 @@ readd <- function(
 #'   - `TRUE`: same as `"promise"`.
 #'   - `FALSE`: same as `"eager"`.
 #'
-#' @param graph optional igraph object, representation
-#'   of the workflow network for getting dependencies
-#'   if `deps` is `TRUE`. If none is supplied,
-#'   it will be read from the cache.
+#' @param graph optional igraph object, the dependency graph
+#'   of the workflow. Used to load dependencies if `deps` is `TRUE`.
+#'   If no graph is supplied, one will be read from the cache.
 #'
 #' @param replace logical. If `FALSE`,
 #'   items already in your environment

--- a/R/sanitize.R
+++ b/R/sanitize.R
@@ -39,7 +39,7 @@ drake_plan_columns <- function(){
 sanitize_targets <- function(plan, targets){
   plan <- sanitize_plan(plan)
   targets <- repair_target_names(targets)
-  sanitize_nodes(nodes = targets, choices = plan$target)
+  sanitize_nodes(nodes = targets, choices = possible_targets(plan))
 }
 
 sanitize_nodes <- function(nodes, choices){

--- a/R/sanitize.R
+++ b/R/sanitize.R
@@ -13,7 +13,6 @@ sanitize_plan <- function(plan){
   if (!is.null(plan[["trigger"]])){
     assert_legal_triggers(plan[["trigger"]])
   }
-  plan <- file_outs_to_targets(plan)
   plan$target <- repair_target_names(plan$target)
   plan[nchar(plan$target) > 0, ]
 }
@@ -82,34 +81,4 @@ repair_target_names <- function(x){
   x <- gsub("^_", "", x)
   x[!nchar(x)] <- "X"
   make.unique(x, sep = "_")
-}
-
-file_outs_to_targets <- function(plan){
-  index <- grepl("file_out", plan$command)
-  plan$target[index] <- vapply(
-    plan$command[index],
-    single_file_out,
-    character(1)
-  )
-  plan$target[is_file(plan$target)] <-
-    plan$target[is_file(plan$target)] %>%
-    gsub(pattern = "^'|'$", replacement = "\"")
-  plan
-}
-
-single_file_out <- function(command){
-  file_out <- command_dependencies(command)$file_out
-  if (length(file_out) < 1){
-    stop("found an empty file_out() in command: ", command, call. = FALSE)
-  }
-  if (length(file_out) > 1){
-    warning(
-      "Multiple file outputs found for command `", command, "`. ",
-      "Choosing ", file_out[1], " as the target name.",
-      call. = FALSE
-    )
-    file_out[1]
-  } else {
-    file_out
-  }
 }

--- a/R/staged_parallelism.R
+++ b/R/staged_parallelism.R
@@ -58,7 +58,10 @@ parallel_stages <- function(
   run_staged_parallelism(config = config, worker = worker_parallel_stages)
   targets_graph <- targets_graph(graph = config$graph)
   config$execution_graph <- targets_graph
-  run_staged_parallelism(config = config, worker = worker_parallel_stages)
+  # Some output files may not exist yet:
+  suppressWarnings(
+    run_staged_parallelism(config = config, worker = worker_parallel_stages)
+  )
   out <- read_parallel_stages(config = config)
   if (!length(out)){
     return(data.frame(

--- a/R/staged_parallelism.R
+++ b/R/staged_parallelism.R
@@ -54,9 +54,9 @@ parallel_stages <- function(
   }
   config$stages_cache <- storr::storr_environment()
   config$stages_cache$clear()
-  config$execution_graph <- imports_graph(config = config)
+  config$execution_graph <- imports_graph(graph = config$graph)
   run_staged_parallelism(config = config, worker = worker_parallel_stages)
-  targets_graph <- targets_graph(config = config)
+  targets_graph <- targets_graph(graph = config$graph)
   config$execution_graph <- targets_graph
   run_staged_parallelism(config = config, worker = worker_parallel_stages)
   out <- read_parallel_stages(config = config)
@@ -156,7 +156,7 @@ read_parallel_stages <- function(config){
 next_stage <- function(config = drake::read_drake_config()){
   config$stages_cache <- storr::storr_environment()
   config$stages_cache$clear()
-  config$execution_graph <- targets_graph(config = config)
+  config$execution_graph <- targets_graph(graph = config$graph)
   parallel_stage(worker = worker_next_stage, config = config)
   tryCatch(
     config$stages_cache$get(key = "next_stage"),

--- a/R/staged_parallelism.R
+++ b/R/staged_parallelism.R
@@ -95,7 +95,7 @@ run_staged_parallelism <- function(config, worker) {
 }
 
 worker_parallel_stages <- function(targets, meta_list, config){
-  imports <- setdiff(targets, config$plan$target)
+  imports <- setdiff(targets, V(imports_graph(config$graph))$name)
   if (length(imports)){
     worker_mclapply(
       targets = imports,
@@ -109,7 +109,7 @@ worker_parallel_stages <- function(targets, meta_list, config){
   stage <- config$stages_cache$get(key = "stage")
   out <- data.frame(
     item = targets,
-    imported = !targets %in% config$plan$target,
+    imported = !targets %in% V(targets_graph(config$graph))$name,
     file = is_file(targets),
     stage = stage,
     stringsAsFactors = FALSE
@@ -219,7 +219,7 @@ parallel_stage <- function(worker, config) {
     }
     old_leaves <- new_leaves
   }
-  if (length(intersect(build_these, config$plan$target))){
+  if (length(intersect(build_these, V(targets_graph(config$graph))$name))){
     set_attempt_flag(config = config)
   }
   if (length(build_these)){

--- a/R/store.R
+++ b/R/store.R
@@ -8,7 +8,7 @@ store_outputs <- function(target, outputs, value, meta, config){
     )
     store_target(
       target = output,
-      value = new_meta$file,
+      value = new_meta$file, # Need the DSL for extra non-file outputs.
       meta = new_meta,
       config = config
     )

--- a/R/store.R
+++ b/R/store.R
@@ -1,6 +1,9 @@
 store_outputs <- function(target, outputs, value, meta, config){
   store_target(target = target, value = value, meta = meta, config = config)
   for (output in setdiff(outputs, target)){
+    
+    browser()
+    
     new_meta <- concomitant_output_meta(
       output = output,
       meta = meta,

--- a/R/store.R
+++ b/R/store.R
@@ -1,9 +1,6 @@
 store_outputs <- function(target, outputs, value, meta, config){
   store_target(target = target, value = value, meta = meta, config = config)
   for (output in setdiff(outputs, target)){
-    
-    browser()
-    
     new_meta <- concomitant_output_meta(
       output = output,
       meta = meta,

--- a/R/store.R
+++ b/R/store.R
@@ -1,3 +1,20 @@
+store_outputs <- function(target, outputs, value, meta, config){
+  store_target(target = target, value = value, meta = meta, config = config)
+  for (output in setdiff(outputs, target)){
+    new_meta <- concomitant_output_meta(
+      output = output,
+      meta = meta,
+      config = config
+    )
+    store_target(
+      target = output,
+      value = new_meta$file,
+      meta = new_meta,
+      config = config
+    )
+  }
+}
+
 store_target <- function(target, value, meta, config) {
   # Failed targets need to stay invalidated,
   # even when `config$keep_going` is `TRUE`.

--- a/R/test.R
+++ b/R/test.R
@@ -33,7 +33,7 @@ justbuilt <- function(config) {
   unlist(all) %>%
     Filter(f = function(x) x == "finished") %>%
     names %>%
-    intersect(y = config$plan$target) %>%
+    intersect(y = V(targets_graph(config$graph))$name) %>%
     sort
 }
 

--- a/R/timestamp.R
+++ b/R/timestamp.R
@@ -28,7 +28,7 @@ time_stamps <- function(config){
   if (length(build_these)){
     set_attempt_flag(config = config)
   }
-  stamp_these <- setdiff(config$plan$target, build_these)
+  stamp_these <- setdiff(V(targets_graph(config$schedule))$name, build_these)
   lightly_parallelize(
     stamp_these, write_time_stamp, jobs = config$jobs, config = config)
   return(invisible())

--- a/R/triggers.R
+++ b/R/triggers.R
@@ -129,7 +129,9 @@ assert_legal_triggers <- function(x){
 }
 
 command_trigger <- function(target, meta, config){
-  stopifnot(!is.null(meta$command))
+  if (is.null(meta$command)){
+    return(FALSE)
+  }
   command <- get_from_subspace(
     key = target,
     subspace = "command",
@@ -140,7 +142,9 @@ command_trigger <- function(target, meta, config){
 }
 
 depends_trigger <- function(target, meta, config){
-  stopifnot(!is.null(meta$depends))
+  if (is.null(meta$depends)){
+    return(FALSE)
+  }
   depends <- get_from_subspace(
     key = target,
     subspace = "depends",
@@ -151,7 +155,9 @@ depends_trigger <- function(target, meta, config){
 }
 
 file_trigger <- function(target, meta, config){
-  stopifnot(!is.null(meta$file))
+  if (is.null(meta$file)){
+    return(FALSE)
+  }
   files <- V(config$graph)$name[V(config$graph)$job == meta$job] %>%
     Filter(f = is_file)
   if (!length(files)){

--- a/R/triggers.R
+++ b/R/triggers.R
@@ -166,17 +166,19 @@ file_trigger <- function(target, meta, config){
   if (!all(file.exists(drake_unquote(files)))){
     return(TRUE)
   }
-  
-  
-  !identical(
-    meta$file,
-    get_from_subspace(
-      key = target,
+  for (file in files){
+    current <- file_hash(target = file, config = config)
+    stored <- get_from_subspace(
+      key = file,
       subspace = "file",
       namespace = "meta",
       cache = config$cache
     )
-  )
+    if (!identical(current, stored)){
+      return(TRUE)
+    }
+  }
+  FALSE
 }
 
 should_build <- function(target, meta_list, config){

--- a/R/triggers.R
+++ b/R/triggers.R
@@ -152,19 +152,24 @@ depends_trigger <- function(target, meta, config){
 
 file_trigger <- function(target, meta, config){
   stopifnot(!is.null(meta$file))
-  if (!is_file(target)){
+  files <- V(config$graph)$name[V(config$graph)$job == meta$job] %>%
+    Filter(f = is_file)
+  if (!length(files)){
     return(FALSE)
   }
-  if (!file.exists(drake_unquote(target))){
+  if (!all(file.exists(drake_unquote(files)))){
     return(TRUE)
   }
-  tryCatch(
+  if (!tryCatch(
     !identical(
-      config$cache$get(target, namespace = "kernels"),
+      config$cache$get(target, namespace = "meta")$file,
       meta$file
     ),
     error = error_false
-  )
+  )){
+    return(FALSE)
+  }
+
 }
 
 should_build <- function(target, meta_list, config){

--- a/R/triggers.R
+++ b/R/triggers.R
@@ -160,16 +160,15 @@ file_trigger <- function(target, meta, config){
   if (!all(file.exists(drake_unquote(files)))){
     return(TRUE)
   }
-  if (!tryCatch(
-    !identical(
-      config$cache$get(target, namespace = "meta")$file,
-      meta$file
-    ),
-    error = error_false
-  )){
-    return(FALSE)
-  }
-
+  !identical(
+    meta$file,
+    get_from_subspace(
+      key = target,
+      subspace = "file",
+      namespace = "meta",
+      cache = config$cache
+    )
+  )
 }
 
 should_build <- function(target, meta_list, config){

--- a/R/triggers.R
+++ b/R/triggers.R
@@ -166,6 +166,8 @@ file_trigger <- function(target, meta, config){
   if (!all(file.exists(drake_unquote(files)))){
     return(TRUE)
   }
+  
+  
   !identical(
     meta$file,
     get_from_subspace(

--- a/R/workplan.R
+++ b/R/workplan.R
@@ -169,6 +169,8 @@ drake_plan <- function(
       "Worry about single-quotes no more!"
     )
   }
+
+  # TODO: get rid of this once we remove the old file API.
   if (identical(file_targets, TRUE)){
     plan$target <- drake::drake_quotes(plan$target, single = TRUE)
   }

--- a/R/workplan.R
+++ b/R/workplan.R
@@ -238,7 +238,8 @@ drake_plan_override <- function(target, field, config){
 #' test_with_dir("Contain side effects", {
 #' # The `file_out()` and `file_in()` functions
 #' # just takes in strings and returns them.
-#' file_out("summaries.txt")
+#' # You can specify multiple files at once.
+#' file_in("summaries.txt", "file.txt")
 #' # Their main purpose is to orchestrate your custom files
 #' # in your workflow plan data frame.
 #' suppressWarnings(
@@ -282,7 +283,8 @@ file_in <- function(...){
 #' test_with_dir("Contain side effects", {
 #' # The `file_out()` and `file_in()` functions
 #' # just takes in strings and returns them.
-#' file_out("summaries.txt")
+#' # You can specify multiple input/output files
+#' file_out("summaries.txt", "text.txt")
 #' # Their main purpose is to orchestrate your custom files
 #' # in your workflow plan data frame.
 #' suppressWarnings(
@@ -305,17 +307,7 @@ file_in <- function(...){
 #' # in your report.
 #' })
 #' }
-file_out <- function(path){
-  if (length(path) != 1){
-    warning(
-      "In file_out(), the `path` argument must ",
-      "have length 1. Supplied length = ", length(path), ". ",
-      "using first file output: ", path[1], ".",
-      call. = FALSE
-    )
-  }
-  as.character(path[1])
-}
+file_out <- file_in
 
 #' @title Declare the `knitr`/`rmarkdown` source files
 #'   of a workflow plan command.

--- a/man/drake_config.Rd
+++ b/man/drake_config.Rd
@@ -224,10 +224,9 @@ and speed with
 \code{\link[=progress]{progress()}} and \code{\link[=in_progress]{in_progress()}}
 will no longer work if you do that.}
 
-\item{graph}{An \code{igraph} object from the previous \code{make()}.
-Supplying a pre-built graph could save time.
+\item{graph}{An optional \code{igraph} object, the dependency graph.
+Supplying a pre-built dependency graph could save time.
 The graph is constructed by \code{\link[=build_drake_graph]{build_drake_graph()}}.
-You can also get one from \code{\link{config}(my_plan)$graph}.
 Overrides \code{skip_imports}.}
 
 \item{trigger}{Name of the trigger to apply to all targets.

--- a/man/file_in.Rd
+++ b/man/file_in.Rd
@@ -23,7 +23,8 @@ for a full explanation.
 test_with_dir("Contain side effects", {
 # The `file_out()` and `file_in()` functions
 # just takes in strings and returns them.
-file_out("summaries.txt")
+# You can specify multiple files at once.
+file_in("summaries.txt", "file.txt")
 # Their main purpose is to orchestrate your custom files
 # in your workflow plan data frame.
 suppressWarnings(

--- a/man/file_out.Rd
+++ b/man/file_out.Rd
@@ -4,14 +4,14 @@
 \alias{file_out}
 \title{Declare the file outputs of a workflow plan command.}
 \usage{
-file_out(path)
+file_out(...)
 }
 \arguments{
+\item{...}{Do not use. For informative input handling only.}
+
 \item{path}{Character string of length 1. File path
 of the file output of a command in your
 workflow plan data frame.}
-
-\item{...}{Do not use. For informative input handling only.}
 }
 \value{
 A character string, the file path of the file output.
@@ -27,7 +27,8 @@ for a full explanation.
 test_with_dir("Contain side effects", {
 # The `file_out()` and `file_in()` functions
 # just takes in strings and returns them.
-file_out("summaries.txt")
+# You can specify multiple input/output files
+file_out("summaries.txt", "text.txt")
 # Their main purpose is to orchestrate your custom files
 # in your workflow plan data frame.
 suppressWarnings(

--- a/man/loadd.Rd
+++ b/man/loadd.Rd
@@ -82,10 +82,9 @@ with \code{\link[=assign]{assign()}}.
 \item \code{FALSE}: same as \code{"eager"}.
 }}
 
-\item{graph}{optional igraph object, representation
-of the workflow network for getting dependencies
-if \code{deps} is \code{TRUE}. If none is supplied,
-it will be read from the cache.}
+\item{graph}{optional igraph object, the dependency graph
+of the workflow. Used to load dependencies if \code{deps} is \code{TRUE}.
+If no graph is supplied, one will be read from the cache.}
 
 \item{replace}{logical. If \code{FALSE},
 items already in your environment

--- a/man/make.Rd
+++ b/man/make.Rd
@@ -231,10 +231,9 @@ of runtime configuration parameters used by \code{make()}.
 This argument is deprecated. Now, a configuration list
 is always invisibly returned.}
 
-\item{graph}{An \code{igraph} object from the previous \code{make()}.
-Supplying a pre-built graph could save time.
+\item{graph}{An optional \code{igraph} object, the dependency graph.
+Supplying a pre-built dependency graph could save time.
 The graph is constructed by \code{\link[=build_drake_graph]{build_drake_graph()}}.
-You can also get one from \code{\link{config}(my_plan)$graph}.
 Overrides \code{skip_imports}.}
 
 \item{trigger}{Name of the trigger to apply to all targets.

--- a/tests/testthat/test-triggers.R
+++ b/tests/testthat/test-triggers.R
@@ -1,5 +1,11 @@
 drake_context("triggers")
 
+test_with_dir("empty triggers return logical", {
+  expect_identical(depends_trigger("x", list(), list()), FALSE)
+  expect_identical(command_trigger("x", list(), list()), FALSE)
+  expect_identical(file_trigger("x", list(), list()), FALSE)
+})
+
 test_with_dir("triggers work as expected", {
   con <- dbug()
   con$plan$trigger <- "missing"

--- a/tests/testthat/test-workflow-plan.R
+++ b/tests/testthat/test-workflow-plan.R
@@ -57,8 +57,10 @@ test_with_dir("File functions handle input", {
   expect_equal(
     knitr_in(1, "x", "y"), c("1", "x", "y")
   )
-  expect_warning(expect_equal(file_out(c(1, "x", "y")), "1"))
-  expect_error(file_out(1, "x", "y"))
+  expect_equal(
+    sort(file_out(c(1, "x", "y"))),
+    sort(c("1", "x", "y"))
+  )
   expect_equal(
     code_dependencies(quote(file_out(c("file1", "file2")))),
     list(file_out = drake_quotes(c("file1", "file2"), single = FALSE))


### PR DESCRIPTION
# Summary

This PR is not ready to merge, and it may not even be the right way to attack the problem. 

Internally, this version of `drake` creates two DAGs: a dependency graph (`config$graph`) and a schedule of jobs (`config$schedule`). It uses the distinction to allow multiple file outputs per job. Any file outputs are cached and stored separately from the command's return value (the true target).

# GitHub issues addressed

- Ref: #283 (not solved)

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
- [ ] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [ ] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [ ] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [ ] I think this pull request is ready to merge.
