### PR TITLE
Add alternative memory management strategies

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,7 @@
 - Use a `README.Rmd` file to generate `README.md`.
 - Add function `deps_targets()`.
 - Deprecate function `deps()` in favor of `deps_code()`
+- Add a `pruning_strategy` argument to `make()` and `drake_config()` so the user can decide how `drake` keeps non-import dependencies in memory when it builds a target.
 
 # Version 5.1.2
 

--- a/R/envir.R
+++ b/R/envir.R
@@ -26,12 +26,14 @@ assign_to_envir <- function(target, value, config){
 #' @examples
 #' # Users should use make().
 prune_envir <- function(targets, config, downstream = NULL, jobs = 1){
-  if (is.null(downstream)){
+  if (is.null(downstream) && config$pruning_strategy == "speed"){
     downstream <- downstream_nodes(
       from = targets,
       graph = config$graph,
       jobs = jobs
     )
+  } else if (config$pruning_strategy == "memory"){
+    downstream <- NULL
   }
   already_loaded <- ls(envir = config$envir, all.names = TRUE) %>%
     intersect(y = config$plan$target)

--- a/R/make.R
+++ b/R/make.R
@@ -108,7 +108,8 @@ make <- function(
   caching = "worker",
   keep_going = FALSE,
   session = NULL,
-  imports_only = NULL
+  imports_only = NULL,
+  pruning_strategy = c("speed", "memory")
 ){
   force(envir)
   if (!is.null(return_config)){
@@ -153,7 +154,8 @@ make <- function(
       caching = caching,
       keep_going = keep_going,
       session = session,
-      imports_only = imports_only
+      imports_only = imports_only,
+      pruning_strategy = pruning_strategy
     )
   }
   make_with_config(config = config)

--- a/R/migrate.R
+++ b/R/migrate.R
@@ -89,6 +89,7 @@ migrate_drake_project <- function(
   config$outdated <- legacy_outdated(config) %>%
     as.character %>%
     sort
+  config$pruning_strategy <- "speed"
   config$cache$clear(namespace = "depends")
   store_drake_config(config = config)
   run_loop(config = config)

--- a/man/drake_config.Rd
+++ b/man/drake_config.Rd
@@ -19,7 +19,8 @@ drake_config(plan = read_drake_plan(),
   skip_targets = FALSE, skip_imports = FALSE, skip_safety_checks = FALSE,
   lazy_load = "eager", session_info = TRUE, cache_log_file = NULL,
   seed = NULL, caching = c("worker", "master"), keep_going = FALSE,
-  session = NULL, imports_only = NULL)
+  session = NULL, imports_only = NULL, pruning_strategy = c("speed",
+  "memory"))
 }
 \arguments{
 \item{plan}{workflow plan data frame.
@@ -327,6 +328,19 @@ but it causes \code{\link[=make]{make()}} to populate your workspace/environment
 with the last few targets it builds.}
 
 \item{imports_only}{deprecated. Use \code{skip_targets} instead.}
+
+\item{pruning_strategy}{Character scalar, either \code{"speed"} (default)
+or \code{"memory"}. These are alternative approaches to how \code{drake}
+keeps non-import dependencies in memory when it builds a target.
+If \code{pruning_strategy} is \code{"memory"}, \code{drake} removes all targets
+from memory (i.e. \code{config$envir}) except the direct dependencies
+of the target is about to build. This is suitable for data so large
+that the optimal strategy is to minimize memory consumption.
+If \code{pruning_strategy} is \code{"speed"}, \code{drake} loads all the dependencies
+and keeps in memory everything that will eventually be a
+dependency of a downstream target. This strategy consumes more
+memory, but does more to minimize the number of times data is
+read from storage/disk.}
 }
 \value{
 The master internal configuration list of a project.

--- a/man/make.Rd
+++ b/man/make.Rd
@@ -18,7 +18,7 @@ make(plan = read_drake_plan(), targets = drake::possible_targets(plan),
   skip_safety_checks = FALSE, config = NULL, lazy_load = "eager",
   session_info = TRUE, cache_log_file = NULL, seed = NULL,
   caching = "worker", keep_going = FALSE, session = NULL,
-  imports_only = NULL)
+  imports_only = NULL, pruning_strategy = c("speed", "memory"))
 }
 \arguments{
 \item{plan}{workflow plan data frame.
@@ -334,6 +334,19 @@ but it causes \code{\link[=make]{make()}} to populate your workspace/environment
 with the last few targets it builds.}
 
 \item{imports_only}{deprecated. Use \code{skip_targets} instead.}
+
+\item{pruning_strategy}{Character scalar, either \code{"speed"} (default)
+or \code{"memory"}. These are alternative approaches to how \code{drake}
+keeps non-import dependencies in memory when it builds a target.
+If \code{pruning_strategy} is \code{"memory"}, \code{drake} removes all targets
+from memory (i.e. \code{config$envir}) except the direct dependencies
+of the target is about to build. This is suitable for data so large
+that the optimal strategy is to minimize memory consumption.
+If \code{pruning_strategy} is \code{"speed"}, \code{drake} loads all the dependencies
+and keeps in memory everything that will eventually be a
+dependency of a downstream target. This strategy consumes more
+memory, but does more to minimize the number of times data is
+read from storage/disk.}
 }
 \value{
 The master internal configuration list, mostly


### PR DESCRIPTION
# Summary

Add a `pruning_strategy` argument to `make()` and `drake_config()` so the user can decide how `drake` keeps non-import dependencies in memory when it builds a target.

If `pruning_strategy` is `"memory"`, `drake` removes all targets from memory (i.e. `config$envir`) except the direct dependencies of the target is about to build. This is suitable for data so large that the optimal strategy is to minimize memory consumption. If `pruning_strategy` is `"speed"`, `drake` loads all the dependencies and keeps in memory everything that will eventually be a dependency of a downstream target. This strategy consumes more memory, but does more to minimize the number of times data is read from storage/disk.

# Related GitHub issues

- Ref: #385

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
