### PR TITLE
Allow different parallelism arguments for targets vs imports

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 - Remove the appearance of staged parallelism from single-job `make()`'s.
 (Previously, there were "check" messages and a call to `staged_parallelism()`.)
 - Remove all remnants of staged parallelism internals.
+- Allow different parallel backends for imports vs targets. For example, `make(parallelism = c(imports = "mclapply_staged", targets = "mclapply")`.
 - Fix a bug in environment pruning. Previously, dependencies of downstream targets were being dropped from memory in `make(jobs = 1)`. Now, they are kept in memory until no downstream target needs them (for `make(jobs = 1)`).
 - Improve `predict_runtime()`. It is a more sensible way to go about predicting runtimes with multiple jobs. Likely to be more accurate.
 - Calls to `make()` no longer leave targets in the user's environment.

--- a/R/Makefile.R
+++ b/R/Makefile.R
@@ -143,7 +143,7 @@ mk <- function(
 #' default_Makefile_args(jobs = 2, verbose = FALSE)
 #' default_Makefile_args(jobs = 4, verbose = TRUE)
 default_Makefile_args <- function(jobs, verbose){
-  out <- paste0("--jobs=", jobs_targets(jobs))
+  out <- paste0("--jobs=", targets_setting(jobs))
   if (verbose < 1){
     out <- c(out, "--silent")
   }

--- a/R/check.R
+++ b/R/check.R
@@ -129,3 +129,21 @@ check_jobs <- function(jobs){
     }
   }
 }
+
+check_parallelism <- function(parallelism){
+  stopifnot(length(parallelism) > 0)
+  stopifnot(is.character(parallelism))
+  if (length(parallelism) > 1){
+    if (
+      is.null(names(parallelism)) ||
+      !identical(sort(names(parallelism)), sort(c("imports", "targets")))
+    ){
+      stop(
+        "In the `parallelism` argument, you must either give a character scalar ",
+        "or a named character vector with names 'imports' and 'targets'.",
+        call. = FALSE
+      )
+    }
+  }
+}
+

--- a/R/check.R
+++ b/R/check.R
@@ -139,11 +139,11 @@ check_parallelism <- function(parallelism){
       !identical(sort(names(parallelism)), sort(c("imports", "targets")))
     ){
       stop(
-        "In the `parallelism` argument, you must either give a character scalar ",
-        "or a named character vector with names 'imports' and 'targets'.",
+        "In the `parallelism` argument, you must either ",
+        "give a character scalar or a named character vector ",
+        "with names 'imports' and 'targets'.",
         call. = FALSE
       )
     }
   }
 }
-

--- a/R/config.R
+++ b/R/config.R
@@ -388,10 +388,8 @@ drake_config <- function(
   }
   plan <- sanitize_plan(plan)
   targets <- sanitize_targets(plan, targets)
-  parallelism <- match.arg(
-    parallelism,
-    choices = parallelism_choices(distributed_only = FALSE)
-  )
+  parallelism <- parse_parallelism(parallelism)
+  jobs <- parse_jobs(jobs)
   prework <- add_packages_to_prework(
     packages = packages,
     prework = prework
@@ -533,4 +531,32 @@ store_drake_config <- function(config) {
     jobs = config$jobs
   )
   invisible()
+}
+
+parse_jobs <- function(jobs){
+  check_jobs(jobs)
+  if (length(jobs) < 2){
+    c(imports = jobs, targets = jobs)
+  } else {
+    jobs
+  }
+}
+
+parse_parallelism <- function(parallelism){
+  check_parallelism(parallelism)
+  for(i in seq_along(parallelism)){
+    parallelism[i] <- match.arg(
+      arg = parallelism[i],
+      choices = parallelism_choices(distributed_only = FALSE)
+    )
+  }
+  if (length(parallelism) < 2){
+    if (parallelism %in% parallelism_choices(distributed_only = TRUE)){
+      c(imports = default_parallelism(), targets = parallelism)
+    } else {
+      c(imports = parallelism, targets = parallelism)
+    }
+  } else {
+    parallelism
+  }
 }

--- a/R/config.R
+++ b/R/config.R
@@ -544,7 +544,7 @@ parse_jobs <- function(jobs){
 
 parse_parallelism <- function(parallelism){
   check_parallelism(parallelism)
-  for(i in seq_along(parallelism)){
+  for (i in seq_along(parallelism)){
     parallelism[i] <- match.arg(
       arg = parallelism[i],
       choices = parallelism_choices(distributed_only = FALSE)

--- a/R/future_lapply.R
+++ b/R/future_lapply.R
@@ -1,6 +1,5 @@
 run_future_lapply <- function(config){
   prepare_distributed(config = config)
-  config$workers <- as.character(seq_len(config$jobs))
   mc_init_worker_cache(config)
   console_persistent_workers(config)
   path <- normalizePath(config$cache_path, winslash = "/")
@@ -28,7 +27,6 @@ run_future_lapply <- function(config){
 #' # No examples here. This function is not for end users.
 fl_master <- function(cache_path){
   config <- recover_drake_config(cache_path)
-  config$workers <- as.character(seq_len(config$jobs))
   drake::mc_process(id = "0", config = config)
 }
 

--- a/R/future_lapply.R
+++ b/R/future_lapply.R
@@ -3,8 +3,13 @@ run_future_lapply <- function(config){
   mc_init_worker_cache(config)
   console_persistent_workers(config)
   path <- normalizePath(config$cache_path, winslash = "/")
-  tmp <- system2(
+  rscript <- grep(
     "Rscript",
+    dir(R.home("bin"), full.names = TRUE),
+    value = TRUE
+  )
+  tmp <- system2(
+    rscript,
     shQuote(c("-e", paste0("drake::fl_master('", path, "')"))),
     wait = FALSE
   )

--- a/R/make.R
+++ b/R/make.R
@@ -235,7 +235,7 @@ make_with_schedules <- function(config){
   } else if (config$skip_imports){
     make_targets(config = config)
   } else if (
-    config$parallelism %in% parallelism_choices(distributed_only = TRUE)
+    length(unique(config$parallelism)) > 1
   ){
     make_imports(config = config)
     make_targets(config = config)
@@ -282,8 +282,8 @@ make_with_schedules <- function(config){
 #' }
 make_imports <- function(config = drake::read_drake_config()){
   config$schedule <- imports_graph(config = config)
-  config$jobs <- jobs_imports(jobs = config$jobs)
-  config$parallelism <- use_default_parallelism(config$parallelism)
+  config$jobs <- imports_setting(config$jobs)
+  config$parallelism <- imports_setting(config$parallelism)
   run_parallel_backend(config = config)
   invisible(config)
 }
@@ -326,7 +326,8 @@ make_imports <- function(config = drake::read_drake_config()){
 #' }
 make_targets <- function(config = drake::read_drake_config()){
   config$schedule <- targets_graph(config = config)
-  config$jobs <- jobs_targets(jobs = config$jobs)
+  config$jobs <- targets_setting(config$jobs)
+  config$parallelism <- targets_setting(config$parallelism)
   run_parallel_backend(config = config)
   console_up_to_date(config = config)
   invisible(config)
@@ -334,6 +335,7 @@ make_targets <- function(config = drake::read_drake_config()){
 
 make_imports_targets <- function(config){
   config$schedule <- config$graph
+  config$parallelism <- config$parallelism[1]
   config$jobs <- max(config$jobs)
   run_parallel_backend(config = config)
   console_up_to_date(config = config)
@@ -342,7 +344,7 @@ make_imports_targets <- function(config){
 
 initialize_session <- function(config){
   if (config$log_progress){
-    clear_progress(cache = config$cache, jobs = jobs_imports(config$jobs))
+    clear_progress(cache = config$cache, jobs = imports_setting(config$jobs))
   }
   config$cache$clear(namespace = "session")
   if (config$session_info){

--- a/R/mclapply.R
+++ b/R/mclapply.R
@@ -247,13 +247,9 @@ warn_mclapply_windows <- function(
   jobs,
   os = this_os()
 ){
-  parallelism <- match.arg(
-    parallelism,
-    choices = parallelism_choices(distributed_only = FALSE)
-  )
   if (
-    identical(parallelism, "mclapply") &&
-    jobs_targets(jobs) > 1 &&
+    "mclapply" %in% parallelism &&
+    targets_setting(jobs) > 1 &&
     identical(os, "windows")
   ){
     warning(

--- a/R/parallel.R
+++ b/R/parallel.R
@@ -78,14 +78,3 @@ parallelism_warnings <- function(config){
     os = this_os()
   )
 }
-
-use_default_parallelism <- function(parallelism){
-  parallelism <- match.arg(
-    parallelism,
-    choices = parallelism_choices(distributed_only = FALSE)
-  )
-  if (parallelism %in% parallelism_choices(distributed_only = TRUE)){
-    parallelism <- default_parallelism()
-  }
-  parallelism
-}

--- a/R/parallel.R
+++ b/R/parallel.R
@@ -1,4 +1,10 @@
 run_parallel_backend <- function(config){
+  config$workers <- as.character(seq_len(config$jobs))
+  config$cache$set(
+    key = "workers",
+    value = config$workers,
+    namespace = "config"
+  )
   get(
     paste0("run_", config$parallelism),
     envir = getNamespace("drake")

--- a/R/parallel.R
+++ b/R/parallel.R
@@ -28,21 +28,21 @@ lightly_parallelize_atomic <- function(X, FUN, jobs = 1, ...){
   values[index]
 }
 
-jobs_imports <- function(jobs){
-  check_jobs(jobs)
-  if (length(jobs) < 2){
-    jobs
+# x is parallelism or jobs
+imports_setting <- function(x){
+  if (length(x) < 2){
+    x
   } else {
-    unname(jobs["imports"])
+    unname(x["imports"])
   }
 }
 
-jobs_targets <- function(jobs){
-  check_jobs(jobs)
-  if (length(jobs) < 2){
-    jobs
+# x is parallelism or jobs
+targets_setting <- function(x){
+  if (length(x) < 2){
+    x
   } else {
-    unname(jobs["targets"])
+    unname(x["targets"])
   }
 }
 
@@ -52,7 +52,7 @@ safe_jobs <- function(jobs){
 }
 
 safe_jobs_imports <- function(jobs){
-  ifelse(on_windows(), 1, jobs_imports(jobs = jobs))
+  ifelse(on_windows(), 1, imports_setting(jobs))
 }
 
 on_windows <- function(){

--- a/tests/testthat/test-lazy-load.R
+++ b/tests/testthat/test-lazy-load.R
@@ -4,7 +4,7 @@ test_with_dir("no overt errors lazy load for the debug example", {
   config <- dbug()
   config$verbose <- FALSE
   config$lazy_load <- TRUE
-  if (config$parallelism == "parLapply"){
+  if ("parLapply" %in% tail(config$parallelism, 1)){
     config$jobs <- 1
   }
   expect_equal(sort(outdated(config)), sort(config$plan$target))

--- a/tests/testthat/test-parallel.R
+++ b/tests/testthat/test-parallel.R
@@ -16,18 +16,14 @@ test_with_dir("check_jobs()", {
   expect_silent(check_jobs(c(imports = 5, targets = 6)))
 })
 
-test_with_dir("jobs_imports()", {
-  expect_equal(jobs_imports(8), 8)
-  expect_error(jobs_imports(c(8, 12)))
-  expect_error(jobs_imports(c(8, 1)))
-  expect_equal(jobs_imports(c(targets = 8, imports = 12)), 12)
-  expect_equal(jobs_imports(c(imports = 8, targets = 12)), 8)
+test_with_dir("imports_setting()", {
+  expect_equal(imports_setting(8), 8)
+  expect_equal(imports_setting(c(targets = 8, imports = 12)), 12)
+  expect_equal(imports_setting(c(imports = 8, targets = 12)), 8)
 })
 
 test_with_dir("targets_setting()", {
   expect_equal(targets_setting(8), 8)
-  expect_error(targets_setting(c(8, 12)))
-  expect_error(targets_setting(c(8, 1)))
   expect_equal(targets_setting(c(targets = 8, imports = 12)), 8)
   expect_equal(targets_setting(c(imports = 8, targets = 12)), 12)
 })

--- a/tests/testthat/test-parallel.R
+++ b/tests/testthat/test-parallel.R
@@ -24,12 +24,12 @@ test_with_dir("jobs_imports()", {
   expect_equal(jobs_imports(c(imports = 8, targets = 12)), 8)
 })
 
-test_with_dir("jobs_targets()", {
-  expect_equal(jobs_targets(8), 8)
-  expect_error(jobs_targets(c(8, 12)))
-  expect_error(jobs_targets(c(8, 1)))
-  expect_equal(jobs_targets(c(targets = 8, imports = 12)), 8)
-  expect_equal(jobs_targets(c(imports = 8, targets = 12)), 12)
+test_with_dir("targets_setting()", {
+  expect_equal(targets_setting(8), 8)
+  expect_error(targets_setting(c(8, 12)))
+  expect_error(targets_setting(c(8, 1)))
+  expect_equal(targets_setting(c(targets = 8, imports = 12)), 8)
+  expect_equal(targets_setting(c(imports = 8, targets = 12)), 12)
 })
 
 test_with_dir("parallelism not found for testrun()", {

--- a/tests/testthat/test-parallel.R
+++ b/tests/testthat/test-parallel.R
@@ -16,6 +16,20 @@ test_with_dir("check_jobs()", {
   expect_silent(check_jobs(c(imports = 5, targets = 6)))
 })
 
+test_with_dir("check_parallelism()", {
+  expect_error(check_parallelism(NULL), regexp = "length")
+  expect_error(check_parallelism(-1), regexp = "character")
+  expect_error(
+    check_parallelism(c(a = "x", targets = "y")), regexp = "character")
+  expect_error(
+    check_parallelism(c("mclapply", "mclapply")), regexp = "with names")
+  expect_silent(check_parallelism("mclapply"))
+  expect_silent(
+    check_parallelism(c(targets = "mclapply", imports = "mclapply")))
+  expect_silent(
+    check_parallelism(c(imports = "parLapply", targets = "future")))
+})
+
 test_with_dir("imports_setting()", {
   expect_equal(imports_setting(8), 8)
   expect_equal(imports_setting(c(targets = 8, imports = 12)), 12)

--- a/tests/testthat/test-triggers.R
+++ b/tests/testthat/test-triggers.R
@@ -109,7 +109,8 @@ test_with_dir("all triggers bring targets up to date", {
 # Similar enough to the triggers to include here:
 test_with_dir("make(..., skip_imports = TRUE) works", {
   con <- dbug()
-  verbose <- con$jobs < 2 & con$parallelism == "parLapply"
+  verbose <- max(con$jobs) < 2 &&
+    targets_setting(con$parallelism) == "parLapply"
   suppressMessages(
     con <- make(
       con$plan, parallelism = con$parallelism,

--- a/vignettes/parallelism.Rmd
+++ b/vignettes/parallelism.Rmd
@@ -52,6 +52,16 @@ There are multiple ways to walk this graph and multiple ways to launch workers, 
 make(my_plan, parallelism = "parLapply", jobs = 2)
 ```
 
+You can use a different backend for the imports than you select for the targets. If you do so, you force all the imports to be processed before any of the targets are built, but you might want to do so anyway. For example, staged scheduling could be great for imports even when it is not be the right choice for the targets (more on that later).
+
+```{r run2differentbackends, eval = FALSE}
+make(
+  my_plan,
+  parallelism = c(imports = "mclapply_staged", targets = "mclapply"),
+  jobs = 2
+)
+```
+
 List your options with `parallelism_choices()`.
 
 ```{r choices}


### PR DESCRIPTION
# Summary

The main use case is something like `make(parallelism = c(imports = "mclapply_staged", targets = "mclapply")`. Imports and targets have different parallelism needs, and staged parallelism is usually the best thing for imports. Note: if you choose different backends for targets and imports, then all the imports will run before any of the targets are checked/built. In some workflows, this may cause a slowdown.

# Related GitHub issues

- Ref: #393 

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
