### PR TITLE
Do not wait for the imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,10 @@ r_packages:
 script:
   - |
     R CMD build .
-    travis_wait 20 R CMD check drake*tar.gz --no-tests
-    travis_wait 20 Rscript -e 'covr::codecov()'
+    travis_wait 20 R CMD check drake*tar.gz
 
 after_success:
+  - Rscript -e 'covr::codecov()'
   - Rscript -e 'lintr::lint_package()'
 
 after_failure:

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 - Remove the appearance of staged parallelism from single-job `make()`'s.
 - Calls to `make()` no longer leave targets in the user's environment.
 - Attempt to fix a Solaris CRAN check error. The test at https://github.com/ropensci/drake/blob/b4dbddb840d2549621b76bcaa46c344b0fd2eccc/tests/testthat/test-edge-cases.R#L3 was previously failing on CRAN's Solaris machine (R 3.5.0). In the test, one of the threads deliberately quits in error, and the R/Solaris installation did not handle this properly. The test should work now because it no longer uses any parallelism.
+- Deprecate the `imports_only` argument to `make()` and `drake_config()` in favor of `skip_targets`.
 - Add an `upstream_only` argument to `failed()` so users can list failed targets that do not have any failed dependencies. Naturally accompanies `make(keep_going = TRUE)`.
 - Add an RStudio R Markdown template compatible with https://krlmlr.github.io/drake-pitch/.
 - Remove `plyr` as a dependency.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # Version 5.1.4
 
 - Remove staged parallelism from all the `lapply()`-like backends (`parallelism =` `"mclapply"`, `"parLapply"`, and `"future_lapply"`). Now, `drake` uses persistent workers and a master process. In the case of `"future_lapply"` parallelism, the master process is a separate `callr::r_bg()` process.
-- Remove the appearance of staged parallelism from single-job `make()`'s.
+- Remove the appearance of staged parallelism from single-job `make()`'s. (Previously, there were "check" messages and a call to `staged_parallelism()`.)
 - Calls to `make()` no longer leave targets in the user's environment.
 - Attempt to fix a Solaris CRAN check error. The test at https://github.com/ropensci/drake/blob/b4dbddb840d2549621b76bcaa46c344b0fd2eccc/tests/testthat/test-edge-cases.R#L3 was previously failing on CRAN's Solaris machine (R 3.5.0). In the test, one of the threads deliberately quits in error, and the R/Solaris installation did not handle this properly. The test should work now because it no longer uses any parallelism.
 - Deprecate the `imports_only` argument to `make()` and `drake_config()` in favor of `skip_targets`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 - Calls to `make()` no longer leave targets in the user's environment.
 - Attempt to fix a Solaris CRAN check error. The test at https://github.com/ropensci/drake/blob/b4dbddb840d2549621b76bcaa46c344b0fd2eccc/tests/testthat/test-edge-cases.R#L3 was previously failing on CRAN's Solaris machine (R 3.5.0). In the test, one of the threads deliberately quits in error, and the R/Solaris installation did not handle this properly. The test should work now because it no longer uses any parallelism.
 - Deprecate the `imports_only` argument to `make()` and `drake_config()` in favor of `skip_targets`.
+- For non-distributed parallel backends, stop waiting for all the imports to finish before the targets begin.
 - Add an `upstream_only` argument to `failed()` so users can list failed targets that do not have any failed dependencies. Naturally accompanies `make(keep_going = TRUE)`.
 - Add an RStudio R Markdown template compatible with https://krlmlr.github.io/drake-pitch/.
 - Remove `plyr` as a dependency.

--- a/R/config.R
+++ b/R/config.R
@@ -75,7 +75,7 @@
 #'   For example, \code{function(code){force(code)}} is a good hook
 #'   and \code{function(code){message("Avoiding the code")}} is a bad hook.
 #'
-#' @param imports_only logical, whether to skip building the targets
+#' @param skip_targets logical, whether to skip building the targets
 #'   in `plan` and just import objects and files.
 #'
 #' @param parallelism character, type of parallelism to use.
@@ -366,7 +366,7 @@ drake_config <- function(
   log_progress = FALSE,
   graph = NULL,
   trigger = drake::default_trigger(),
-  imports_only = FALSE,
+  skip_targets = FALSE,
   skip_imports = FALSE,
   skip_safety_checks = FALSE,
   lazy_load = "eager",
@@ -375,9 +375,16 @@ drake_config <- function(
   seed = NULL,
   caching = c("worker", "master"),
   keep_going = FALSE,
-  session = NULL
+  session = NULL,
+  imports_only = NULL
 ){
   force(envir)
+  if (!is.null(imports_only)){
+    warning(
+      "Argument imports_only is deprecated. Use skip_targets instead.",
+      call. = FALSE
+    ) # May 4, 2018
+  }
   plan <- sanitize_plan(plan)
   targets <- sanitize_targets(plan, targets)
   parallelism <- match.arg(
@@ -422,7 +429,7 @@ drake_config <- function(
     long_hash_algo = cache$get("long_hash_algo", namespace = "config"),
     seed = seed, trigger = trigger,
     timeout = timeout, cpu = cpu, elapsed = elapsed, retries = retries,
-    imports_only = imports_only, skip_imports = skip_imports,
+    skip_targets = skip_targets, skip_imports = skip_imports,
     skip_safety_checks = skip_safety_checks, log_progress = log_progress,
     lazy_load = lazy_load, session_info = session_info,
     cache_log_file = cache_log_file, caching = match.arg(caching),

--- a/R/config.R
+++ b/R/config.R
@@ -78,6 +78,8 @@
 #' @param skip_targets logical, whether to skip building the targets
 #'   in `plan` and just import objects and files.
 #'
+#' @param imports_only deprecated. Use `skip_targets` instead.
+#'
 #' @param parallelism character, type of parallelism to use.
 #'   To list the options, call [parallelism_choices()].
 #'   For detailed explanations, see \code{?\link{parallelism_choices}},

--- a/R/distributed.R
+++ b/R/distributed.R
@@ -44,6 +44,7 @@ finish_distributed <- function(config){
 build_distributed <- function(target, meta_list, cache_path){
   config <- recover_drake_config(cache_path = cache_path)
   config$hook({
+    eval(parse(text = "base::require(drake, quietly = TRUE)"))
     do_prework(config = config, verbose_packages = FALSE)
     prune_envir(targets = target, config = config)
   })

--- a/R/make.R
+++ b/R/make.R
@@ -221,7 +221,9 @@ make_session <- function(config){
     make_targets(config = config)
   } else if (config$skip_targets){
     make_imports(config = config)
-  } else if (parallelism %in% parallelism_choices(distributed = TRUE)){
+  } else if (
+    config$parallelism %in% parallelism_choices(distributed_only = TRUE)
+  ){
     make_imports(config = config)
     make_targets(config = config)
   } else {

--- a/R/make.R
+++ b/R/make.R
@@ -89,7 +89,7 @@ make <- function(
   ),
   recipe_command = drake::default_recipe_command(),
   log_progress = TRUE,
-  imports_only = FALSE,
+  skip_targets = FALSE,
   timeout = Inf,
   cpu = NULL,
   elapsed = NULL,
@@ -107,7 +107,8 @@ make <- function(
   seed = NULL,
   caching = "worker",
   keep_going = FALSE,
-  session = NULL
+  session = NULL,
+  imports_only = NULL
 ){
   force(envir)
   if (!is.null(return_config)){
@@ -143,7 +144,7 @@ make <- function(
       force = force,
       graph = graph,
       trigger = trigger,
-      imports_only = imports_only,
+      skip_targets = skip_targets,
       skip_imports = skip_imports,
       skip_safety_checks = skip_safety_checks,
       lazy_load = lazy_load,
@@ -151,7 +152,8 @@ make <- function(
       cache_log_file = cache_log_file,
       caching = caching,
       keep_going = keep_going,
-      session = session
+      session = session,
+      imports_only = imports_only
     )
   }
   make_with_config(config = config)
@@ -215,7 +217,7 @@ make_session <- function(config){
   if (!config$skip_imports){
     make_imports(config = config)
   }
-  if (!config$imports_only){
+  if (!config$skip_targets){
     make_targets(config = config)
   }
   drake_cache_log_file(

--- a/docs/articles/debug.html
+++ b/docs/articles/debug.html
@@ -136,7 +136,7 @@ config &lt;-<span class="st"> </span><span class="kw"><a href="../reference/drak
 ##  [4] "cache_path"         "caching"            "command"           
 ##  [7] "cpu"                "elapsed"            "envir"             
 ## [10] "evaluator"          "fetch_cache"        "graph"             
-## [13] "hook"               "imports_only"       "jobs"              
+## [13] "hook"               "skip_targets"       "jobs"              
 ## [16] "keep_going"         "lazy_load"          "log_progress"      
 ## [19] "long_hash_algo"     "parallelism"        "plan"              
 ## [22] "prepend"            "prework"            "recipe_command"    

--- a/docs/reference/drake_config.html
+++ b/docs/reference/drake_config.html
@@ -183,7 +183,7 @@ and it could lead to false negative results from
   <span class='kw'>recipe_command</span> <span class='kw'>=</span> <span class='kw pkg'>drake</span><span class='kw ns'>::</span><span class='fu'><a href='http://www.rdocumentation.org/packages/drake/topics/default_recipe_command'>default_recipe_command</a></span>(), <span class='kw'>timeout</span> <span class='kw'>=</span> <span class='fl'>Inf</span>,
   <span class='kw'>cpu</span> <span class='kw'>=</span> <span class='no'>timeout</span>, <span class='kw'>elapsed</span> <span class='kw'>=</span> <span class='no'>timeout</span>, <span class='kw'>retries</span> <span class='kw'>=</span> <span class='fl'>0</span>, <span class='kw'>force</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>,
   <span class='kw'>log_progress</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>, <span class='kw'>graph</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>trigger</span> <span class='kw'>=</span> <span class='kw pkg'>drake</span><span class='kw ns'>::</span><span class='fu'><a href='http://www.rdocumentation.org/packages/drake/topics/default_trigger'>default_trigger</a></span>(),
-  <span class='kw'>imports_only</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>, <span class='kw'>skip_imports</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>, <span class='kw'>skip_safety_checks</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>,
+  <span class='kw'>skip_targets</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>, <span class='kw'>skip_imports</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>, <span class='kw'>skip_safety_checks</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>,
   <span class='kw'>lazy_load</span> <span class='kw'>=</span> <span class='st'>"eager"</span>, <span class='kw'>session_info</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>, <span class='kw'>cache_log_file</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
   <span class='kw'>seed</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>caching</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"worker"</span>, <span class='st'>"master"</span>), <span class='kw'>keep_going</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>,
   <span class='kw'>session</span> <span class='kw'>=</span> <span class='kw'>NULL</span>)</pre>
@@ -448,7 +448,7 @@ Must be in <code><a href='triggers.html'>triggers()</a></code>.
 See <a href='triggers.html'>triggers</a> for explanations of the choices.</p></td>
     </tr>
     <tr>
-      <th>imports_only</th>
+      <th>skip_targets</th>
       <td><p>logical, whether to skip building the targets
 in <code>plan</code> and just import objects and files.</p></td>
     </tr>

--- a/docs/reference/make.html
+++ b/docs/reference/make.html
@@ -161,7 +161,7 @@ for an overview of the documentation.</p>
   <span class='kw'>prepend</span> <span class='kw'>=</span> <span class='fu'>character</span>(<span class='fl'>0</span>), <span class='kw'>command</span> <span class='kw'>=</span> <span class='kw pkg'>drake</span><span class='kw ns'>::</span><span class='fu'><a href='http://www.rdocumentation.org/packages/drake/topics/default_Makefile_command'>default_Makefile_command</a></span>(),
   <span class='kw'>args</span> <span class='kw'>=</span> <span class='kw pkg'>drake</span><span class='kw ns'>::</span><span class='fu'><a href='http://www.rdocumentation.org/packages/drake/topics/default_Makefile_args'>default_Makefile_args</a></span>(<span class='kw'>jobs</span> <span class='kw'>=</span> <span class='no'>jobs</span>, <span class='kw'>verbose</span> <span class='kw'>=</span> <span class='no'>verbose</span>),
   <span class='kw'>recipe_command</span> <span class='kw'>=</span> <span class='kw pkg'>drake</span><span class='kw ns'>::</span><span class='fu'><a href='http://www.rdocumentation.org/packages/drake/topics/default_recipe_command'>default_recipe_command</a></span>(), <span class='kw'>log_progress</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>,
-  <span class='kw'>imports_only</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>, <span class='kw'>timeout</span> <span class='kw'>=</span> <span class='fl'>Inf</span>, <span class='kw'>cpu</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>elapsed</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
+  <span class='kw'>skip_targets</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>, <span class='kw'>timeout</span> <span class='kw'>=</span> <span class='fl'>Inf</span>, <span class='kw'>cpu</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>elapsed</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
   <span class='kw'>retries</span> <span class='kw'>=</span> <span class='fl'>0</span>, <span class='kw'>force</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>, <span class='kw'>return_config</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>graph</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
   <span class='kw'>trigger</span> <span class='kw'>=</span> <span class='kw pkg'>drake</span><span class='kw ns'>::</span><span class='fu'><a href='http://www.rdocumentation.org/packages/drake/topics/default_trigger'>default_trigger</a></span>(), <span class='kw'>skip_imports</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>,
   <span class='kw'>skip_safety_checks</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>, <span class='kw'>config</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>lazy_load</span> <span class='kw'>=</span> <span class='st'>"eager"</span>,
@@ -380,7 +380,7 @@ and speed with
 will no longer work if you do that.</p></td>
     </tr>
     <tr>
-      <th>imports_only</th>
+      <th>skip_targets</th>
       <td><p>logical, whether to skip building the targets
 in <code>plan</code> and just import objects and files.</p></td>
     </tr>

--- a/man/drake_config.Rd
+++ b/man/drake_config.Rd
@@ -326,6 +326,8 @@ If \code{session} is \code{NULL} (default), then \code{\link[=make]{make()}} wil
 your current R session as the master session. This is slightly faster,
 but it causes \code{\link[=make]{make()}} to populate your workspace/environment
 with the last few targets it builds.}
+
+\item{imports_only}{deprecated. Use \code{skip_targets} instead.}
 }
 \value{
 The master internal configuration list of a project.

--- a/man/drake_config.Rd
+++ b/man/drake_config.Rd
@@ -16,7 +16,7 @@ drake_config(plan = read_drake_plan(),
   recipe_command = drake::default_recipe_command(), timeout = Inf,
   cpu = timeout, elapsed = timeout, retries = 0, force = FALSE,
   log_progress = FALSE, graph = NULL, trigger = drake::default_trigger(),
-  imports_only = FALSE, skip_imports = FALSE, skip_safety_checks = FALSE,
+  skip_targets = FALSE, skip_imports = FALSE, skip_safety_checks = FALSE,
   lazy_load = "eager", session_info = TRUE, cache_log_file = NULL,
   seed = NULL, caching = c("worker", "master"), keep_going = FALSE,
   session = NULL)
@@ -236,7 +236,7 @@ Ignored if \code{plan} has a \code{trigger} column.
 Must be in \code{\link[=triggers]{triggers()}}.
 See \link{triggers} for explanations of the choices.}
 
-\item{imports_only}{logical, whether to skip building the targets
+\item{skip_targets}{logical, whether to skip building the targets
 in \code{plan} and just import objects and files.}
 
 \item{skip_imports}{logical, whether to totally neglect to

--- a/man/drake_config.Rd
+++ b/man/drake_config.Rd
@@ -19,7 +19,7 @@ drake_config(plan = read_drake_plan(),
   skip_targets = FALSE, skip_imports = FALSE, skip_safety_checks = FALSE,
   lazy_load = "eager", session_info = TRUE, cache_log_file = NULL,
   seed = NULL, caching = c("worker", "master"), keep_going = FALSE,
-  session = NULL)
+  session = NULL, imports_only = NULL)
 }
 \arguments{
 \item{plan}{workflow plan data frame.

--- a/man/make.Rd
+++ b/man/make.Rd
@@ -17,7 +17,8 @@ make(plan = read_drake_plan(), targets = drake::possible_targets(plan),
   trigger = drake::default_trigger(), skip_imports = FALSE,
   skip_safety_checks = FALSE, config = NULL, lazy_load = "eager",
   session_info = TRUE, cache_log_file = NULL, seed = NULL,
-  caching = "worker", keep_going = FALSE, session = NULL)
+  caching = "worker", keep_going = FALSE, session = NULL,
+  imports_only = NULL)
 }
 \arguments{
 \item{plan}{workflow plan data frame.

--- a/man/make.Rd
+++ b/man/make.Rd
@@ -12,7 +12,7 @@ make(plan = read_drake_plan(), targets = drake::possible_targets(plan),
   prepend = character(0), command = drake::default_Makefile_command(),
   args = drake::default_Makefile_args(jobs = jobs, verbose = verbose),
   recipe_command = drake::default_recipe_command(), log_progress = TRUE,
-  imports_only = FALSE, timeout = Inf, cpu = NULL, elapsed = NULL,
+  skip_targets = FALSE, timeout = Inf, cpu = NULL, elapsed = NULL,
   retries = 0, force = FALSE, return_config = NULL, graph = NULL,
   trigger = drake::default_trigger(), skip_imports = FALSE,
   skip_safety_checks = FALSE, config = NULL, lazy_load = "eager",
@@ -200,7 +200,7 @@ and speed with
 \code{\link[=progress]{progress()}} and \code{\link[=in_progress]{in_progress()}}
 will no longer work if you do that.}
 
-\item{imports_only}{logical, whether to skip building the targets
+\item{skip_targets}{logical, whether to skip building the targets
 in \code{plan} and just import objects and files.}
 
 \item{timeout}{Seconds of overall time to allow before imposing

--- a/man/make.Rd
+++ b/man/make.Rd
@@ -333,6 +333,8 @@ If \code{session} is \code{NULL} (default), then \code{\link[=make]{make()}} wil
 your current R session as the master session. This is slightly faster,
 but it causes \code{\link[=make]{make()}} to populate your workspace/environment
 with the last few targets it builds.}
+
+\item{imports_only}{deprecated. Use \code{skip_targets} instead.}
 }
 \value{
 The master internal configuration list, mostly

--- a/tests/testthat/test-deprecate.R
+++ b/tests/testthat/test-deprecate.R
@@ -116,7 +116,13 @@ test_with_dir("deprecate misc utilities", {
 
 test_with_dir("deprecated arguments", {
   pl <- drake_plan(a = 1, b = a)
-  con <- drake_config(plan = pl, session_info = FALSE)
+  expect_warning(
+    con <- drake_config(
+      plan = pl,
+      session_info = FALSE,
+      imports_only = FALSE
+    )
+  )
   expect_warning(drake_build(a, config = con, meta = list()))
 })
 

--- a/tests/testthat/test-edge-cases.R
+++ b/tests/testthat/test-edge-cases.R
@@ -1,5 +1,19 @@
 drake_context("edge cases")
 
+test_with_dir("skip everything", {
+  f <- function(x){
+    x
+  }
+  pl <- drake_plan(a = f(0))
+  con <- make(
+    pl,
+    session_info = FALSE,
+    skip_targets = TRUE,
+    skip_imports = TRUE
+  )
+  expect_equal(justbuilt(con), character(0))
+})
+
 test_with_dir("can keep going", {
   scenario <- get_testing_scenario()
   e <- eval(parse(text = scenario$envir))

--- a/tests/testthat/test-future.R
+++ b/tests/testthat/test-future.R
@@ -9,18 +9,14 @@ test_with_dir("future package functionality", {
   caching <- c(rep("worker", 2), "master")
   for (i in 1:3){
     clean(destroy = TRUE)
-    withr::with_options(
-      new = list(mc.cores = 2), code = {
-        config <- make(
-          e$my_plan,
-          envir = e,
-          parallelism = backends[i],
-          caching = caching[i],
-          jobs = 1,
-          verbose = FALSE,
-          session_info = FALSE
-        )
-      }
+    config <- make(
+      e$my_plan,
+      envir = e,
+      parallelism = backends[i],
+      caching = caching[i],
+      jobs = 1,
+      verbose = FALSE,
+      session_info = FALSE
     )
     expect_equal(
       outdated(config),

--- a/tests/testthat/test-other-features.R
+++ b/tests/testthat/test-other-features.R
@@ -103,8 +103,8 @@ test_with_dir("shapes", {
   expect_equal(color_of("bluhlaksjdf"), color_of("other"))
 })
 
-test_with_dir("make() with imports_only", {
-  expect_silent(make(drake_plan(x = 1), imports_only = TRUE,
+test_with_dir("make() with skip_targets", {
+  expect_silent(make(drake_plan(x = 1), skip_targets = TRUE,
     verbose = FALSE, session_info = FALSE))
   expect_false(cached(x))
 })


### PR DESCRIPTION
# Summary

In this PR, for the non-distributed parallel backends, `make()` no longer waits for the imports to finish before starting the targets. This marks an official end to staged parallelism. There is still some cleanup/aftermath to deal with, but we have passed the crux.

# GitHub issues addressed

- Ref: #369 (not done yet)

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
