### PR TITLE
Allow custom Makefile paths

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,8 @@
 - Deprecate function `deps()` in favor of `deps_code()`
 - Add a `pruning_strategy` argument to `make()` and `drake_config()` so the user can decide how `drake` keeps non-import dependencies in memory when it builds a target.
 - Add optional custom (experimental) "workers" and "priorities" columns to the `drake` plans to help users customize scheduling.
+- Add a `makefile_path` argument to `make()` and `drake_config()` to avoid potential conflicts between user-side custom `Makefile`s and the one written by `make(parallelism = "Makefile")`.
+- Document batch mode for long workflows in the HPC vignette.
 
 # Version 5.1.2
 

--- a/R/Makefile.R
+++ b/R/Makefile.R
@@ -4,13 +4,7 @@ run_Makefile <- function( #nolint: we want Makefile capitalized.
   debug = FALSE
 ){
   prepare_distributed(config = config)
-  with_output_sink(
-    new = "Makefile",
-    code = {
-      makefile_head(config)
-      makefile_rules(config)
-    }
-  )
+  write_makefile(config = config)
   time_stamps(config = config)
   error_code <- ifelse(
     run,
@@ -23,7 +17,39 @@ run_Makefile <- function( #nolint: we want Makefile capitalized.
   return(invisible(config))
 }
 
+write_makefile <- function(config){
+  assert_no_conflicting_makefile(config)
+  with_output_sink(
+    new = config$makefile_path,
+    code = {
+      makefile_head(config)
+      makefile_rules(config)
+    }
+  )
+}
+
+assert_no_conflicting_makefile <- function(config){
+  if (file.exists(config$makefile_path)){
+    top_lines <- readLines(con = config$makefile_path, n = 2)
+    if (!identical(top_lines, makefile_top_lines)){
+      stop(
+        "Makefile at `", config$makefile_path, "` already exists ",
+        "and was not created by drake. You must either: \n  (1) ",
+        "Remove the file `", config$makefile_path, "` or \n  (2) ",
+        "Set the `parallelism` argument of drake::make() ",
+        "to a value other than \"Makefile\", along with the right `args`. ",
+        "Example: `make(parallelism = \"Makefile\", makefile_path = \".drake/.makefile\", command = \"make\", args = \"--file=.drake/.makefile\")` ", # nolint
+        "See `?parallelism_choices` for your options ",
+        "for the `parallelism` argument to `make()`.",
+        call. = FALSE
+      )
+    }
+  }
+}
+
 makefile_head <- function(config){
+  cat(makefile_top_lines, sep = "\n")
+  cat("\n")
   if (length(config$prepend)){
     cat(config$prepend, "\n", sep = "\n")
   }
@@ -165,6 +191,10 @@ default_Makefile_command <- function(){
 
 cache_macro <- "DRAKE_CACHE"
 cache_value_macro <- paste0("$(", cache_macro, ")")
+makefile_top_lines <- c(
+  "# Created by the drake R package for internal use only.",
+  "# Do not run it yourself or modify it by hand."
+)
 
 globalenv_file <- function(cache_path){
   file.path(cache_path, "globalenv.RData")

--- a/R/config.R
+++ b/R/config.R
@@ -335,6 +335,12 @@
 #'   memory, but does more to minimize the number of times data is
 #'   read from storage/disk.
 #'
+#' @param makefile_path Path to the `Makefile` for
+#'   `make(parallelism = "Makefile")`. If you set this argument to a
+#'   non-default value, you are responsible for supplying this same
+#'   path to the `args` argument so `make` knows where to find it.
+#'   Example: `make(parallelism = "Makefile", makefile_path = ".drake/.makefile", command = "make", args = "--file=.drake/.makefile")` # nolint
+#'
 #' @examples
 #' \dontrun{
 #' test_with_dir("Quarantine side effects.", {
@@ -391,7 +397,8 @@ drake_config <- function(
   keep_going = FALSE,
   session = NULL,
   imports_only = NULL,
-  pruning_strategy = c("speed", "memory")
+  pruning_strategy = c("speed", "memory"),
+  makefile_path = "Makefile"
 ){
   force(envir)
   if (!is.null(imports_only)){
@@ -448,7 +455,8 @@ drake_config <- function(
     lazy_load = lazy_load, session_info = session_info,
     cache_log_file = cache_log_file, caching = match.arg(caching),
     evaluator = future::plan("next"), keep_going = keep_going,
-    session = session, pruning_strategy = pruning_strategy
+    session = session, pruning_strategy = pruning_strategy,
+    makefile_path = makefile_path
   )
 }
 

--- a/R/make.R
+++ b/R/make.R
@@ -109,7 +109,8 @@ make <- function(
   keep_going = FALSE,
   session = NULL,
   imports_only = NULL,
-  pruning_strategy = c("speed", "memory")
+  pruning_strategy = c("speed", "memory"),
+  makefile_path = "Makefile"
 ){
   force(envir)
   if (!is.null(return_config)){
@@ -155,7 +156,8 @@ make <- function(
       keep_going = keep_going,
       session = session,
       imports_only = imports_only,
-      pruning_strategy = pruning_strategy
+      pruning_strategy = pruning_strategy,
+      makefile_path = makefile_path
     )
   }
   make_with_config(config = config)

--- a/man/drake_config.Rd
+++ b/man/drake_config.Rd
@@ -20,7 +20,7 @@ drake_config(plan = read_drake_plan(),
   lazy_load = "eager", session_info = TRUE, cache_log_file = NULL,
   seed = NULL, caching = c("worker", "master"), keep_going = FALSE,
   session = NULL, imports_only = NULL, pruning_strategy = c("speed",
-  "memory"))
+  "memory"), makefile_path = "Makefile")
 }
 \arguments{
 \item{plan}{workflow plan data frame.
@@ -341,6 +341,12 @@ and keeps in memory everything that will eventually be a
 dependency of a downstream target. This strategy consumes more
 memory, but does more to minimize the number of times data is
 read from storage/disk.}
+
+\item{makefile_path}{Path to the \code{Makefile} for
+\code{make(parallelism = "Makefile")}. If you set this argument to a
+non-default value, you are responsible for supplying this same
+path to the \code{args} argument so \code{make} knows where to find it.
+Example: \code{make(parallelism = "Makefile", makefile_path = ".drake/.makefile", command = "make", args = "--file=.drake/.makefile")} # nolint}
 }
 \value{
 The master internal configuration list of a project.

--- a/man/make.Rd
+++ b/man/make.Rd
@@ -18,7 +18,8 @@ make(plan = read_drake_plan(), targets = drake::possible_targets(plan),
   skip_safety_checks = FALSE, config = NULL, lazy_load = "eager",
   session_info = TRUE, cache_log_file = NULL, seed = NULL,
   caching = "worker", keep_going = FALSE, session = NULL,
-  imports_only = NULL, pruning_strategy = c("speed", "memory"))
+  imports_only = NULL, pruning_strategy = c("speed", "memory"),
+  makefile_path = "Makefile")
 }
 \arguments{
 \item{plan}{workflow plan data frame.
@@ -347,6 +348,12 @@ and keeps in memory everything that will eventually be a
 dependency of a downstream target. This strategy consumes more
 memory, but does more to minimize the number of times data is
 read from storage/disk.}
+
+\item{makefile_path}{Path to the \code{Makefile} for
+\code{make(parallelism = "Makefile")}. If you set this argument to a
+non-default value, you are responsible for supplying this same
+path to the \code{args} argument so \code{make} knows where to find it.
+Example: \code{make(parallelism = "Makefile", makefile_path = ".drake/.makefile", command = "make", args = "--file=.drake/.makefile")} # nolint}
 }
 \value{
 The master internal configuration list, mostly

--- a/vignettes/parallelism.Rmd
+++ b/vignettes/parallelism.Rmd
@@ -33,10 +33,35 @@ load_mtcars_example()
 make(my_plan, jobs = 2)
 ```
 
-To deploy serious long workflows, we recommend putting the call to `make()` in a script (say, `make.R`) and running it in an unobtrusive background process that persists after you log out. In the Linux command line, this is straightforward.
+# Batch mode for long workflows
 
-<pre><code>nohup nice -19 R CMD BATCH make.R &
+To deploy serious long workflows, we recommend putting the call to `make()` in a script (say, `drake_work.R`) and running it in an unobtrusive background process that persists after you log out. In the Linux command line, this is straightforward.
+
+<pre><code>nohup nice -19 R CMD BATCH drake_work.R &
 </code></pre>
+
+Or, you could call `drake` inside an overarching [`Makefile`](https://www.gnu.org/software/make/) that chains multiple stages together in a larger reproducible pipeline. (See [Karl Broman's post](http://kbroman.org/minimal_make/) on [`Makefile`](https://www.gnu.org/software/make/)s for reproducible research.)
+
+<pre><code>all: final_output.pdf
+
+final_output.pdf: python_magic.py results_summary.csv
+    python python_magic.py
+
+results_summary.csv: drake_work.R
+    Rscript drake_work.R
+
+clean:
+    rm -rf .drake
+</code></pre>
+
+Then, run your whole pipleine in a persistent background process.
+
+<pre><code>nohup nice -19 R CMD BATCH make &
+</code></pre>
+
+If you do write a custom [`Makefile`](https://www.gnu.org/software/make/) at the root of your project and you plan to use `make(parallelism = "Makefile")`, please read about `make(parallelism = "Makefile")` later in this document to avoid potential conflicts between your [`Makefile`](https://www.gnu.org/software/make/) and the one `drake` writes.
+
+# Let drake schedule your targets.
 
 When you deploy your project, `drake` uses the dependency network to figure out how to run your work in parallel. You as the user do not have to micromanage when individual targets are built.
 
@@ -45,6 +70,8 @@ src = "https://ropensci.github.io/drake/images/outdated.html"
 width = "100%" height = "600px" allowtransparency="true"
 style="border: none; box-shadow: none">
 </iframe>
+
+# Parallel backends
 
 There are multiple ways to walk this graph and multiple ways to launch workers, and every project has its own needs. Thus, `drake` supports multiple parallel backends. Choose the backend with the `parallelism` argument.
 
@@ -175,6 +202,17 @@ make(
   parallelism = "Makefile",
   command = "lsmake",
   args = c("--touch", "--silent")
+)
+```
+
+If `drake`'s `Makefile` conflicts with a `Makefile` you already wrote yourself, `drake` does not overwrite your `Makefile`. Instead, `make()` tells you about the conflict and then stops running. To force `drake` to use a different `Makefile` that does not conflict with yours, pass the file path to the `makefile_path` argument and set the `--file` argument in `args`.
+
+```{r custommakefilepath, eval = FALSE}
+make(
+  my_plan,
+  parallelism = "Makefile",
+  makefile_path = "my_folder/my_makefile",
+  args = "--file=my_folder/my_makefile"
 )
 ```
 


### PR DESCRIPTION
# Summary

- Detect and avoid conflicts between custom `Makefile`s and ones written by `make(parallelism = "Makefile")`.
- Allow custom `Makefile` paths: `make(parallelism = "Makefile", makefile_path = "my_dir/my_makefile", args = "--file=my_dir/my_makefile")`
- At the top of the `parallelism.Rmd` vignette, document the use of `drake` as one of many steps inside an overarching custom `Makefile`. 
- Document "batch mode" for `drake` in the the `parallelism.Rmd` vignette. After all, this is the intended use for large pipelines.

cc @lorenzwalthert, @rkrug

# Related GitHub issues

- Ref: #397, #398

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
