### PR TITLE
Support custom columns to fine tune scheduling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,7 @@
 - Add function `deps_targets()`.
 - Deprecate function `deps()` in favor of `deps_code()`
 - Add a `pruning_strategy` argument to `make()` and `drake_config()` so the user can decide how `drake` keeps non-import dependencies in memory when it builds a target.
+- Add optional custom (experimental) "workers" and "priorities" columns to the `drake` plans to help users customize scheduling.
 
 # Version 5.1.2
 

--- a/R/future.R
+++ b/R/future.R
@@ -12,7 +12,7 @@ run_future <- function(config){
           queue = queue
         )
         # Pop the head target only if its priority is 0
-        next_target <- queue$pop0(what = "names")
+        next_target <- queue$pop0()
         if (!length(next_target)){
           # It's hard to make this line run in a small test workflow
           # suitable enough for unit testing, but
@@ -21,7 +21,7 @@ run_future <- function(config){
           next # nocov
         }
         running <- running_targets(workers = workers, config = config)
-        protect <- c(running, queue$list(what = "names"))
+        protect <- c(running, queue$list())
         workers[[id]] <- new_worker(
           id = id,
           target = next_target,
@@ -192,8 +192,8 @@ decrease_revdep_keys <- function(worker, config, queue){
     config = config,
     reverse = TRUE
   ) %>%
-    intersect(y = queue$list(what = "names"))
-  queue$decrease_key(names = revdeps)
+    intersect(y = queue$list())
+  queue$decrease_key(targets = revdeps)
 }
 
 conclude_worker <- function(worker, config, queue){

--- a/R/mclapply.R
+++ b/R/mclapply.R
@@ -130,7 +130,7 @@ mc_conclude_target <- function(worker, config){
     reverse = TRUE
   ) %>%
     intersect(y = config$queue$list())
-  config$queue$decrease_key(names = revdeps)
+  config$queue$decrease_key(targets = revdeps)
   flag_attempt <- !get_attempt_flag(config) &&
     get_progress_single(target = target, cache = config$cache) == "finished" &&
     target %in% config$plan$target

--- a/R/mclapply.R
+++ b/R/mclapply.R
@@ -63,14 +63,14 @@ mc_master <- function(config){
           mc_set_done(worker = worker, config = config)
           next
         }
-        target <- config$queue$peek0(what = "names")
+        target <- config$queue$peek0()
         should_assign <- mc_should_assign_target(
           worker = worker,
           target = target,
           config = config
         )
         if (should_assign){
-          config$queue$pop0(what = "names")
+          config$queue$pop0()
           mc_set_target(worker = worker, target = target, config = config)
           mc_set_running(worker = worker, config = config)
         }
@@ -129,7 +129,7 @@ mc_conclude_target <- function(worker, config){
     config = config,
     reverse = TRUE
   ) %>%
-    intersect(y = config$queue$list(what = "names"))
+    intersect(y = config$queue$list())
   config$queue$decrease_key(names = revdeps)
   flag_attempt <- !get_attempt_flag(config) &&
     get_progress_single(target = target, cache = config$cache) == "finished" &&

--- a/R/mclapply.R
+++ b/R/mclapply.R
@@ -273,7 +273,10 @@ mc_should_assign_target <- function(worker, target, config){
   if (!length(target)){
     return(FALSE)
   }
-  if (!length(config$plan$workers) || !(target %in% config$plan$target)){
+  if (
+    !("workers" %in% colnames(config$plan)) ||
+    !(target %in% config$plan$target)
+  ){
     return(TRUE)
   }
   allowed_workers <- as.integer(

--- a/R/predict_runtime.R
+++ b/R/predict_runtime.R
@@ -304,8 +304,14 @@ balance_load <- function(config, jobs){
           mc_set_done(worker = worker, config = config)
           next
         }
-        target <- config$queue$pop0(what = "names")
-        if (length(target)){
+        target <- config$queue$peek0()
+        should_assign <- mc_should_assign_target(
+          worker = worker,
+          target = target,
+          config = config
+        )
+        if (should_assign){
+          config$queue$pop0()
           # Added line: get the time that the worker will spend on the target.
           step_times[worker] <- igraph::vertex_attr(
             graph = config$graph,

--- a/R/queue.R
+++ b/R/queue.R
@@ -4,7 +4,7 @@ new_target_queue <- function(config){
   if (!length(targets)){
     return(R6_priority_queue$new())
   }
-  priorities <- lightly_parallelize(
+  ndeps <- lightly_parallelize(
     X = targets,
     FUN = function(target){
       length(dependencies(targets = target, config = config))
@@ -12,8 +12,16 @@ new_target_queue <- function(config){
     jobs = config$jobs
   ) %>%
     unlist
-  stopifnot(any(priorities < 1)) # Stop if nothing has ready deps.
-  R6_priority_queue$new(names = targets, priorities = priorities)
+  if ("priority" %in% colnames(config$plan)){
+    priorities <- config$plan$priority
+  } else {
+    priorities <- rep(0, length(targets))
+  }
+  R6_priority_queue$new(
+    targets = targets,
+    ndeps = ndeps,
+    priorities = priorities
+  )
 }
 
 # This is not actually a serious O(log n) priority queue
@@ -24,84 +32,57 @@ new_target_queue <- function(config){
 # (https://github.com/dirmeier/datastructures/issues/4).
 R6_priority_queue <- R6::R6Class(
   classname = "R6_priority_queue",
-  private = list(
-    data = numeric(0),
-    return_value = function(x, what = c("names", "priorities")){
-      what <- match.arg(what)
-      if (what == "names"){
-        names(x)
-      } else {
-        x
-      }
-    }
-  ),
   public = list(
-    # The values are priorities and the names are targets.
-    initialize = function(names = character(0), priorities = numeric(0)){
-      self$push(names = names, priorities = priorities)
+    data = data.frame(
+      targets = character(0),
+      ndeps = integer(0),
+      priorities = numeric(0)
+    ),
+    initialize = function(
+      targets = character(0),
+      ndeps = integer(0),
+      priorities = numeric(0)
+    ){
+      stopifnot(length(targets) == length(ndeps))
+      self$data <- data.frame(
+        target = targets,
+        ndeps = ndeps,
+        priority = priorities,
+        stringsAsFactors = FALSE
+      )
+      self$sort()
     },
     size = function(){
-      length(private$data)
+      nrow(self$data)
     },
     empty = function(){
       self$size() < 1
     },
-    list = function(what = "names"){
-      self$peek(n = self$size(), what = what)
-    },
-    # Are any targets ready to build?
-    # the priority is the number of dependencies left to build.
-    any0 = function(){
-      !self$empty() && private$data[1] < 1
-    },
     sort = function(){
-      private$data <- sort(private$data)
-    },
-    push = function(names = character(0), priorities = numeric(0)){
-      stopifnot(length(names) == length(priorities))
-      if (!length(names)){
-        return()
-      }
-      data <- priorities
-      names(data) <- names
-      stopifnot(!length(data) || !is.null(names(data)))
-      private$data <- c(private$data, data)
-      self$sort()
-    },
-    peek = function(n = 1, what = "names"){
-      if (self$empty() || n < 1){
-        return(character(0))
-      }
-      x <- private$data[seq_len(min(n, self$size()))]
-      private$return_value(x = x, what = what)
-    },
-    pop = function(n = 1, what = "names"){
-      if (n < 1){
-        return(character(0))
-      }
-      index <- seq_len(min(n, self$size()))
-      x <- private$data[index]
-      private$data <- private$data[-index]
-      private$return_value(x = x, what = what)
+      ndeps <- priority <- NULL
+      self$data <- dplyr::arrange(self$data, ndeps, priority)
     },
     # Peek at the head node of the queue
-    # if and only if its priority is 0.
-    peek0 = function(what = "names"){
-      if (!self$empty() && private$data[1] < 1){
-        self$peek(n = 1, what = what)
+    # if and only if its ndeps is 0.
+    peek0 = function(){
+      if (!self$empty() && self$data$ndeps[1] < 1){
+        self$data$target[1]
       }
     },
     # Extract the head node of the queue
-    # if and only if its priority is 0.
-    pop0 = function(what = "names"){
-      if (!self$empty() && private$data[1] < 1){
-        self$pop(n = 1, what = what)
+    # if and only if its ndeps is 0.
+    pop0 = function(){
+      if (!self$empty() && self$data$ndeps[1] < 1){
+        out <- self$data$target[1]
+        self$data <- self$data[-1, ]
+        out
       }
     },
     # This is all wrong and inefficient.
     # Needs the actual decrease-key algorithm
-    decrease_key = function(names){
-      private$data[names] <- private$data[names] - 1
+    decrease_key = function(targets){
+      index <- self$data$target %in% targets
+      self$data$ndeps[index] <- self$data$ndeps[index] - 1
       self$sort()
     }
   )

--- a/R/queue.R
+++ b/R/queue.R
@@ -43,7 +43,18 @@ R6_priority_queue <- R6::R6Class(
       ndeps = integer(0),
       priorities = numeric(0)
     ){
-      stopifnot(length(targets) == length(ndeps))
+      if (
+        length(targets) != length(ndeps) ||
+        length(ndeps) != length(priorities)
+      ){
+        stop(
+          "Cannot create priority queue:\nlength(targets) = ",
+          length(targets),
+          ", length(ndeps) = ", length(ndeps),
+          ", length(priorities) = ", length(priorities),
+          call. = FALSE
+        )
+      }
       self$data <- data.frame(
         target = targets,
         ndeps = ndeps,

--- a/R/queue.R
+++ b/R/queue.R
@@ -58,6 +58,9 @@ R6_priority_queue <- R6::R6Class(
     empty = function(){
       self$size() < 1
     },
+    list = function(){
+      self$data$target
+    },
     sort = function(){
       ndeps <- priority <- NULL
       self$data <- dplyr::arrange(self$data, ndeps, priority)

--- a/R/queue.R
+++ b/R/queue.R
@@ -84,6 +84,13 @@ R6_priority_queue <- R6::R6Class(
       private$data <- private$data[-index]
       private$return_value(x = x, what = what)
     },
+    # Peek at the head node of the queue
+    # if and only if its priority is 0.
+    peek0 = function(what = "names"){
+      if (!self$empty() && private$data[1] < 1){
+        self$peek(n = 1, what = what)
+      }
+    },
     # Extract the head node of the queue
     # if and only if its priority is 0.
     pop0 = function(what = "names"){

--- a/R/queue.R
+++ b/R/queue.R
@@ -15,7 +15,10 @@ new_target_queue <- function(config){
   priorities <- rep(Inf, length(targets))
   names(priorities) <- targets
   if ("priority" %in% colnames(config$plan)){
-    priorities[config$plan$target] <- config$plan$priority
+    prioritized <- intersect(targets, config$plan$target)
+    set_priorities <- config$plan$priority
+    names(set_priorities) <- config$plan$target
+    priorities[prioritized] <- set_priorities[prioritized]
   }
   R6_priority_queue$new(
     targets = targets,

--- a/R/queue.R
+++ b/R/queue.R
@@ -12,10 +12,10 @@ new_target_queue <- function(config){
     jobs = config$jobs
   ) %>%
     unlist
+  priorities <- rep(Inf, length(targets))
+  names(priorities) <- targets
   if ("priority" %in% colnames(config$plan)){
-    priorities <- config$plan$priority
-  } else {
-    priorities <- rep(0, length(targets))
+    priorities[config$plan$target] <- config$plan$priority
   }
   R6_priority_queue$new(
     targets = targets,

--- a/R/sanitize.R
+++ b/R/sanitize.R
@@ -10,10 +10,8 @@ sanitize_plan <- function(plan, allow_duplicated_targets = FALSE){
       }
     }
   }
-  if ("trigger" %in% colnames(plan)){
-    plan$trigger[is.na(plan$trigger) | !nzchar(plan$trigger)] <- "any"
-    assert_legal_triggers(plan[["trigger"]])
-  }
+  plan$trigger <- parse_triggers(plan$trigger)
+  plan$workers <- parse_workers(plan$workers)
   plan <- file_outs_to_targets(plan)
   plan$target <- repair_target_names(plan$target)
   plan <- plan[nzchar(plan$target), ]
@@ -120,4 +118,25 @@ single_file_out <- function(command){
   } else {
     file_out
   }
+}
+
+parse_triggers <- function(x){
+  if (is.null(x)){
+    return()
+  }
+  x[is.na(x) | !nzchar(x)] <- "any"
+  assert_legal_triggers(x)
+  x
+}
+
+parse_workers <- function(x){
+  if (is.null(x)){
+    return()
+  }
+  levels <- sort(as.integer(unique(unlist(x))))
+  keys <- seq_along(levels)
+  names(keys) <- as.character(levels)
+  lapply(x, function(y) {
+    unname(keys[as.character(y)])
+  })
 }

--- a/R/sanitize.R
+++ b/R/sanitize.R
@@ -10,8 +10,12 @@ sanitize_plan <- function(plan, allow_duplicated_targets = FALSE){
       }
     }
   }
-  plan$trigger <- parse_triggers(plan$trigger)
-  plan$workers <- parse_workers(plan$workers)
+  if ("trigger" %in% colnames(plan)){
+    plan$trigger <- parse_triggers(plan$trigger)
+  }
+  if ("workers" %in% colnames(plan)){
+    plan$workers <- parse_workers(plan$workers)
+  }
   plan <- file_outs_to_targets(plan)
   plan$target <- repair_target_names(plan$target)
   plan <- plan[nzchar(plan$target), ]
@@ -38,8 +42,10 @@ drake_plan_columns <- function(){
     "cpu",
     "elapsed",
     "evaluator",
+    "priority",
     "retries",
-    "timeout"
+    "timeout",
+    "workers"
   )
 }
 
@@ -121,18 +127,12 @@ single_file_out <- function(command){
 }
 
 parse_triggers <- function(x){
-  if (is.null(x)){
-    return()
-  }
   x[is.na(x) | !nzchar(x)] <- "any"
   assert_legal_triggers(x)
   x
 }
 
 parse_workers <- function(x){
-  if (is.null(x)){
-    return()
-  }
   levels <- sort(as.integer(unique(unlist(x))))
   keys <- seq_along(levels)
   names(keys) <- as.character(levels)

--- a/tests/testthat/test-envir.R
+++ b/tests/testthat/test-envir.R
@@ -64,3 +64,12 @@ test_with_dir("prune_envir in full build", {
     c("a_x", "c_y", "s_b_x", "t_a_z", "y")
   )
 })
+
+test_with_dir("alt strategy for pruning", {
+  envir <- new.env(parent = globalenv())
+  cache <- storr::storr_environment()
+  load_mtcars_example(envir = envir, cache = cache)
+  make(envir$my_plan, envir = envir, cache = cache,
+       session_info = FALSE, pruning_strategy = "memory")
+  expect_true(file_store("report.md") %in% cache$list())
+})

--- a/tests/testthat/test-parallel.R
+++ b/tests/testthat/test-parallel.R
@@ -150,3 +150,14 @@ test_with_dir("lightly_parallelize_atomic() is correct", {
     expect_identical(x, y)
   })
 })
+
+test_with_dir("worker & priority cols don't generate overt problems", {
+  envir <- new.env(parent = globalenv())
+  cache <- storr::storr_environment()
+  load_mtcars_example(envir = envir, cache = cache)
+  my_plan <- envir$my_plan
+  my_plan$workers <- my_plan$priority <- seq_len(nrow(my_plan))
+  make(my_plan, envir = envir, cache = cache,
+       session_info = FALSE, pruning_strategy = "memory")
+  expect_true(file_store("report.md") %in% cache$list())
+})

--- a/tests/testthat/test-parallel.R
+++ b/tests/testthat/test-parallel.R
@@ -152,12 +152,14 @@ test_with_dir("lightly_parallelize_atomic() is correct", {
 })
 
 test_with_dir("worker & priority cols don't generate overt problems", {
+  future::plan(future::sequential)
   envir <- new.env(parent = globalenv())
-  cache <- storr::storr_environment()
-  load_mtcars_example(envir = envir, cache = cache)
+  load_mtcars_example(envir = envir)
   my_plan <- envir$my_plan
-  my_plan$workers <- my_plan$priority <- seq_len(nrow(my_plan))
-  make(my_plan, envir = envir, cache = cache,
+  my_plan$priority <- seq_len(nrow(my_plan))
+  my_plan$workers <- as.list(my_plan$priority)
+  my_plan$workers[[1]] <- numeric(0)
+  make(my_plan, envir = envir, parallelism = "future_lapply",
        session_info = FALSE, pruning_strategy = "memory")
-  expect_true(file_store("report.md") %in% cache$list())
+  expect_true(file_store("report.md") %in% cached())
 })

--- a/tests/testthat/test-queue.R
+++ b/tests/testthat/test-queue.R
@@ -37,7 +37,7 @@ test_with_dir("the priority queue works", {
     target = c("spren", "bar", "Joe", "baz", "Amy", "soup", "Bob", "foo"),
     ndeps = c(0, 0, 1, 3, 4, 7, 7, 8),
     priority = c(1, 2, 1, 2, 1, 1, 2, 2),
-    stringsAsFactors = FALSE   
+    stringsAsFactors = FALSE
   )
   expect_equal(x$data, y)
   expect_equal(x$peek0(), "spren")
@@ -50,7 +50,7 @@ test_with_dir("the priority queue works", {
   expect_null(x$peek0())
   expect_null(x$pop0())
   expect_equal(x$data, y[-1:-2, ])
-  
+
   priorities[targets == "bar"] <- 1
   priorities[targets == "spren"] <- 2
   x <- R6_priority_queue$new(
@@ -65,7 +65,7 @@ test_with_dir("the priority queue works", {
     target = c("bar", "spren", "Joe", "baz", "Amy", "soup", "Bob", "foo"),
     ndeps = c(0, 0, 1, 3, 4, 7, 7, 8),
     priority = c(1, 2, 1, 2, 1, 1, 2, 2),
-    stringsAsFactors = FALSE   
+    stringsAsFactors = FALSE
   )
   expect_equal(x$data, y)
   expect_equal(x$peek0(), "bar")

--- a/tests/testthat/test-queue.R
+++ b/tests/testthat/test-queue.R
@@ -3,64 +3,79 @@ drake_context("queue")
 test_with_dir("empty queue", {
   config <- list(schedule = igraph::make_empty_graph())
   q <- new_target_queue(config)
-  expect_equal(length(q$list()), 0)
+  expect_equal(nrow(q$data), 0)
 })
 
 test_with_dir("the priority queue works", {
-  names <- c("foo", "bar", "baz", "Bob", "Amy", "Joe", "soup", "spren")
-  priorities <- c(8, 2, 3, 7, 4, 1, 7, 5)
-  priorities[4] <- priorities[7]
-  expect_false(identical(priorities, sort(priorities, decreasing = TRUE)))
-  expect_error(R6_priority_queue$new(names = letters[1:2], priorities = 1:4))
-  x <- R6_priority_queue$new(names = names, priorities = priorities)
-  expect_equal(x$list(what = "names"), names[order(priorities)])
-  expect_equal(
-    unname(x$list(what = "priorities")),
-    sort(priorities, decreasing = FALSE)
+  targets <- c("foo", "bar", "baz", "Bob", "Amy", "Joe", "soup", "spren")
+  ndeps <- c(8, 2, 3, 7, 4, 1, 7, 5)
+  priorities <- c(rep(2, 4), rep(1, 4))
+  ndeps[4] <- ndeps[7]
+  expect_false(identical(ndeps, sort(ndeps, decreasing = TRUE)))
+  expect_error(
+    R6_priority_queue$new(
+      targets = letters[1:2], ndeps = 1:4, priorities = 1:2))
+  x <- R6_priority_queue$new(
+    targets = targets, ndeps = ndeps, priorities = priorities)
+  y <- data.frame(
+    target = c("Joe", "bar", "baz", "Amy", "spren", "soup", "Bob", "foo"),
+    ndeps = c(1, 2, 3, 4, 5, 7, 7, 8),
+    priority = c(1, 2, 2, 1, 1, 1, 2, 2),
+    stringsAsFactors = FALSE
   )
-
-  expect_equal(x$size(), length(names))
-  expect_false(x$empty())
-  expect_false(x$any0())
-  expect_true(!length(x$pop0()))
-  elts <- x$list()
-  head <- x$peek(n = 2)
-  expect_equal(head, c("Joe", "bar"))
-  expect_equal(unname(x$peek(n = 2, what = "priorities")), 1:2)
-  expect_equal(x$list(what = "names"), names[order(priorities)])
-  expect_equal(
-    unname(x$list(what = "priorities")),
-    sort(priorities, decreasing = FALSE)
+  expect_equal(x$data, y)
+  expect_null(x$peek0())
+  expect_null(x$pop0())
+  expect_equal(x$data, y)
+  for (i in 1:2){
+    x$decrease_key(c("bar", "spren"))
+  }
+  for (i in 1:3){
+    x$decrease_key("spren")
+  }
+  y <- data.frame(
+    target = c("spren", "bar", "Joe", "baz", "Amy", "soup", "Bob", "foo"),
+    ndeps = c(0, 0, 1, 3, 4, 7, 7, 8),
+    priority = c(1, 2, 1, 2, 1, 1, 2, 2),
+    stringsAsFactors = FALSE   
   )
-
-  expect_equal(x$pop(n = 2), head)
-  expect_equal(x$list(what = "names"), names[order(priorities)][-1:-2])
-  expect_equal(
-    unname(x$list(what = "priorities")),
-    sort(priorities, decreasing = FALSE)[-1:-2]
+  expect_equal(x$data, y)
+  expect_equal(x$peek0(), "spren")
+  expect_equal(x$data, y)
+  expect_equal(x$pop0(), "spren")
+  expect_equal(x$peek0(), "bar")
+  expect_equal(x$data, y[-1, ])
+  expect_equal(x$pop0(), "bar")
+  expect_equal(x$data, y[-1:-2, ])
+  expect_null(x$peek0())
+  expect_null(x$pop0())
+  expect_equal(x$data, y[-1:-2, ])
+  
+  priorities[targets == "bar"] <- 1
+  priorities[targets == "spren"] <- 2
+  x <- R6_priority_queue$new(
+    targets = targets, ndeps = ndeps, priorities = priorities)
+  for (i in 1:2){
+    x$decrease_key(c("bar", "spren"))
+  }
+  for (i in 1:3){
+    x$decrease_key("spren")
+  }
+  y <- data.frame(
+    target = c("bar", "spren", "Joe", "baz", "Amy", "soup", "Bob", "foo"),
+    ndeps = c(0, 0, 1, 3, 4, 7, 7, 8),
+    priority = c(1, 2, 1, 2, 1, 1, 2, 2),
+    stringsAsFactors = FALSE   
   )
-  x$push(names = c("Preservation", "Ruin"), priorities = c(0, 6.66))
-  expect_true(x$any0())
-  nms <- c("Preservation", "baz", "Amy", "spren", "Ruin", "Bob", "soup", "foo")
-  pri <- c(0, 3, 4, 5, 6.66, 7, 7, 8)
-  expect_equal(x$list("names"), nms)
-  expect_equal(unname(x$list("priorities")), pri)
-  x$push()
-  expect_equal(x$list("names"), nms)
-  expect_equal(unname(x$list("priorities")), pri)
-
-  expect_equal(x$pop(n = 0), character(0))
-  expect_equal(x$list("names"), nms)
-  expect_equal(unname(x$list("priorities")), pri)
-  expect_equal(x$pop0(), "Preservation")
-  expect_true(!length(x$pop0()))
-  expect_equal(x$list("names"), nms[-1])
-  expect_equal(unname(x$list("priorities")), pri[-1])
-
-  x$decrease_key("soup")
-  x$decrease_key("soup")
-  nms <- c("baz", "Amy", "spren", "soup", "Ruin", "Bob", "foo")
-  pri <- c(3, 4, 5, 5, 6.66, 7, 8)
-  expect_equal(x$list("names"), nms)
-  expect_equal(unname(x$list("priorities")), pri)
+  expect_equal(x$data, y)
+  expect_equal(x$peek0(), "bar")
+  expect_equal(x$data, y)
+  expect_equal(x$pop0(), "bar")
+  expect_equal(x$peek0(), "spren")
+  expect_equal(x$data, y[-1, ])
+  expect_equal(x$pop0(), "spren")
+  expect_equal(x$data, y[-1:-2, ])
+  expect_null(x$peek0())
+  expect_null(x$pop0())
+  expect_equal(x$data, y[-1:-2, ])
 })

--- a/tests/testthat/test-queue.R
+++ b/tests/testthat/test-queue.R
@@ -93,28 +93,9 @@ test_with_dir("queues with priorities", {
   config <- drake_config(my_plan)
   config$schedule <- config$graph
   q <- new_target_queue(config)
-  x <- data.frame(
-    target = c(
-      "lm", "nrow", "suppressWarnings", "data.frame", "mtcars", "sample.int",
-      "knit", file_store("report.Rmd"), "summary", "small", "large", "reg1",
-      "reg2", "regression1_small", "regression1_large", "regression2_small",
-      "regression2_large", "random_rows", "summ_regression1_small",
-      "summ_regression1_large", "summ_regression2_small",
-      "summ_regression2_large", "coef_regression1_small",
-      "coef_regression1_large", "coef_regression2_small",
-      "coef_regression2_large", "simulate", file_store("report.md")
-    ),
-    ndeps = as.integer(c(rep(0, 9), rep(1, 4), rep(2, 5), rep(3, 9), 5)),
-    priority = c(rep(Inf, 9), 2, 3, Inf, Inf, 4, 5, 6, 7, Inf, 8:15, Inf, 1),
-    stringsAsFactors = FALSE
-  )
   expect_true(all(diff(q$data$ndeps) >= 0))
   expect_equal(nrow(q$data), length(igraph::V(config$graph)))
   expect_equal(sum(is.finite(q$data$priority)), nrow(config$plan))
-  expect_equal(
-    dplyr::arrange(x, ndeps, priority, target),
-    dplyr::arrange(q$data, ndeps, priority, target)
-  )
   config$schedule <- targets_graph(config)
   q <- new_target_queue(config)
   expect_true(all(diff(q$data$ndeps) >= 0))

--- a/tests/testthat/test-queue.R
+++ b/tests/testthat/test-queue.R
@@ -6,6 +6,13 @@ test_with_dir("empty queue", {
   expect_equal(nrow(q$data), 0)
 })
 
+test_with_dir("bad queue", {
+  expect_error(
+    R6_priority_queue$new(1:2, 1:4, 1:3),
+    regexp = "priority queue"
+  )
+})
+
 test_with_dir("the priority queue works", {
   targets <- c("foo", "bar", "baz", "Bob", "Amy", "Joe", "soup", "spren")
   ndeps <- c(8, 2, 3, 7, 4, 1, 7, 5)

--- a/tests/testthat/test-queue.R
+++ b/tests/testthat/test-queue.R
@@ -79,3 +79,33 @@ test_with_dir("the priority queue works", {
   expect_null(x$pop0())
   expect_equal(x$data, y[-1:-2, ])
 })
+
+test_with_dir("queue with priorities", {
+  load_mtcars_example(cache = storr::storr_environment())
+  my_plan$priority <- seq_len(nrow(my_plan))
+  config <- drake_config(my_plan)
+  config$schedule <- config$graph
+  q <- new_target_queue(config)
+  x <- data.frame(
+    target = c(
+      "lm", "nrow", "suppressWarnings", "data.frame", "mtcars", "sample.int",
+      "knit", file_store("report.Rmd"), "summary", "small", "large", "reg1",
+      "reg2", "regression1_small", "regression1_large", "regression2_small",
+      "regression2_large", "random_rows", "summ_regression1_small",
+      "summ_regression1_large", "summ_regression2_small",
+      "summ_regression2_large", "coef_regression1_small",
+      "coef_regression1_large", "coef_regression2_small",
+      "coef_regression2_large", "simulate", file_store("report.md")
+    ),
+    ndeps = as.integer(c(rep(0, 9), rep(1, 4), rep(2, 5), rep(3, 9), 5)),
+    priority = c(rep(Inf, 9), 2, 3, Inf, Inf, 4, 5, 6, 7, Inf, 8:15, Inf, 1),
+    stringsAsFactors = FALSE
+  )
+  expect_true(all(diff(q$data$ndeps) >= 0))
+  expect_equal(nrow(q$data), length(igraph::V(config$graph)))
+  expect_equal(sum(is.finite(q$data$priority)), nrow(config$plan))
+  expect_equal(
+    dplyr::arrange(x, ndeps, priority, target),
+    dplyr::arrange(q$data, ndeps, priority, target)
+  )
+})

--- a/tests/testthat/test-time.R
+++ b/tests/testthat/test-time.R
@@ -147,3 +147,23 @@ test_with_dir("runtime predictions", {
   expect_equal(p7, 43, tolerance = 1e-6)
   expect_equal(p8, 70, tolerance = 1e-6)
 })
+
+test_with_dir("load balancing with custom worker assignemnts", {
+  config <- load_mtcars_example()
+  config$plan$workers <- 1
+  config$plan$workers[grepl("large", config$plan$target)] <- 2
+  suppressWarnings(
+    x <- predict_load_balancing(config, default_time = 2, jobs = 2))
+  expect_false(any(grep("large", x$targets_per_worker[[1]])))
+  expect_true(any(grep("large", x$targets_per_worker[[2]])))
+  expect_false(any(grep("small", x$targets_per_worker[[2]])))
+  expect_true(any(grep("small", x$targets_per_worker[[1]])))
+  config$plan$workers <- 1
+  config$plan$workers[grepl("small", config$plan$target)] <- 2
+  suppressWarnings(
+    x <- predict_load_balancing(config, default_time = 2, jobs = 2))
+  expect_false(any(grep("large", x$targets_per_worker[[2]])))
+  expect_true(any(grep("large", x$targets_per_worker[[1]])))
+  expect_false(any(grep("small", x$targets_per_worker[[1]])))
+  expect_true(any(grep("small", x$targets_per_worker[[2]])))
+})

--- a/tests/testthat/test-time.R
+++ b/tests/testthat/test-time.R
@@ -131,8 +131,19 @@ test_with_dir("runtime predictions", {
     targets = targets
   ) %>%
     as.numeric
+  con$plan$workers <- 1
+  p8 <- predict_runtime(
+    config = con,
+    jobs = 2,
+    default_time = Inf,
+    from_scratch = TRUE,
+    known_times = known_times,
+    targets = targets
+  ) %>%
+    as.numeric
   expect_true(all(is.finite(c(p1, p2, p3, p4))))
   expect_equal(p5, 0, tolerance = 1e-6)
   expect_equal(p6, 70, tolerance = 1e-6)
   expect_equal(p7, 43, tolerance = 1e-6)
+  expect_equal(p8, 70, tolerance = 1e-6)
 })

--- a/tests/testthat/test-workflow-plan.R
+++ b/tests/testthat/test-workflow-plan.R
@@ -472,3 +472,17 @@ test_with_dir("spaces in target names are replaced only when appropriate", {
   )
   expect_equal(pl, pl2)
 })
+
+test_with_dir("parse the optional workers column", {
+  x <- list(10, 4, -1, 18, c(0, 4, 10, 123), numeric(0), 123)
+  y <- list(
+    as.integer(4),
+    as.integer(3),
+    as.integer(1),
+    as.integer(5),
+    as.integer(c(2, 3, 4, 6)),
+    integer(0),
+    as.integer(6)
+  )
+  expect_equal(y, parse_workers(x))
+})

--- a/vignettes/parallelism.Rmd
+++ b/vignettes/parallelism.Rmd
@@ -252,7 +252,28 @@ In each of these calls to `make()`, three processes launch: two workers and one 
 <iframe width="700" height="434" src="https://www.powtoon.com/embed/bUfSIaXjrw5/" frameborder="0"></iframe>
 </div>
 
-The `predict_runtime()` and `predict_load_balancing()` functions emulate persistent workers, and the predictions also apply to transient workers. See the [timing guide](https://ropensci.github.io/drake/articles/timing.html) for a demonstration.
+For staged scheduling, you can micromanage which workers can run which targets. This column can be an integer vector or a list of integer vectors. Simply set an optional `workers` column in your `drake_plan()`. Why would you wish to do this? Consider the `mtcars` example.
+
+```{r workerscol}
+load_mtcars_example()
+my_plan$workers <- 1
+my_plan$workers[grepl("large", my_plan$target)] <- 2
+my_plan
+```
+
+Here, one of the workers is in charge of all the targets that have to do with the `large` dataset. That way, we do not need other workers to read `large` from disk. If reads from disk take a long time, this could speed up your workflow. On the other hand, delegating all the `large` targets to worker 2 could prevent worker 1 from sharing the computational load, which could slow things down. Ultimately, you as the user need to make these tradeoffs. Also, the `workers` column only applies to the persistent scheduling backends.
+
+Similarly, you can set an optional `priority` column for your `drake_plan()`.
+
+```{r prioritycol}
+plan <- drake_plan(A = build(), B = stuff())
+plan$priority <- c(1, 2)
+plan
+```
+
+Because of the `priority` column, if targets `A` and `B` are both ready to build, then `A` will be assigned to a worker first. Custom priorities apply to the staged scheduling backends, plus the `"future"` backend.
+
+The `predict_runtime()` and `predict_load_balancing()` functions emulate persistent workers, and the predictions also apply to transient workers. See the [timing guide](https://ropensci.github.io/drake/articles/timing.html) for a demonstration. These functions also respond to the `workers` column.
 
 ## Transient scheduling
 

--- a/vignettes/timing.Rmd
+++ b/vignettes/timing.Rmd
@@ -106,3 +106,5 @@ We see serious potential speed gains up to 4 jobs, but beyond that point, we hav
 clean(destroy = TRUE, verbose = FALSE)
 unlink(c("Makefile", "report.Rmd", "shell.sh", "STDIN.o*", "Thumbs.db"))
 ```
+
+A final note on predicting runtime: the output of `predict_runtime()` and `predict_load_balancing()` also depends the optional `workers` column of your `drake_plan()`. If you micromanage which workers are allowed to build which targets, you may minimize reads from disk, but you could also slow down your workflow if you are not careful. See the [high-performance computing guide](https://ropensci.github.io/drake/articles/parallelism.html) for more.


### PR DESCRIPTION
# Summary

- `plan$workers` now restricts the workers that the targets can go to (persistent scheduling only). That way, you can assign targets to workers that are likely to have the dependencies already in memory.
- `plan$priority`: if multiple targets are ready to go, only the most important one (lowest value in `plan$priority`) gets deployed. Supported for persistent scheduling and the `"future"` backend.

Do we want this functionality for non-persistent workers?

@krlmlr, I think fancier knapsack-derived scheduling algorithms could just be a matter of figuring out clever ways to set these columns, at least for persistent workers.

cc @guilhermealles

Needs manual testing on old projects.

# Related GitHub issues

- Ref: #391, #392 

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [ ] I think this pull request is ready to merge.
