### PR TITLE
Ensure workers before assigning them targets

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -477,7 +477,8 @@ drake_config <- function(
     cache_log_file = cache_log_file, caching = match.arg(caching),
     evaluator = future::plan("next"), keep_going = keep_going,
     session = session, pruning_strategy = pruning_strategy,
-    makefile_path = makefile_path, console = console
+    makefile_path = makefile_path, console = console,
+    ensure_workers = ensure_workers
   )
 }
 

--- a/R/config.R
+++ b/R/config.R
@@ -345,6 +345,15 @@
 #'   Otherwise, `console` should be the name of a flat file.
 #'   Console output will be appended to that file.
 #'
+#' @param ensure_workers logical, whether the master process
+#'   should wait for the workers to post before assigning them
+#'   targets. Should usually be `TRUE`. Set to `FALSE`
+#'   for `make(parallelism = "future_lapply", jobs = n)`
+#'   (`n > 1`) when combined with `future::plan(future::sequential)`. 
+#'   This argument only applies to parallel computing with persistent workers
+#'   (`make(parallelism = x)`, where `x` could be `"mclapply"`,
+#'   `"parLapply"`, or `"future_lapply"`).
+#'
 #' @examples
 #' \dontrun{
 #' test_with_dir("Quarantine side effects.", {
@@ -404,7 +413,8 @@ drake_config <- function(
   imports_only = NULL,
   pruning_strategy = c("speed", "memory"),
   makefile_path = "Makefile",
-  console = NULL
+  console = NULL,
+  ensure_workers = TRUE
 ){
   force(envir)
   if (!is.null(imports_only)){

--- a/R/make.R
+++ b/R/make.R
@@ -112,7 +112,8 @@ make <- function(
   imports_only = NULL,
   pruning_strategy = c("speed", "memory"),
   makefile_path = "Makefile",
-  console = NULL
+  console = NULL,
+  ensure_workers = TRUE
 ){
   force(envir)
   if (!is.null(return_config)){
@@ -160,7 +161,8 @@ make <- function(
       imports_only = imports_only,
       pruning_strategy = pruning_strategy,
       makefile_path = makefile_path,
-      console = console
+      console = console,
+      ensure_workers = ensure_workers
     )
   }
   make_with_config(config = config)

--- a/R/mc_utils.R
+++ b/R/mc_utils.R
@@ -28,6 +28,19 @@ mc_init_worker_cache <- function(config){
   invisible()
 }
 
+mc_ensure_workers <- function(config){
+  paths <- vapply(
+    X = config$cache$list(namespace = "mc_ready_db"),
+    FUN = function(worker){
+      config$cache$get(key = worker, namespace = "mc_ready_db")
+    },
+    FUN.VALUE = character(1)
+  )
+  while (!all(file.exists(paths))){
+    Sys.sleep(mc_wait) # nocov
+  }
+}
+
 mc_refresh_queue_lists <- function(config){
   for (namespace in c("mc_ready_db", "mc_done_db")){
     field <- gsub("db$", "queues", namespace)

--- a/R/mclapply.R
+++ b/R/mclapply.R
@@ -57,6 +57,9 @@ mc_process <- function(id, config){
 mc_master <- function(config){
   on.exit(mc_conclude_workers(config))
   config$queue <- new_priority_queue(config = config)
+  if (!isFALSE(config$ensure_workers)){
+    mc_ensure_workers(config)
+  }
   while (!config$queue$empty()){
     config <- mc_refresh_queue_lists(config)
     mc_conclude_done_targets(config)

--- a/man/drake_config.Rd
+++ b/man/drake_config.Rd
@@ -20,7 +20,8 @@ drake_config(plan = read_drake_plan(),
   lazy_load = "eager", session_info = TRUE, cache_log_file = NULL,
   seed = NULL, caching = c("worker", "master"), keep_going = FALSE,
   session = NULL, imports_only = NULL, pruning_strategy = c("speed",
-  "memory"), makefile_path = "Makefile", console = NULL)
+  "memory"), makefile_path = "Makefile", console = NULL,
+  ensure_workers = TRUE)
 }
 \arguments{
 \item{plan}{workflow plan data frame.
@@ -351,6 +352,15 @@ Example: \code{make(parallelism = "Makefile", makefile_path = ".drake/.makefile"
 output will be printed to the R console using \code{message()}.
 Otherwise, \code{console} should be the name of a flat file.
 Console output will be appended to that file.}
+
+\item{ensure_workers}{logical, whether the master process
+should wait for the workers to post before assigning them
+targets. Should usually be \code{TRUE}. Set to \code{FALSE}
+for \code{make(parallelism = "future_lapply", jobs = n)}
+(\code{n > 1}) when combined with \code{future::plan(future::sequential)}.
+This argument only applies to parallel computing with persistent workers
+(\code{make(parallelism = x)}, where \code{x} could be \code{"mclapply"},
+\code{"parLapply"}, or \code{"future_lapply"}).}
 }
 \value{
 The master internal configuration list of a project.

--- a/man/make.Rd
+++ b/man/make.Rd
@@ -20,7 +20,7 @@ make(plan = read_drake_plan(), targets = drake::possible_targets(plan),
   session_info = TRUE, cache_log_file = NULL, seed = NULL,
   caching = "worker", keep_going = FALSE, session = NULL,
   imports_only = NULL, pruning_strategy = c("speed", "memory"),
-  makefile_path = "Makefile", console = NULL)
+  makefile_path = "Makefile", console = NULL, ensure_workers = TRUE)
 }
 \arguments{
 \item{plan}{workflow plan data frame.
@@ -359,6 +359,15 @@ Example: \code{make(parallelism = "Makefile", makefile_path = ".drake/.makefile"
 output will be printed to the R console using \code{message()}.
 Otherwise, \code{console} should be the name of a flat file.
 Console output will be appended to that file.}
+
+\item{ensure_workers}{logical, whether the master process
+should wait for the workers to post before assigning them
+targets. Should usually be \code{TRUE}. Set to \code{FALSE}
+for \code{make(parallelism = "future_lapply", jobs = n)}
+(\code{n > 1}) when combined with \code{future::plan(future::sequential)}.
+This argument only applies to parallel computing with persistent workers
+(\code{make(parallelism = x)}, where \code{x} could be \code{"mclapply"},
+\code{"parLapply"}, or \code{"future_lapply"}).}
 }
 \value{
 The master internal configuration list, mostly

--- a/tests/testthat/test-future.R
+++ b/tests/testthat/test-future.R
@@ -46,7 +46,8 @@ test_with_dir("future package functionality", {
     caching = caching[3],
     jobs = c(imports = 1, targets = 2),
     verbose = FALSE,
-    session_info = FALSE
+    session_info = FALSE,
+    ensure_workers = FALSE
   )
 })
 

--- a/tests/testthat/test-parallel.R
+++ b/tests/testthat/test-parallel.R
@@ -177,3 +177,14 @@ test_with_dir("null cases for message queues", {
   expect_null(config$mc_done_queues)
   expect_null(mc_assign_ready_targets(config))
 })
+
+test_with_dir("ensure_workers can be disabled", {
+  load_mtcars_example()
+  future::plan(future::sequential)
+  make(
+    my_plan, jobs = 2, parallelism = "future_lapply",
+    session_info = FALSE, ensure_workers = FALSE
+  )
+  config <- drake_config(my_plan)
+  expect_equal(outdated(config), character(0))
+})

--- a/tests/testthat/test-parallel.R
+++ b/tests/testthat/test-parallel.R
@@ -181,10 +181,13 @@ test_with_dir("null cases for message queues", {
 test_with_dir("ensure_workers can be disabled", {
   load_mtcars_example()
   future::plan(future::sequential)
+  config <- drake_config(my_plan)
+  make(my_plan, skip_targets = TRUE)
+  expect_true(length(outdated(config)) >= nrow(my_plan))
   make(
-    my_plan, jobs = 2, parallelism = "future_lapply",
+    my_plan, jobs = 2, skip_imports = TRUE,
+    parallelism = "future_lapply",
     session_info = FALSE, ensure_workers = FALSE
   )
-  config <- drake_config(my_plan)
   expect_equal(outdated(config), character(0))
 })


### PR DESCRIPTION
# Summary

`make(ensure_workers = TRUE)` requires the master to wait for all the workers to post before assigning them targets. `ensure_workers` should be `TRUE` most of the time. However, it needs to be set to `FALSE` for `future`-related situations like the one below.

```r
future::plan(future::sequential)
make(plan, jobs = 2, ensure_workers = FALSE)
```

Here, only one worker runs at a time.

# Related GitHub issues

- Ref: #409 

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
