### PR TITLE
fix typo in console message

### DIFF
--- a/R/console.R
+++ b/R/console.R
@@ -133,7 +133,7 @@ console_nondefault_triggers <- function(){
   color(
     paste(
       "Used non-default triggers.",
-      "Some targets may be not be up to date."
+      "Some targets may not be up to date."
     ),
     colors["trigger"]
   ) %>%


### PR DESCRIPTION
# Summary

Just fixing a typo in "R/console.R"
