### PR TITLE
Lock storr namespaces when setting worker status

### DIFF
--- a/R/cache.R
+++ b/R/cache.R
@@ -452,11 +452,11 @@ is_default_cache <- function(cache){
 }
 
 safe_get <- function(key, namespace, config){
-  if (config$cache$exists(key = key, namespace = namespace)){
-    config$cache$get(key = key, namespace = namespace)
-  } else {
-    NA
+  out <- just_try(config$cache$get(key = key, namespace = namespace))
+  if (inherits(out, "try-error")){
+    out <- NA
   }
+  out
 }
 
 kernel_exists <- function(target, config){

--- a/R/future.R
+++ b/R/future.R
@@ -175,7 +175,6 @@ running_targets <- function(workers, config){
 }
 
 initialize_workers <- function(config){
-  config$cache$clear(namespace = "workers")
   out <- list()
   for (i in seq_len(config$jobs))
     out[[i]] <- empty_worker(target = NA)

--- a/R/handlers.R
+++ b/R/handlers.R
@@ -65,3 +65,8 @@ error_process <- function(e, id, config){
   config$cache$set(key = id, value = e, namespace = "mc_fail")
   drake_error("make() failed.", config = config)
 }
+
+# Should be used as sparingly as possible.
+just_try <- function(code){
+  try(suppressWarnings(code), silent = TRUE)
+}

--- a/R/mclapply.R
+++ b/R/mclapply.R
@@ -255,7 +255,7 @@ mc_with_lock <- function(code, worker, config){
   force(code)
 }
 
-mc_wait <- 1e-6
+mc_wait <- 1e-9
 
 warn_mclapply_windows <- function(
   parallelism,

--- a/R/mclapply.R
+++ b/R/mclapply.R
@@ -152,6 +152,7 @@ mc_get <- function(worker, namespace, config){
   out <- NA
   while (is.na(out)){
     out <- safe_get(key = worker, namespace = namespace, config = config)
+    Sys.sleep(mc_wait)
   }
   out
 }
@@ -246,7 +247,7 @@ mc_set_done_all <- function(config){
 }
 
 mc_with_lock <- function(code, worker, config){
-  on.exit(config$cache$del(key = worker, namespace = "mc_lock"))
+  on.exit(just_try(config$cache$del(key = worker, namespace = "mc_lock")))
   while (config$cache$exists(key = worker, namespace = "mc_lock")){
     Sys.sleep(mc_wait)
   }

--- a/R/mclapply.R
+++ b/R/mclapply.R
@@ -133,7 +133,12 @@ mc_conclude_target <- function(worker, config){
   ) %>%
     intersect(y = config$queue$list())
   config$queue$decrease_key(targets = revdeps)
-  if (target %in% config$plan$target){
+  if (
+    identical(
+      get_progress_single(target = target, cache = config$cache),
+      "finished"
+    ) && target %in% config$plan$target
+  ){
     set_attempt_flag(key = worker, config = config)
   }
   mc_set_target(worker = worker, target = NA, config = config)


### PR DESCRIPTION
# Summary

This PR is an attempt to make message-passing from the master to the workers safer. It is simply a set of precautions, I have not actually encountered race conditions in real projects with parallel computing.

The real solution is a serious thread safe [message queue](https://en.wikipedia.org/wiki/Message_queue), but finding one will take some time.

# Related GitHub issues

- Ref: #369

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
