### PR TITLE
Trivial: add space in warning message

### DIFF
--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -355,7 +355,7 @@ safe_find_globals <- function(expr){
     find_globals(expr),
     error = function(e){
       warning(
-        "could not resolve implicit dependencies of code:",
+        "could not resolve implicit dependencies of code: ",
         head(deparse(expr)),
         call. = FALSE
       )


### PR DESCRIPTION
Not sure if this should be an `\n` instead.