### PR TITLE
Get rid of staged parallelism in make(parallelism = "mclapply")

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: drake
 Title: Data Frames in R for Make
 Description: An R-focused pipeline toolkit
   for reproducible code and high-performance computing.
-Version: 5.1.3.9000
+Version: 5.1.3.9001
 License: GPL-3
 URL: https://github.com/ropensci/drake
 BugReports: https://github.com/ropensci/drake/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # Version 5.1.4
 
+- Remove staged parallelism from the `make(parallelism = "mclapply")` backend. Now uses persistent workers and a master process.
 - Attempt to fix a Solaris CRAN check error. The test at https://github.com/ropensci/drake/blob/b4dbddb840d2549621b76bcaa46c344b0fd2eccc/tests/testthat/test-edge-cases.R#L3 was previously failing on CRAN's Solaris machine (R 3.5.0). In the test, one of the threads deliberately quits in error, and the R/Solaris installation did not handle this properly. The test should work now because it no longer uses any parallelism.
 - Add an `upstream_only` argument to `failed()` so users can list failed targets that do not have any failed dependencies. Naturally accompanies `make(keep_going = TRUE)`.
 - Add an RStudio R Markdown template compatible with https://krlmlr.github.io/drake-pitch/.

--- a/R/future.R
+++ b/R/future.R
@@ -61,7 +61,6 @@ drake_future_task <- function(target, meta, config, protect){
 
 new_worker <- function(id, target, config, protect){
   meta <- drake_meta(target = target, config = config)
-  meta$start <- proc.time()
   if (!should_build_target(
     target = target,
     meta = meta,
@@ -69,6 +68,7 @@ new_worker <- function(id, target, config, protect){
   )){
     return(empty_worker(target = target))
   }
+  meta$start <- proc.time()
   config$cache$flush_cache() # Less data to pass this way.
   DRAKE_GLOBALS__ <- NULL # Fixes warning about undefined globals.
   # Avoid potential name conflicts with other globals.

--- a/R/graph.R
+++ b/R/graph.R
@@ -222,9 +222,10 @@ filter_upstream <- function(targets, graph){
   leaf_nodes(graph)
 }
 
+# This function will go away when we get rid of staged parallelism.
 exclude_imports_if <- function(config){
   if (!length(config$skip_imports)){
-    config$skip_imports <- FALSE
+    config$skip_imports <- FALSE # nocov
   }
   if (!config$skip_imports){
     return(config)

--- a/R/graph.R
+++ b/R/graph.R
@@ -230,11 +230,11 @@ exclude_imports_if <- function(config){
     return(config)
   }
   delete_these <- setdiff(
-    V(config$execution_graph)$name,
+    V(config$schedule)$name,
     config$plan$target
   )
-  config$execution_graph <- delete_vertices(
-    graph = config$execution_graph,
+  config$schedule <- delete_vertices(
+    graph = config$schedule,
     v = delete_these
   )
   config

--- a/R/handlers.R
+++ b/R/handlers.R
@@ -49,6 +49,10 @@ error_null <- function(e){
   NULL
 }
 
+error_show <- function(e){
+  message("Error: ", e$message)
+}
+
 error_tibble_times <- function(e){
   stop(
     "Failed converting a data frame of times to a tibble. ",

--- a/R/handlers.R
+++ b/R/handlers.R
@@ -50,7 +50,7 @@ error_null <- function(e){
 }
 
 error_show <- function(e){
-  message("Error: ", e$message)
+  message("Error: ", e$message) # nocov
 }
 
 error_tibble_times <- function(e){

--- a/R/make.R
+++ b/R/make.R
@@ -263,7 +263,7 @@ make_session <- function(config){
 #' })
 #' }
 make_imports <- function(config = drake::read_drake_config()){
-  config$execution_graph <- imports_graph(config = config)
+  config$schedule <- imports_graph(config = config)
   config$jobs <- jobs_imports(jobs = config$jobs)
   config$parallelism <- use_default_parallelism(config$parallelism)
   run_parallel_backend(config = config)
@@ -312,7 +312,7 @@ imports_graph <- function(config){
 #' })
 #' }
 make_targets <- function(config = drake::read_drake_config()){
-  config$execution_graph <- targets_graph(config = config)
+  config$schedule <- targets_graph(config = config)
   config$jobs <- jobs_targets(jobs = config$jobs)
   run_parallel_backend(config = config)
   console_up_to_date(config = config)

--- a/R/mclapply.R
+++ b/R/mclapply.R
@@ -221,3 +221,18 @@ warn_mclapply_windows <- function(
     )
   }
 }
+
+# Get rid of this:
+
+worker_mclapply <- function(targets, meta_list, config){
+  prune_envir(targets = targets, config = config)
+  jobs <- safe_jobs(config$jobs)
+  values <- mclapply(
+    X = targets,
+    FUN = drake_build_worker,
+    meta_list = meta_list,
+    config = config,
+    mc.cores = jobs
+  )
+  assign_to_envir(targets = targets, values = values, config = config)
+}

--- a/R/mclapply.R
+++ b/R/mclapply.R
@@ -132,15 +132,6 @@ mc_all_done <- function(config){
   TRUE
 }
 
-mc_running_targets <- function(config){
-  Filter(
-    x = config$workers,
-    f = function(worker){
-      mc_is_running(worker = worker, config = config)
-    }
-  )
-}
-
 mc_is_status <- function(worker, status, config){
   while (TRUE){
     worker_status <- try(
@@ -150,7 +141,7 @@ mc_is_status <- function(worker, status, config){
     if (worker_status %in% c("done", "idle", "running")){
       break
     }
-    Sys.sleep(mc_wait)
+    Sys.sleep(mc_wait) # nocov
   }
   identical(status, worker_status)
 }
@@ -161,10 +152,6 @@ mc_is_done <- function(worker, config){
 
 mc_is_idle <- function(worker, config){
   mc_is_status(worker = worker, status = "idle", config = config)
-}
-
-mc_is_running <- function(worker, config){
-  mc_is_status(worker = worker, status = "running", config = config)
 }
 
 mc_set_status <- function(worker, status, config){
@@ -192,7 +179,7 @@ mc_get_target <- function(worker, config){
     if (is.character(target)){
       break
     }
-    Sys.sleep(mc_wait)
+    Sys.sleep(mc_wait) # nocov
   }
   target
 }

--- a/R/mclapply.R
+++ b/R/mclapply.R
@@ -159,7 +159,7 @@ mc_conclude_worker <- function(worker, config){
   if (!get_attempt_flag(config) && target %in% config$plan$target){
     set_attempt_flag(config)
   }
-  queue$decrease_key(names = revdeps)
+  config$queue$decrease_key(names = revdeps)
   mc_set_idle(worker = worker, config = config)
 }
 

--- a/R/mclapply.R
+++ b/R/mclapply.R
@@ -16,12 +16,18 @@ run_mclapply <- function(config){
   invisible()
 }
 
+mc_try <- function(code){
+  tryCatch(code, error = error_show)
+}
+
 mclapply_process <- function(id, config){
-  if (id == "0"){
-    mclapply_master(config)
-  } else {
-    mclapply_worker(worker = id, config = config)
-  }
+  mc_try({
+    if (id == "0"){
+      mclapply_master(config)
+    } else {
+      mclapply_worker(worker = id, config = config)
+    }
+  })
 }
 
 mclapply_master <- function(config){

--- a/R/mclapply.R
+++ b/R/mclapply.R
@@ -1,18 +1,148 @@
 run_mclapply <- function(config){
-  run_staged_parallelism(config = config, worker = worker_mclapply)
+  config$jobs <- safe_jobs(config$jobs)
+  if (config$jobs < 2) {
+    return(run_lapply(config = config))
+  }
+  mc_initialize_mc_cache(config)
+  tmp <- mclapply(
+    X = c(0L, seq_len(config$jobs)),
+    FUN = mclapply_process,
+    mc.cores = config$jobs + 1,
+    config = config
+  )
+  invisible()
 }
 
-worker_mclapply <- function(targets, meta_list, config){
-  prune_envir(targets = targets, config = config)
-  jobs <- safe_jobs(config$jobs)
-  values <- mclapply(
-    X = targets,
-    FUN = drake_build_worker,
-    meta_list = meta_list,
-    config = config,
-    mc.cores = jobs
+mclapply_process <- function(id, config){
+  if (id == 0L){
+    mclapply_master(config)
+  } else {
+    mclapply_worker(id = id, config = config)
+  }
+}
+
+mclapply_master <- function(config){
+  config$queue <- new_target_queue(config = config)
+  config$workers <- as.character(seq_len(config$jobs))
+  # While any targets are queued or running...
+  while (mc_work_remains(config)){
+    for (worker in config$workers){
+      if (mc_is_idle(worker)){
+        mc_conclude_worker(worker = worker, config = config)
+        # Pop the head target only if its priority is 0
+        next_target <- queue$pop0(what = "names")
+        if (!length(next_target)){
+          # It's hard to make this line run in a small test workflow
+          # suitable enough for unit testing, but
+          # I did artificially stall targets and verified that this line
+          # is reached in the future::multisession backend as expected.
+          next # nocov
+        }
+        config$cache$set(
+          key = worker,
+          value = next_target,
+          namespace = "workers"
+        )
+      }
+    }
+    Sys.sleep(1e-9)
+  }
+}
+
+mclapply_worker <- function(worker, config){
+  while (TRUE){
+    target <- config$cache$get(key = worker, namespace = "config")
+    if (identical(target, FALSE)){
+      return()
+    } else if (identical(target, TRUE)){
+      Sys.sleep(1e-9)
+      next
+    }
+    meta <- drake_meta(target = target, config = config)
+    if (!should_build_target(
+      target = target,
+      meta = meta,
+      config = config
+    )){
+      next
+    }
+    meta$start <- proc.time()
+    do_prework(config = config, verbose_packages = FALSE)
+    prune_envir(
+      targets = target,
+      config = config,
+      downstream = config$cache$list(namespace = "protect")
+    )
+    value <- build_and_store(target = target, meta = meta, config = config)
+    assign(x = target, value = vlaue, envir = config$envir)
+    invisible()
+  }
+}
+
+mc_initialize_mc_cache <- function(config){
+  config$cache$clear(namespace = "workers")
+  lapply(
+    X = config$workers,
+    FUN = function(worker){
+      config$cache$set(key = worker, value = TRUE, namespace = "workers")
+    }
   )
-  assign_to_envir(targets = targets, values = values, config = config)
+  lapply(
+    X = igraph::V(config$schedule)$name,
+    FUN = function(target){
+      config$cache$set(key = target, value = TRUE, namespace = "protect")
+    }
+  )
+  invisible()
+}
+
+mc_work_remains <- function(config){
+  !queue$empty() ||
+    !mc_all_idle(config)
+}
+
+mc_all_idle <- function(config){
+  for (worker in config$workers){
+    if (!mc_is_idle(worker, config)){
+      return(FALSE)
+    }
+  }
+  TRUE
+}
+
+mc_is_idle <- function(worker, config){
+  is.na(config$cache$get(key = worker, namespace = "workers"))
+}
+
+mc_running_targets <- function(config){
+  lapply(
+    X = config$workers,
+    FUN = function(worker){
+      if (is_idle(worker)){
+        NULL
+      } else {
+        # It's hard to make this line run in a small test workflow
+        # suitable enough for unit testing, but
+        # I did artificially stall targets and verified that this line
+        # is reached in the future::multisession backend as expected.
+        config$cache$get(key = worker, namespace = "workers") # nocov
+      }
+    }
+  ) %>%
+    unlist
+}
+
+mc_conclude_worker <- function(worker, config){
+  target <- config$cache$get(key = worker, namespace = "workers")
+  config$cache$del(key = target, namespace = "protect")
+  revdeps <- dependencies(
+    targets = target,
+    config = config,
+    reverse = TRUE
+  ) %>%
+    intersect(y = config$queue$list(what = "names"))
+  queue$decrease_key(names = revdeps)
+  config$cache$set(key = worker, value = TRUE, namespace = "workers")
 }
 
 warn_mclapply_windows <- function(

--- a/R/migrate.R
+++ b/R/migrate.R
@@ -66,7 +66,7 @@ migrate_drake_project <- function(
   config$envir <- new.env(parent = globalenv())
   config$verbose <- TRUE
   config$trigger <- "any"
-  config$execution_graph <- config$graph
+  config$schedule <- config$graph
   config$lazy_load <- FALSE
   config$log_progress <- FALSE
   config$session_info <- TRUE

--- a/R/queue.R
+++ b/R/queue.R
@@ -1,6 +1,9 @@
 new_target_queue <- function(config){
   config$graph <- config$schedule
   targets <- V(config$graph)$name
+  if (!length(targets)){
+    return(R6_priority_queue$new())
+  }
   priorities <- lightly_parallelize(
     X = targets,
     FUN = function(target){

--- a/R/queue.R
+++ b/R/queue.R
@@ -1,5 +1,5 @@
 new_target_queue <- function(config){
-  config$graph <- config$execution_graph
+  config$graph <- config$schedule
   targets <- V(config$graph)$name
   priorities <- lightly_parallelize(
     X = targets,

--- a/R/triggers.R
+++ b/R/triggers.R
@@ -171,9 +171,6 @@ file_trigger <- function(target, meta, config){
 }
 
 should_build <- function(target, meta_list, config){
-  if (meta_list[[target]]$imported) {
-    return(TRUE)
-  }
   should_build_target(
     target = target,
     meta = meta_list[[target]],
@@ -182,6 +179,9 @@ should_build <- function(target, meta_list, config){
 }
 
 should_build_target <- function(target, meta, config){
+  if (meta$imported) {
+    return(TRUE)
+  }
   if (meta$missing){
     return(TRUE)
   }

--- a/tests/testthat/test-future.R
+++ b/tests/testthat/test-future.R
@@ -65,7 +65,7 @@ test_with_dir("can gracefully conclude a crashed worker", {
   for (caching in c("master", "worker")){
     con <- dbug()
     con$caching <- caching
-    con$execution_graph <- con$graph
+    con$schedule <- con$graph
     worker <- structure(list(), target = "myinput")
     class(worker) <- "Future"
     expect_false(is_empty_worker(worker))

--- a/tests/testthat/test-parallel.R
+++ b/tests/testthat/test-parallel.R
@@ -73,30 +73,36 @@ test_with_dir("mclapply and lapply", {
   config <- dbug()
   make(plan = config$plan, envir = config$envir, verbose = FALSE,
     jobs = 1, parallelism = "mclapply", session_info = FALSE)
-
   expect_true(is.numeric(readd(final)))
   clean()
-
   make(plan = config$plan, envir = config$envir, verbose = FALSE,
     jobs = 1, parallelism = "parLapply", session_info = FALSE)
   expect_true(is.numeric(readd(final)))
-
   expect_true(is.numeric(readd(final)))
   clean()
-
   skip_on_cran()
-
   # should demote to 1 job on Windows
   suppressWarnings(
-    make(plan = config$plan, envir = config$envir, verbose = FALSE,
+    out <- make(plan = config$plan, envir = config$envir, verbose = FALSE,
       jobs = 2, parallelism = "mclapply", session_info = FALSE)
   )
-
+  expect_true(length(justbuilt(out)) > 0)
+  expect_true(is.numeric(readd(final)))
+  suppressWarnings(
+    out <- make(plan = config$plan, envir = config$envir, verbose = FALSE,
+      jobs = 2, parallelism = "mclapply", session_info = FALSE)
+  )
+  expect_equal(justbuilt(out), character(0))
   expect_true(is.numeric(readd(final)))
   clean()
-
-  make(plan = config$plan, envir = config$envir, verbose = FALSE,
+  out <- make(plan = config$plan, envir = config$envir, verbose = FALSE,
     jobs = 2, parallelism = "parLapply", session_info = FALSE)
+  expect_true(length(justbuilt(out)) > 0)
+  expect_true(is.numeric(readd(final)))
+  out <- make(plan = config$plan, envir = config$envir, verbose = FALSE,
+    jobs = 2, parallelism = "parLapply", session_info = FALSE)
+  expect_equal(justbuilt(out), character(0))
+  expect_true(is.numeric(readd(final)))
 })
 
 test_with_dir("lightly_parallelize_atomic() is correct", {

--- a/tests/testthat/test-parallel.R
+++ b/tests/testthat/test-parallel.R
@@ -73,25 +73,30 @@ test_with_dir("mclapply and lapply", {
   config <- dbug()
   make(plan = config$plan, envir = config$envir, verbose = FALSE,
     jobs = 1, parallelism = "mclapply", session_info = FALSE)
-  expect_true(is.numeric(readd(final)))
-  clean()
 
-  # should demote to 1 job on Windows
-  suppressWarnings(
-    make(plan = config$plan, envir = config$envir, verbose = FALSE,
-      jobs = 2, parallelism = "mclapply", session_info = FALSE)
-  )
-  expect_true(is.numeric(readd(final)))
-  clean()
-
-  make(plan = config$plan, envir = config$envir, verbose = FALSE,
-    jobs = 2, parallelism = "parLapply", session_info = FALSE)
   expect_true(is.numeric(readd(final)))
   clean()
 
   make(plan = config$plan, envir = config$envir, verbose = FALSE,
     jobs = 1, parallelism = "parLapply", session_info = FALSE)
   expect_true(is.numeric(readd(final)))
+
+  expect_true(is.numeric(readd(final)))
+  clean()
+
+  skip_on_cran()
+
+  # should demote to 1 job on Windows
+  suppressWarnings(
+    make(plan = config$plan, envir = config$envir, verbose = FALSE,
+      jobs = 2, parallelism = "mclapply", session_info = FALSE)
+  )
+
+  expect_true(is.numeric(readd(final)))
+  clean()
+
+  make(plan = config$plan, envir = config$envir, verbose = FALSE,
+    jobs = 2, parallelism = "parLapply", session_info = FALSE)
 })
 
 test_with_dir("lightly_parallelize_atomic() is correct", {

--- a/tests/testthat/test-queue.R
+++ b/tests/testthat/test-queue.R
@@ -1,5 +1,11 @@
 drake_context("queue")
 
+test_with_dir("empty queue", {
+  config <- list(schedule = igraph::make_empty_graph())
+  q <- new_target_queue(config)
+  expect_equal(length(q$list()), 0)
+})
+
 test_with_dir("the priority queue works", {
   names <- c("foo", "bar", "baz", "Bob", "Amy", "Joe", "soup", "spren")
   priorities <- c(8, 2, 3, 7, 4, 1, 7, 5)


### PR DESCRIPTION
# Summary

In `make(parallelism = "mclapply", jobs = 2)`, `drake` spawns 2 persistent workers and a master process to govern them. This gets rid of staged parallelism for the `mclapply` backend. Other minor changes:

- Skip the `mclapply` tests on CRAN (would spawn 3 jobs).
- Rename `config$execution_graph` to `config$schedule` internally.

All the unit tests seem to work, even for the ["`local_mclapply_9`" testing scenario](https://github.com/ropensci/drake/blob/master/inst/testing/scenarios.csv#L5), but there is some testing left to do on real projects.

cc @krlmlr 

# GitHub issues fixed

This PR chips away at #369, but does not solve it. Many more to-do's remain in the checklist.

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [ ] I think this pull request is ready to merge.
