### PR TITLE
Fix #358

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # Version 5.1.4
 
 - Attempt to fix a Solaris CRAN check error. The test at https://github.com/ropensci/drake/blob/b4dbddb840d2549621b76bcaa46c344b0fd2eccc/tests/testthat/test-edge-cases.R#L3 was previously failing on CRAN's Solaris machine (R 3.5.0). In the test, one of the threads deliberately quits in error, and the R/Solaris installation did not handle this properly. The test should work now because it no longer uses any parallelism.
+- Add an `upstream_only` argument to `failed()` so users can list failed targets that do not have any failed dependencies. Naturally accompanies `make(keep_going = TRUE)`.
 
 # Version 5.1.2
 

--- a/R/graph.R
+++ b/R/graph.R
@@ -225,6 +225,12 @@ leaf_nodes <- function(graph){
   V(graph)[is_leaf]$name
 }
 
+filter_upstream <- function(targets, graph){
+  delete_these <- setdiff(V(graph)$name, targets)
+  graph <- delete_vertices(graph = graph, v = delete_these)
+  leaf_nodes(graph)
+}
+
 exclude_imports_if <- function(config){
   if (!length(config$skip_imports)){
     config$skip_imports <- FALSE

--- a/R/progress.R
+++ b/R/progress.R
@@ -67,6 +67,9 @@ in_progress <- function(path = getwd(), search = TRUE,
 #' @export
 #' @return A character vector of target names.
 #' @inheritParams cached
+#' @param upstream_only logical, whether to list only those targets
+#'   with no failed dependencies.
+#'   Naturally accompanies `make(keep_going = TRUE)`.
 #' @examples
 #' \dontrun{
 #' test_with_dir("Quarantine side effects.", {
@@ -82,12 +85,18 @@ in_progress <- function(path = getwd(), search = TRUE,
 #' }
 failed <- function(path = getwd(), search = TRUE,
   cache = drake::get_cache(path = path, search = search, verbose = verbose),
-  verbose = drake::default_verbose()
+  verbose = drake::default_verbose(),
+  upstream_only = FALSE
 ){
   prog <- progress(path = path, search = search, cache = cache)
-  which(prog == "failed") %>%
+  out <- which(prog == "failed") %>%
     names() %>%
     as.character()
+  if (upstream_only){
+    graph <- read_drake_graph(cache = cache)
+    out <- filter_upstream(targets = out, graph = graph)
+  }
+  out
 }
 
 #' @title Get the build progress of your targets

--- a/man/failed.Rd
+++ b/man/failed.Rd
@@ -7,7 +7,7 @@ to \code{\link[=make]{make()}}.}
 \usage{
 failed(path = getwd(), search = TRUE, cache = drake::get_cache(path =
   path, search = search, verbose = verbose),
-  verbose = drake::default_verbose())
+  verbose = drake::default_verbose(), upstream_only = FALSE)
 }
 \arguments{
 \item{path}{Root directory of the drake project,
@@ -34,6 +34,10 @@ for example, \code{pkgconfig::set_config("drake::verbose" = 2)}.
 \item{3:}{in addition, print any potentially missing items.}
 \item{4:}{in addition, print imports. Full verbosity.}
 }}
+
+\item{upstream_only}{logical, whether to list only those targets
+with no failed dependencies.
+Naturally accompanies \code{make(keep_going = TRUE)}.}
 }
 \value{
 A character vector of target names.

--- a/tests/testthat/test-edge-cases.R
+++ b/tests/testthat/test-edge-cases.R
@@ -36,6 +36,10 @@ test_with_dir("can keep going", {
   )
   expect_equal(sort(built()), sort(c("a2", "a3", "b2", "b3", "b4")))
   expect_equal(sort(failed()), sort(c("a1", "a4", "b1")))
+  expect_equal(
+    sort(failed(upstream_only = TRUE)),
+    sort(c("a1", "a4"))
+  )
 })
 
 test_with_dir("failed targets do not become up to date", {


### PR DESCRIPTION
# Summary

Add an `upstream_only` argument to `failed()` so users can list failed targets that do not have any failed dependencies. Naturally accompanies `make(keep_going = TRUE)`.

# GitHub issues fixed

- Ref: #358

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
