### PR TITLE
Avoid hanging processes in the lapply-like backends

### DIFF
--- a/R/handlers.R
+++ b/R/handlers.R
@@ -33,10 +33,6 @@ handle_build_exceptions <- function(target, meta, config){
   }
 }
 
-try_message <- function(code){
-  tryCatch(code, error = error_message)
-}
-
 error_character0 <- function(e){
   character(0)
 }

--- a/R/handlers.R
+++ b/R/handlers.R
@@ -53,10 +53,6 @@ error_null <- function(e){
   NULL
 }
 
-error_message <- function(e){
-  message("Error: ", e$message) # nocov
-}
-
 error_tibble_times <- function(e){
   stop(
     "Failed converting a data frame of times to a tibble. ",

--- a/tests/testthat/test-migrate.R
+++ b/tests/testthat/test-migrate.R
@@ -56,7 +56,7 @@ test_with_dir("migrate_drake_project() a partially outdated cache", {
   plan <- cache$get("plan", namespace = "config")
   plan$command[plan$target == "small"] <- "simulate(6)"
   cache$set(key = "plan", value = plan, namespace = "config")
-  expect_true(migrate_drake_project(path = "old", jobs = 1))
+  expect_true(suppressWarnings(migrate_drake_project(path = "old", jobs = 2)))
   out <- c("\"report.md\"", plan$target[grep("small", plan$target)])
   config <- load_mtcars_example(cache = cache)
   out2 <- outdated(config = config)


### PR DESCRIPTION
# Summary

Previously, there were problems with hanging processes in the `mclapply` and `parLapply` backends when one of the processes exited in error. In this PR, I use `on.exit()` to enforce the following.

1. If the master dies, all the workers die.
2. If all the workers die, the master dies.

Also, the error log of the process is cached in the `"mc_fail"` `storr` namespace. For example, retrieve with `config$cache$get("2", namespace = "mc_fail")` for worker 2 and `config$cache$get("0", namespace = "mc_fail")` for master. I haven't wrote a friendly API function to retrieve these types of errors, and I currently do not have plans for one. This error caching is mostly just to help me and the contributors debug. Will revisit if these errors come up a lot, but I am expecting most errors to be related to targets once #369 is solved, and there is already error handling for that.

Currently affects `mclapply` and `parLapply` parallelism, and will affect `future_lapply` parallelism going forward (hopefully soon).

# GitHub issues addressed

- Ref: #369 (not done yet)

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
