### PR TITLE
Remove the appearance of staged parallelism for single-job runthroughs.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # Version 5.1.4
 
-- Remove staged parallelism from the `make(parallelism = "mclapply")` backend. Now uses persistent workers and a master process.
+- Remove staged parallelism from the `"mclapply"` backend. Now uses persistent workers and a master process.
+- Remove the appearance of staged parallelism from single-job `make()`'s.
+- Calls to `make()` no longer leave targets in the user's environment.
 - Attempt to fix a Solaris CRAN check error. The test at https://github.com/ropensci/drake/blob/b4dbddb840d2549621b76bcaa46c344b0fd2eccc/tests/testthat/test-edge-cases.R#L3 was previously failing on CRAN's Solaris machine (R 3.5.0). In the test, one of the threads deliberately quits in error, and the R/Solaris installation did not handle this properly. The test should work now because it no longer uses any parallelism.
 - Add an `upstream_only` argument to `failed()` so users can list failed targets that do not have any failed dependencies. Naturally accompanies `make(keep_going = TRUE)`.
 - Add an RStudio R Markdown template compatible with https://krlmlr.github.io/drake-pitch/.

--- a/R/build.R
+++ b/R/build.R
@@ -64,6 +64,34 @@ drake_build <- function(
   build_and_store(target = target, config = config)
 }
 
+build_check_store <- function(
+  target, config, downstream = NULL, announce = TRUE, flag_attempt = FALSE
+){
+  meta <- drake_meta(target = target, config = config)
+  if (!should_build_target(
+    target = target,
+    meta = meta,
+    config = config
+  )){
+    return()
+  }
+  meta$start <- proc.time()
+  prune_envir(
+    targets = target,
+    config = config,
+    downstream = downstream
+  )
+  value <- build_and_store(target = target, meta = meta, config = config)
+  if (target %in% config$plan$target){
+    if (!is_file(target)){
+      assign(x = target, value = value, envir = config$envir)
+    }
+    if (flag_attempt){
+      set_attempt_flag(config)
+    }
+  }
+}
+
 build_and_store <- function(target, config, meta = NULL, announce = TRUE){
   # The environment should have been pruned by now.
   # For staged parallelism, this was already done in bulk

--- a/R/build.R
+++ b/R/build.R
@@ -82,13 +82,9 @@ build_check_store <- function(
     downstream = downstream
   )
   value <- build_and_store(target = target, meta = meta, config = config)
-  if (target %in% config$plan$target){
-    if (!is_file(target)){
-      assign(x = target, value = value, envir = config$envir)
-    }
-    if (flag_attempt){
-      set_attempt_flag(config)
-    }
+  assign_to_envir(target = target, value = value, config = config)
+  if (flag_attempt && target %in% config$plan$target){
+    set_attempt_flag(config)
   }
 }
 

--- a/R/envir.R
+++ b/R/envir.R
@@ -1,4 +1,16 @@
-assign_to_envir <- function(targets, values, config){
+assign_to_envir <- function(target, value, config){
+  if (
+    identical(config$lazy_load, "eager") &&
+    !is_file(target) &&
+    target %in% config$plan$target
+  ){
+    assign(x = target, value = value, envir = config$envir)
+  }
+  invisible()
+}
+
+# Should go away when staged parallelism goes away.
+assign_to_envir_batch <- function(targets, values, config){
   if (config$lazy_load != "eager"){
     return()
   }
@@ -13,6 +25,7 @@ assign_to_envir <- function(targets, values, config){
   invisible()
 }
 
+# Same.
 assign_to_envir_single <- function(index, targets, values, config){
   target <- targets[index]
   value <- values[[index]]

--- a/R/graph.R
+++ b/R/graph.R
@@ -223,9 +223,11 @@ filter_upstream <- function(targets, graph){
 }
 
 # This function will go away when we get rid of staged parallelism.
+# No point in testing it.
+# nocov start
 exclude_imports_if <- function(config){
   if (!length(config$skip_imports)){
-    config$skip_imports <- FALSE # nocov
+    config$skip_imports <- FALSE
   }
   if (!config$skip_imports){
     return(config)
@@ -240,6 +242,7 @@ exclude_imports_if <- function(config){
   )
   config
 }
+# nocov end
 
 subset_graph <- function(graph, subset){
   if (!length(subset)){

--- a/R/lapply.R
+++ b/R/lapply.R
@@ -1,14 +1,9 @@
 run_lapply <- function(config){
-  run_staged_parallelism(config = config, worker = worker_lapply)
-}
-
-worker_lapply <- function(targets, meta_list, config){
-  prune_envir(targets = targets, config = config)
-  values <- lapply(
-    X = targets,
-    FUN = drake_build_worker,
-    meta_list = meta_list,
-    config = config
+  lapply(
+    X = igraph::topo_sort(config$schedule)$name,
+    FUN = build_check_store,
+    config = config,
+    flag_attempt = TRUE
   )
-  assign_to_envir(targets = targets, values = values, config = config)
+  invisible()
 }

--- a/R/make.R
+++ b/R/make.R
@@ -223,6 +223,10 @@ make_session <- function(config){
     cache = config$cache,
     jobs = config$jobs
   )
+  remove(
+    list = intersect(config$plan$target, ls(envir = config$envir)),
+    envir = config$envir
+  )
   return(invisible(config))
 }
 

--- a/R/mclapply.R
+++ b/R/mclapply.R
@@ -1,5 +1,4 @@
 run_mclapply <- function(config){
-  do_prework(config = config, verbose_packages = FALSE)
   config$jobs <- safe_jobs(config$jobs)
   if (config$jobs < 2) {
     return(run_lapply(config = config))
@@ -54,23 +53,11 @@ mc_worker <- function(worker, config){
       break
     }
     target <- mc_get_target(worker = worker, config = config)
-    meta <- drake_meta(target = target, config = config)
-    if (!should_build_target(
+    build_check_store(
       target = target,
-      meta = meta,
-      config = config
-    )){
-      mc_set_idle(worker = worker, config = config)
-      next
-    }
-    meta$start <- proc.time()
-    prune_envir(
-      targets = target,
       config = config,
       downstream = config$cache$list(namespace = "protect")
     )
-    value <- build_and_store(target = target, meta = meta, config = config)
-    assign(x = target, value = value, envir = config$envir)
     mc_set_idle(worker = worker, config = config)
   }
 }

--- a/R/mclapply.R
+++ b/R/mclapply.R
@@ -31,9 +31,12 @@ mc_master <- function(config){
     for (worker in config$workers){
       if (mc_is_idle(worker = worker, config = config)){
         mc_conclude_worker(worker = worker, config = config)
+        if (!config$queue$size()){
+          mc_set_done(worker = worker, config = config)
+          next
+        }
         target <- config$queue$pop0(what = "names")
         if (!length(target)){
-          mc_set_done(worker = worker, config = config)
           next
         }
         mc_set_target(worker = worker, target = target, config = config)
@@ -210,5 +213,5 @@ worker_mclapply <- function(targets, meta_list, config){
     config = config,
     mc.cores = jobs
   )
-  assign_to_envir(targets = targets, values = values, config = config)
+  assign_to_envir_batch(targets = targets, values = values, config = config)
 }

--- a/R/mclapply.R
+++ b/R/mclapply.R
@@ -95,13 +95,14 @@ mc_conclude_worker <- function(worker, config){
     reverse = TRUE
   ) %>%
     intersect(y = config$queue$list(what = "names"))
+  config$queue$decrease_key(names = revdeps)
   flag_attempt <- !get_attempt_flag(config) &&
     get_progress_single(target = target, cache = config$cache) == "finished" &&
     target %in% config$plan$target
   if (flag_attempt){
     set_attempt_flag(config)
   }
-  config$queue$decrease_key(names = revdeps)
+  mc_set_target(worker = worker, target = NA, config = config)
 }
 
 mc_work_remains <- function(config){

--- a/R/parLapply.R
+++ b/R/parLapply.R
@@ -47,7 +47,7 @@ prune_envir_parLapply <- function(targets = targets, config = config) { # nolint
 
 assign_to_envir_parLapply <- # nolint
   function(targets, values, config) {
-  assign_to_envir(targets = targets, values = values, config = config)
+  assign_to_envir_batch(targets = targets, values = values, config = config)
   if (identical(config$envir, globalenv()))
     clusterCall(cl = config$cluster, fun = assign_to_envir,
       targets = targets, values = values, config = config)

--- a/tests/testthat/test-lazy-load.R
+++ b/tests/testthat/test-lazy-load.R
@@ -32,38 +32,6 @@ test_with_dir("no overt errors lazy load for the debug example", {
   expect_equal(outdated(config), character(0))
 })
 
-test_with_dir("lazy loading is actually lazy", {
-  lazily_loaded <- c("nextone", "yourinput")
-  eagerly_loaded <- "combined"
-  config <- dbug()
-  unload_these <- c(lazily_loaded, eagerly_loaded) %>%
-    intersect(y = ls(envir = config$envir))
-  remove(list = unload_these, envir = config$envir)
-  config <- make(
-    lazy_load = TRUE,
-    plan = config$plan,
-    targets = "combined",
-    envir = config$envir,
-    verbose = FALSE,
-    session_info = FALSE
-  )
-  loaded <- ls(envir = config$envir)
-  expect_true(all(lazily_loaded %in% loaded))
-  expect_false(any(eagerly_loaded %in% loaded))
-  clean()
-  config <- make(
-    lazy_load = FALSE,
-    plan = config$plan,
-    targets = "combined",
-    envir = config$envir,
-    verbose = FALSE,
-    session_info = FALSE
-  )
-  loaded <- ls(envir = config$envir)
-  expect_true(all(lazily_loaded %in% loaded))
-  expect_true(all(eagerly_loaded %in% loaded))
-})
-
 test_with_dir("active bindings", {
   config <- dbug()
   if (identical(globalenv(), config$envir)){

--- a/tests/testthat/test-lazy-load.R
+++ b/tests/testthat/test-lazy-load.R
@@ -32,6 +32,28 @@ test_with_dir("no overt errors lazy load for the debug example", {
   expect_equal(outdated(config), character(0))
 })
 
+test_with_dir("lazy loading is actually lazy", {
+  lazily_loaded <- c("nextone", "yourinput")
+  eagerly_loaded <- "combined"
+  config <- dbug()
+  unload_these <- c(lazily_loaded, eagerly_loaded) %>%
+    intersect(y = ls(envir = config$envir))
+  remove(list = unload_these, envir = config$envir)
+  config <- drake_config(
+    lazy_load = TRUE,
+    plan = config$plan,
+    targets = "combined",
+    envir = config$envir,
+    verbose = FALSE,
+    session_info = FALSE
+  )
+  config$schedule <- config$graph
+  run_lapply(config)
+  loaded <- ls(envir = config$envir)
+  expect_true(all(lazily_loaded %in% loaded))
+  expect_false(any(eagerly_loaded %in% loaded))
+})
+
 test_with_dir("active bindings", {
   config <- dbug()
   if (identical(globalenv(), config$envir)){

--- a/tests/testthat/test-other-features.R
+++ b/tests/testthat/test-other-features.R
@@ -48,16 +48,11 @@ test_with_dir("drake_build works as expected", {
   x <- cached()
   expect_equal(x, "a")
   o <- make(pl, envir = e)
-  expect_true("a" %in% ls(envir = e))
   expect_equal(justbuilt(o), "b")
-  remove(list = "a", envir = e)
-  expect_false("a" %in% ls(envir = e))
 
   # Can run without config
   o <- drake_build(b, envir = e)
-  expect_equal(o, e$b)
   expect_equal(o, readd(b))
-  expect_true("a" %in% ls(envir = e))
 
   # Replacing deps in environment
   expect_equal(e$a, 1)
@@ -73,6 +68,7 @@ test_with_dir("drake_build works as expected", {
   expect_equal(e$a, 1)
 
   # `replace` in loadd()
+  e$b <- 1
   expect_equal(e$b, 1)
   e$b <- 5
   loadd(b, envir = e, replace = FALSE)


### PR DESCRIPTION
# Summary

Previously, `make(jobs = 1)` gave the appearance of checking parallel stages. Now, the code (`run_lapply()`) conceptually matches what is actually happening. Also, there is a new `build_check_store()` function that will likely be shared over most of the backends before I am through with #369.

This PR also fixes some bugs in #370.

# GitHub issues addressed

- Ref: #369 (not done yet)

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
