### PR TITLE
Option to redirect informal console messages to a file

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -36,6 +36,7 @@ vignettes/.*_files
 ^.*\.css$
 ^.*\.js$
 ^.*\.log$
+^.*\.out$
 ^.*\.Rproj$
 ^.*\.svg$
 ^\.Rproj\.user$

--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,7 @@
 - Add optional custom (experimental) "workers" and "priorities" columns to the `drake` plans to help users customize scheduling.
 - Add a `makefile_path` argument to `make()` and `drake_config()` to avoid potential conflicts between user-side custom `Makefile`s and the one written by `make(parallelism = "Makefile")`.
 - Document batch mode for long workflows in the HPC vignette.
+- Add a `console` argument to `make()` and `drake_config()` so users can redirect console output to a file.
 
 # Version 5.1.2
 

--- a/R/cache.R
+++ b/R/cache.R
@@ -79,7 +79,8 @@ get_cache <- function(
   search = TRUE,
   verbose = drake::default_verbose(),
   force = FALSE,
-  fetch_cache = NULL
+  fetch_cache = NULL,
+  console = NULL
 ){
   if (search){
     path <- find_cache(path = path)
@@ -88,7 +89,7 @@ get_cache <- function(
   }
   this_cache(
     path = path, force = force, verbose = verbose,
-    fetch_cache = fetch_cache
+    fetch_cache = fetch_cache, console = console
   )
 }
 
@@ -98,14 +99,11 @@ get_cache <- function(
 #' in-memory caches such as `storr_environment()`.
 #' @return A drake/storr cache at the specified path, if it exists.
 #' @inheritParams cached
+#' @inheritParams config
 #' @param path file path of the cache
 #' @param force logical, whether to load the cache
 #'   despite any back compatibility issues with the
 #'   running version of drake.
-#' @param fetch_cache character vector containing lines of code.
-#'   The purpose of this code is to fetch the `storr` cache
-#'   with a command like [storr_rds()] or [storr_dbi()],
-#'   but customized. This feature is experimental.
 #' @examples
 #' \dontrun{
 #' test_with_dir("Quarantine side effects.", {
@@ -122,14 +120,21 @@ get_cache <- function(
 this_cache <- function(
   path = drake::default_cache_path(), force = FALSE,
   verbose = drake::default_verbose(),
-  fetch_cache = NULL
+  fetch_cache = NULL,
+  console = NULL
 ){
   usual_path_missing <- is.null(path) || !file.exists(path)
   if (usual_path_missing & is.null(fetch_cache)){
     return(NULL)
   }
   if (!is.null(path)){
-    console_cache(path = path, verbose = verbose)
+    console_cache(
+      config = list(
+        cache_path = path,
+        verbose = verbose,
+        console = console
+      )
+    )
   }
   fetch_cache <- as.character(fetch_cache)
   if (length(fetch_cache) && nzchar(fetch_cache)){
@@ -167,6 +172,7 @@ drake_fetch_rds <- function(path){
 #' @export
 #' @return A newly created drake cache as a storr object.
 #' @inheritParams cached
+#' @inheritParams config
 #' @seealso [default_short_hash_algo()],
 #'   [default_long_hash_algo()],
 #'   [make()]
@@ -197,7 +203,8 @@ new_cache <- function(
   type = NULL,
   short_hash_algo = drake::default_short_hash_algo(),
   long_hash_algo = drake::default_long_hash_algo(),
-  ...
+  ...,
+  console = NULL
 ){
   if (!is.null(type)){
     warning(
@@ -220,7 +227,13 @@ new_cache <- function(
     long_hash_algo = long_hash_algo,
     overwrite_hash_algos = FALSE
   )
-  console_cache(path = cache_path(cache), verbose = verbose)
+  console_cache(
+    config = list(
+      cache_path = cache_path(cache),
+      verbose = verbose,
+      console = console
+    )
+  )
   cache
 }
 
@@ -234,6 +247,7 @@ new_cache <- function(
 #' in-memory caches such as [storr_environment()].
 #' @return A drake/storr cache.
 #' @inheritParams cached
+#' @inheritParams config
 #' @param path file path of the cache
 #' @param short_hash_algo short hash algorithm for the cache.
 #'   See [default_short_hash_algo()] and
@@ -244,10 +258,6 @@ new_cache <- function(
 #' @param force logical, whether to load the cache
 #'   despite any back compatibility issues with the
 #'   running version of drake.
-#' @param fetch_cache character vector containing lines of code.
-#'   The purpose of this code is to fetch the `storr` cache
-#'   with a command like [storr_rds()] or [storr_dbi()],
-#'   but customized.
 #' @examples
 #' \dontrun{
 #' test_with_dir("Quarantine side effects.", {
@@ -263,11 +273,12 @@ recover_cache <- function(
   long_hash_algo = drake::default_long_hash_algo(),
   force = FALSE,
   verbose = drake::default_verbose(),
-  fetch_cache = NULL
+  fetch_cache = NULL,
+  console = NULL
 ){
   cache <- this_cache(
     path = path, force = force, verbose = verbose,
-    fetch_cache = fetch_cache
+    fetch_cache = fetch_cache, console = console
   )
   if (is.null(cache)){
     cache <- new_cache(
@@ -275,7 +286,8 @@ recover_cache <- function(
       verbose = verbose,
       short_hash_algo = short_hash_algo,
       long_hash_algo = long_hash_algo,
-      fetch_cache = fetch_cache
+      fetch_cache = fetch_cache,
+      console = console
     )
   }
   cache

--- a/R/cache.R
+++ b/R/cache.R
@@ -99,7 +99,7 @@ get_cache <- function(
 #' in-memory caches such as `storr_environment()`.
 #' @return A drake/storr cache at the specified path, if it exists.
 #' @inheritParams cached
-#' @inheritParams config
+#' @inheritParams drake_config
 #' @param path file path of the cache
 #' @param force logical, whether to load the cache
 #'   despite any back compatibility issues with the
@@ -172,7 +172,7 @@ drake_fetch_rds <- function(path){
 #' @export
 #' @return A newly created drake cache as a storr object.
 #' @inheritParams cached
-#' @inheritParams config
+#' @inheritParams drake_config
 #' @seealso [default_short_hash_algo()],
 #'   [default_long_hash_algo()],
 #'   [make()]
@@ -247,7 +247,7 @@ new_cache <- function(
 #' in-memory caches such as [storr_environment()].
 #' @return A drake/storr cache.
 #' @inheritParams cached
-#' @inheritParams config
+#' @inheritParams drake_config
 #' @param path file path of the cache
 #' @param short_hash_algo short hash algorithm for the cache.
 #'   See [default_short_hash_algo()] and

--- a/R/cache.R
+++ b/R/cache.R
@@ -54,6 +54,7 @@ force_cache_path <- function(cache = NULL){
 #' @return A drake/storr cache in a folder called `.drake/`,
 #'   if available. `NULL` otherwise.
 #' @inheritParams cached
+#' @inheritParams drake_config
 #' @param force logical, whether to load the cache
 #'   despite any back compatibility issues with the
 #'   running version of drake.

--- a/R/config.R
+++ b/R/config.R
@@ -341,6 +341,11 @@
 #'   path to the `args` argument so `make` knows where to find it.
 #'   Example: `make(parallelism = "Makefile", makefile_path = ".drake/.makefile", command = "make", args = "--file=.drake/.makefile")` # nolint
 #'
+#' @param console character scalar or `NULL`. If `console` is `NULL`, console
+#'   output will be printed to the R console using `message()`.
+#'   Otherwise, `console` should be the name of a flat file.
+#'   Console output will be appended to that file.
+#'
 #' @examples
 #' \dontrun{
 #' test_with_dir("Quarantine side effects.", {
@@ -365,7 +370,8 @@ drake_config <- function(
   envir = parent.frame(),
   verbose = drake::default_verbose(),
   hook = default_hook,
-  cache = drake::get_cache(verbose = verbose, force = force),
+  cache = drake::get_cache(
+    verbose = verbose, force = force, console = console),
   fetch_cache = NULL,
   parallelism = drake::default_parallelism(),
   jobs = 1,
@@ -398,7 +404,8 @@ drake_config <- function(
   session = NULL,
   imports_only = NULL,
   pruning_strategy = c("speed", "memory"),
-  makefile_path = "Makefile"
+  makefile_path = "Makefile",
+  console = NULL
 ){
   force(envir)
   if (!is.null(imports_only)){
@@ -417,7 +424,11 @@ drake_config <- function(
   )
   if (is.null(cache)) {
     cache <- recover_cache(
-      force = force, verbose = verbose, fetch_cache = fetch_cache)
+      force = force,
+      verbose = verbose,
+      fetch_cache = fetch_cache,
+      console = console
+    )
   }
   if (!force){
     assert_compatible_cache(cache = cache)
@@ -433,7 +444,7 @@ drake_config <- function(
   if (is.null(graph)){
     graph <- build_drake_graph(plan = plan, targets = targets,
       envir = envir, verbose = verbose, jobs = jobs,
-      sanitize_plan = FALSE)
+      sanitize_plan = FALSE, console = console)
   } else {
     graph <- prune_drake_graph(graph = graph, to = targets, jobs = jobs)
   }
@@ -456,7 +467,7 @@ drake_config <- function(
     cache_log_file = cache_log_file, caching = match.arg(caching),
     evaluator = future::plan("next"), keep_going = keep_going,
     session = session, pruning_strategy = pruning_strategy,
-    makefile_path = makefile_path
+    makefile_path = makefile_path, console = console
   )
 }
 

--- a/R/console.R
+++ b/R/console.R
@@ -67,6 +67,9 @@ console_cache <- function(config){
   if (config$verbose < 2){
     return()
   }
+  if (is.null(config$cache_path)){
+    config$cache_path <- default_cache_path()
+  }
   paste("cache", config$cache_path) %>%
     finish_console(pattern = "cache", config = config)
 }
@@ -170,7 +173,7 @@ finish_console <- function(text, pattern, config){
 }
 
 write_to_console <- function(msg, config){
-  if(is.null(config$console)){
+  if (is.null(config$console)){
     message(msg, sep = "")
   } else {
     write(x = msg, sep = "", file = config$console, append = TRUE)

--- a/R/graph.R
+++ b/R/graph.R
@@ -26,7 +26,8 @@ build_drake_graph <- function(
   envir = parent.frame(),
   verbose = drake::default_verbose(),
   jobs = 1,
-  sanitize_plan = TRUE
+  sanitize_plan = TRUE,
+  console = NULL
 ){
   force(envir)
   if (sanitize_plan){
@@ -42,11 +43,12 @@ build_drake_graph <- function(
   )
   import_names <- setdiff(names(imports), targets)
   imports <- imports[import_names]
+  config <- list(verbose = verbose, console = console)
   console_many_targets(
     targets = names(imports),
     pattern = "connect",
     type = "import",
-    config = list(verbose = verbose)
+    config = config
   )
   imports_edges <- lightly_parallelize(
     X = seq_along(imports),
@@ -59,7 +61,7 @@ build_drake_graph <- function(
     targets = plan$target,
     pattern = "connect",
     type = "target",
-    config = list(verbose = verbose)
+    config = config
   )
   commands_edges <- lightly_parallelize(
     X = seq_len(nrow(plan)),

--- a/R/handlers.R
+++ b/R/handlers.R
@@ -19,7 +19,7 @@ handle_build_exceptions <- function(target, meta, config){
   if (inherits(meta$error, "error")){
     if (config$verbose){
       text <- paste("fail", target)
-      finish_console(text = text, pattern = "fail", verbose = config$verbose)
+      finish_console(text = text, pattern = "fail", config = config)
     }
     store_failure(target = target, meta = meta, config = config)
     if (!config$keep_going){

--- a/R/make.R
+++ b/R/make.R
@@ -75,7 +75,8 @@ make <- function(
   envir = parent.frame(),
   verbose = drake::default_verbose(),
   hook = default_hook,
-  cache = drake::get_cache(verbose = verbose, force = force),
+  cache = drake::get_cache(
+    verbose = verbose, force = force, console = console),
   fetch_cache = NULL,
   parallelism = drake::default_parallelism(),
   jobs = 1,
@@ -110,7 +111,8 @@ make <- function(
   session = NULL,
   imports_only = NULL,
   pruning_strategy = c("speed", "memory"),
-  makefile_path = "Makefile"
+  makefile_path = "Makefile",
+  console = NULL
 ){
   force(envir)
   if (!is.null(return_config)){
@@ -157,7 +159,8 @@ make <- function(
       session = session,
       imports_only = imports_only,
       pruning_strategy = pruning_strategy,
-      makefile_path = makefile_path
+      makefile_path = makefile_path,
+      console = console
     )
   }
   make_with_config(config = config)

--- a/man/build_drake_graph.Rd
+++ b/man/build_drake_graph.Rd
@@ -6,7 +6,8 @@
 \usage{
 build_drake_graph(plan = read_drake_plan(),
   targets = drake::possible_targets(plan), envir = parent.frame(),
-  verbose = drake::default_verbose(), jobs = 1, sanitize_plan = TRUE)
+  verbose = drake::default_verbose(), jobs = 1, sanitize_plan = TRUE,
+  console = NULL)
 }
 \arguments{
 \item{plan}{workflow plan data frame.
@@ -84,6 +85,11 @@ most 4 jobs for targets, run
 \code{make(..., parallelism = "Makefile", jobs = 2, args = "--jobs=4")}.}
 
 \item{sanitize_plan}{logical, whether to sanitize the workflow plan first.}
+
+\item{console}{character scalar or \code{NULL}. If \code{console} is \code{NULL}, console
+output will be printed to the R console using \code{message()}.
+Otherwise, \code{console} should be the name of a flat file.
+Console output will be appended to that file.}
 }
 \value{
 An igraph object representing

--- a/man/drake_config.Rd
+++ b/man/drake_config.Rd
@@ -8,8 +8,8 @@ used internally in \code{\link[=make]{make()}}.}
 drake_config(plan = read_drake_plan(),
   targets = drake::possible_targets(plan), envir = parent.frame(),
   verbose = drake::default_verbose(), hook = default_hook,
-  cache = drake::get_cache(verbose = verbose, force = force),
-  fetch_cache = NULL, parallelism = drake::default_parallelism(),
+  cache = drake::get_cache(verbose = verbose, force = force, console =
+  console), fetch_cache = NULL, parallelism = drake::default_parallelism(),
   jobs = 1, packages = rev(.packages()), prework = character(0),
   prepend = character(0), command = drake::default_Makefile_command(),
   args = drake::default_Makefile_args(jobs = jobs, verbose = verbose),
@@ -20,7 +20,7 @@ drake_config(plan = read_drake_plan(),
   lazy_load = "eager", session_info = TRUE, cache_log_file = NULL,
   seed = NULL, caching = c("worker", "master"), keep_going = FALSE,
   session = NULL, imports_only = NULL, pruning_strategy = c("speed",
-  "memory"), makefile_path = "Makefile")
+  "memory"), makefile_path = "Makefile", console = NULL)
 }
 \arguments{
 \item{plan}{workflow plan data frame.
@@ -347,6 +347,11 @@ read from storage/disk.}
 non-default value, you are responsible for supplying this same
 path to the \code{args} argument so \code{make} knows where to find it.
 Example: \code{make(parallelism = "Makefile", makefile_path = ".drake/.makefile", command = "make", args = "--file=.drake/.makefile")} # nolint}
+
+\item{console}{character scalar or \code{NULL}. If \code{console} is \code{NULL}, console
+output will be printed to the R console using \code{message()}.
+Otherwise, \code{console} should be the name of a flat file.
+Console output will be appended to that file.}
 }
 \value{
 The master internal configuration list of a project.

--- a/man/get_cache.Rd
+++ b/man/get_cache.Rd
@@ -39,6 +39,11 @@ running version of drake.}
 The purpose of this code is to fetch the \code{storr} cache
 with a command like \code{storr_rds()} or \code{storr_dbi()},
 but customized. This feature is experimental.}
+
+\item{console}{character scalar or \code{NULL}. If \code{console} is \code{NULL}, console
+output will be printed to the R console using \code{message()}.
+Otherwise, \code{console} should be the name of a flat file.
+Console output will be appended to that file.}
 }
 \value{
 A drake/storr cache in a folder called \code{.drake/},

--- a/man/get_cache.Rd
+++ b/man/get_cache.Rd
@@ -5,7 +5,8 @@
 \title{Get the drake cache, optionally searching up the file system.}
 \usage{
 get_cache(path = getwd(), search = TRUE,
-  verbose = drake::default_verbose(), force = FALSE, fetch_cache = NULL)
+  verbose = drake::default_verbose(), force = FALSE, fetch_cache = NULL,
+  console = NULL)
 }
 \arguments{
 \item{path}{Root directory of the drake project,

--- a/man/make.Rd
+++ b/man/make.Rd
@@ -7,8 +7,9 @@
 make(plan = read_drake_plan(), targets = drake::possible_targets(plan),
   envir = parent.frame(), verbose = drake::default_verbose(),
   hook = default_hook, cache = drake::get_cache(verbose = verbose, force =
-  force), fetch_cache = NULL, parallelism = drake::default_parallelism(),
-  jobs = 1, packages = rev(.packages()), prework = character(0),
+  force, console = console), fetch_cache = NULL,
+  parallelism = drake::default_parallelism(), jobs = 1,
+  packages = rev(.packages()), prework = character(0),
   prepend = character(0), command = drake::default_Makefile_command(),
   args = drake::default_Makefile_args(jobs = jobs, verbose = verbose),
   recipe_command = drake::default_recipe_command(), log_progress = TRUE,
@@ -19,7 +20,7 @@ make(plan = read_drake_plan(), targets = drake::possible_targets(plan),
   session_info = TRUE, cache_log_file = NULL, seed = NULL,
   caching = "worker", keep_going = FALSE, session = NULL,
   imports_only = NULL, pruning_strategy = c("speed", "memory"),
-  makefile_path = "Makefile")
+  makefile_path = "Makefile", console = NULL)
 }
 \arguments{
 \item{plan}{workflow plan data frame.
@@ -354,6 +355,11 @@ read from storage/disk.}
 non-default value, you are responsible for supplying this same
 path to the \code{args} argument so \code{make} knows where to find it.
 Example: \code{make(parallelism = "Makefile", makefile_path = ".drake/.makefile", command = "make", args = "--file=.drake/.makefile")} # nolint}
+
+\item{console}{character scalar or \code{NULL}. If \code{console} is \code{NULL}, console
+output will be printed to the R console using \code{message()}.
+Otherwise, \code{console} should be the name of a flat file.
+Console output will be appended to that file.}
 }
 \value{
 The master internal configuration list, mostly

--- a/man/new_cache.Rd
+++ b/man/new_cache.Rd
@@ -37,6 +37,11 @@ See \code{\link[=default_long_hash_algo]{default_long_hash_algo()}} and
 \code{\link[=make]{make()}}}
 
 \item{...}{other arguments to the cache constructor}
+
+\item{console}{character scalar or \code{NULL}. If \code{console} is \code{NULL}, console
+output will be printed to the R console using \code{message()}.
+Otherwise, \code{console} should be the name of a flat file.
+Console output will be appended to that file.}
 }
 \value{
 A newly created drake cache as a storr object.

--- a/man/new_cache.Rd
+++ b/man/new_cache.Rd
@@ -7,7 +7,7 @@
 new_cache(path = drake::default_cache_path(),
   verbose = drake::default_verbose(), type = NULL,
   short_hash_algo = drake::default_short_hash_algo(),
-  long_hash_algo = drake::default_long_hash_algo(), ...)
+  long_hash_algo = drake::default_long_hash_algo(), ..., console = NULL)
 }
 \arguments{
 \item{path}{file path to the cache if the cache

--- a/man/recover_cache.Rd
+++ b/man/recover_cache.Rd
@@ -36,6 +36,20 @@ for example, \code{pkgconfig::set_config("drake::verbose" = 2)}.
 \item{3:}{in addition, print any potentially missing items.}
 \item{4:}{in addition, print imports. Full verbosity.}
 }}
+
+\item{fetch_cache}{character vector containing lines of code.
+The purpose of this code is to fetch the \code{storr} cache
+with a command like \code{\link[=storr_rds]{storr_rds()}} or \code{\link[=storr_dbi]{storr_dbi()}},
+but customized. This feature is experimental. It will turn out
+to be necessary if you are using both custom non-RDS caches
+and distributed parallelism (\code{parallelism = "future_lapply"}
+or \code{"Makefile"}) because the distributed R sessions
+need to know how to load the cache.}
+
+\item{console}{character scalar or \code{NULL}. If \code{console} is \code{NULL}, console
+output will be printed to the R console using \code{message()}.
+Otherwise, \code{console} should be the name of a flat file.
+Console output will be appended to that file.}
 }
 \value{
 A drake/storr cache.

--- a/man/recover_cache.Rd
+++ b/man/recover_cache.Rd
@@ -8,7 +8,7 @@ or create a new one otherwise.}
 recover_cache(path = drake::default_cache_path(),
   short_hash_algo = drake::default_short_hash_algo(),
   long_hash_algo = drake::default_long_hash_algo(), force = FALSE,
-  verbose = drake::default_verbose(), fetch_cache = NULL)
+  verbose = drake::default_verbose(), fetch_cache = NULL, console = NULL)
 }
 \arguments{
 \item{path}{file path of the cache}
@@ -36,11 +36,6 @@ for example, \code{pkgconfig::set_config("drake::verbose" = 2)}.
 \item{3:}{in addition, print any potentially missing items.}
 \item{4:}{in addition, print imports. Full verbosity.}
 }}
-
-\item{fetch_cache}{character vector containing lines of code.
-The purpose of this code is to fetch the \code{storr} cache
-with a command like \code{\link[=storr_rds]{storr_rds()}} or \code{\link[=storr_dbi]{storr_dbi()}},
-but customized.}
 }
 \value{
 A drake/storr cache.

--- a/man/this_cache.Rd
+++ b/man/this_cache.Rd
@@ -5,7 +5,7 @@
 \title{Get the cache at the exact file path specified.}
 \usage{
 this_cache(path = drake::default_cache_path(), force = FALSE,
-  verbose = drake::default_verbose(), fetch_cache = NULL)
+  verbose = drake::default_verbose(), fetch_cache = NULL, console = NULL)
 }
 \arguments{
 \item{path}{file path of the cache}
@@ -25,11 +25,6 @@ for example, \code{pkgconfig::set_config("drake::verbose" = 2)}.
 \item{3:}{in addition, print any potentially missing items.}
 \item{4:}{in addition, print imports. Full verbosity.}
 }}
-
-\item{fetch_cache}{character vector containing lines of code.
-The purpose of this code is to fetch the \code{storr} cache
-with a command like \code{\link[=storr_rds]{storr_rds()}} or \code{\link[=storr_dbi]{storr_dbi()}},
-but customized. This feature is experimental.}
 }
 \value{
 A drake/storr cache at the specified path, if it exists.

--- a/man/this_cache.Rd
+++ b/man/this_cache.Rd
@@ -25,6 +25,20 @@ for example, \code{pkgconfig::set_config("drake::verbose" = 2)}.
 \item{3:}{in addition, print any potentially missing items.}
 \item{4:}{in addition, print imports. Full verbosity.}
 }}
+
+\item{fetch_cache}{character vector containing lines of code.
+The purpose of this code is to fetch the \code{storr} cache
+with a command like \code{\link[=storr_rds]{storr_rds()}} or \code{\link[=storr_dbi]{storr_dbi()}},
+but customized. This feature is experimental. It will turn out
+to be necessary if you are using both custom non-RDS caches
+and distributed parallelism (\code{parallelism = "future_lapply"}
+or \code{"Makefile"}) because the distributed R sessions
+need to know how to load the cache.}
+
+\item{console}{character scalar or \code{NULL}. If \code{console} is \code{NULL}, console
+output will be printed to the R console using \code{message()}.
+Otherwise, \code{console} should be the name of a flat file.
+Console output will be appended to that file.}
 }
 \value{
 A drake/storr cache at the specified path, if it exists.

--- a/tests/testthat/test-console.R
+++ b/tests/testthat/test-console.R
@@ -132,3 +132,27 @@ test_with_dir("console_skip", {
   con$verbose <- 4
   expect_message(console_skip(file_store("bla"), con))
 })
+
+test_with_dir("console to file", {
+  load_mtcars_example()
+  cache <- storr::storr_environment()
+  expect_error(readLines("log.txt"))
+  tmp <- capture.output({
+      make(
+        my_plan, cache = cache, verbose = 4, session_info = FALSE,
+        console = "log.txt"
+      )
+      make(
+        my_plan, cache = cache, verbose = 4, session_info = FALSE,
+        console = "log.txt"
+      )
+      make(
+        my_plan, cache = cache, verbose = 4, session_info = FALSE,
+        trigger = "always", console = "log.txt"
+      )
+    },
+    type = "message"
+  )
+  expect_equal(tmp, character(0))
+  expect_true(length(readLines("log.txt")) > 0)
+})

--- a/tests/testthat/test-console.R
+++ b/tests/testthat/test-console.R
@@ -1,10 +1,12 @@
 drake_context("console")
 
 test_with_dir("console_cache", {
-  expect_silent(console_cache("12345", verbose = TRUE))
-  expect_message(console_cache("12345", verbose = 2))
-  expect_silent(console_cache(NULL, verbose = TRUE))
-  expect_message(console_cache(NULL, verbose = 2))
+  expect_silent(
+    console_cache(config = list(cache_path = "123", verbose = TRUE)))
+  expect_message(
+    console_cache(config = list(cache_path = "123", verbose = 2)))
+  expect_silent(console_cache(config = list(verbose = TRUE)))
+  expect_message(console_cache(config = list(verbose = 2)))
 })
 
 test_with_dir("console_up_to_date", {
@@ -136,7 +138,7 @@ test_with_dir("console_skip", {
 test_with_dir("console to file", {
   load_mtcars_example()
   cache <- storr::storr_environment()
-  expect_error(readLines("log.txt"))
+  expect_false(file.exists("log.txt"))
   tmp <- capture.output({
       make(
         my_plan, cache = cache, verbose = 4, session_info = FALSE,


### PR DESCRIPTION
# Summary

If `verbose` is `> 0`, `make()` outputs progress `message()`s to the console.

```r
make(my_plan)
#> target large
#> target small
#> ...
```

In this PR, `make(console = "log.txt")` appends these messages to the file `"log.txt"`. That way, users can just inspect a log file instead of polling `progress()`, and we avoid the issues described in https://github.com/HenrikBengtsson/future/issues/171#issuecomment-339442682.

Note: if you want to suppress color coding characters, you will need to call `options(crayon.enabled = FALSE)` in your session and possibly `make(prework = "options(crayon.enabled = FALSE)")`.

cc @lorenzwalthert

# Related GitHub issues

- Ref: #400

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
