### PR TITLE
Increase the occupancy of persistent workers

### DIFF
--- a/R/mc_utils.R
+++ b/R/mc_utils.R
@@ -74,10 +74,12 @@ mc_assign_ready_targets <- function(config){
   if (!length(config$mc_ready_queues)){
     return()
   }
-  while (!is.null(target <- config$queue$peek0())){
+  for (target in config$queue$list0()){
     queue <- mc_preferred_queue(target = target, config = config)
-    queue$push(title = target, message = "target")
-    config$queue$pop0()
+    if (!is.null(queue)){
+      queue$push(title = target, message = "target")
+      config$queue$remove(target = target)
+    }
   }
 }
 
@@ -96,14 +98,12 @@ mc_preferred_queue <- function(target, config){
       )
     }
   }
-  backlog <- vapply(
-    config$mc_ready_queues,
-    function(queue){
-      queue$count()
-    },
-    FUN.VALUE = integer(1)
-  )
-  config$mc_ready_queues[[which.min(backlog)]]
+  for (queue in config$mc_ready_queues){
+    if (queue$empty()){
+      return(queue)
+    }
+  }
+  return(NULL)
 }
 
 mc_conclude_done_targets <- function(config){

--- a/R/mc_utils.R
+++ b/R/mc_utils.R
@@ -41,6 +41,20 @@ mc_ensure_workers <- function(config){
   }
 }
 
+mc_work_remains <- function(config){
+  if (config$queue$empty()){
+    return(FALSE)
+  }
+  backlog <- vapply(
+    config$mc_ready_queues,
+    function(queue){
+      queue$count()
+    },
+    FUN.VALUE = integer(1)
+  )
+  any(backlog > 0)
+}
+
 mc_refresh_queue_lists <- function(config){
   for (namespace in c("mc_ready_db", "mc_done_db")){
     field <- gsub("db$", "queues", namespace)

--- a/R/mc_utils.R
+++ b/R/mc_utils.R
@@ -42,8 +42,8 @@ mc_ensure_workers <- function(config){
 }
 
 mc_work_remains <- function(config){
-  if (config$queue$empty()){
-    return(FALSE)
+  if (!config$queue$empty()){
+    return(TRUE)
   }
   backlog <- vapply(
     config$mc_ready_queues,

--- a/R/mc_utils.R
+++ b/R/mc_utils.R
@@ -78,7 +78,7 @@ mc_assign_ready_targets <- function(config){
     queue <- mc_preferred_queue(target = target, config = config)
     if (!is.null(queue)){
       queue$push(title = target, message = "target")
-      config$queue$remove(target = target)
+      config$queue$remove(targets = target)
     }
   }
 }

--- a/R/mclapply.R
+++ b/R/mclapply.R
@@ -72,23 +72,20 @@ mc_worker <- function(worker, config){
   ready_queue <- mc_get_ready_queue(worker, config)
   done_queue <- mc_get_done_queue(worker, config)
   while (TRUE){
-    while (nrow(messages <- ready_queue$pop(-1)) < 1){
+    while (nrow(msg <- ready_queue$pop()) < 1){
       Sys.sleep(mc_wait)
     }
-    for (i in seq_len(nrow(messages))){
-      msg <- messages[i, ]
-      if (identical(msg$message, "done")){
-        return()
-      }
-      target <- msg$title
-      build_check_store(
-        target = target,
-        config = config,
-        downstream = config$cache$list(namespace = "mc_protect"),
-        flag_attempt = TRUE
-      )
-      done_queue$push(title = target, message = "target")
+    if (identical(msg$message, "done")){
+      return()
     }
+    target <- msg$title
+    build_check_store(
+      target = target,
+      config = config,
+      downstream = config$cache$list(namespace = "mc_protect"),
+      flag_attempt = TRUE
+    )
+    done_queue$push(title = target, message = "target")
   }
 }
 

--- a/R/mclapply.R
+++ b/R/mclapply.R
@@ -60,7 +60,7 @@ mc_master <- function(config){
   if (!isFALSE(config$ensure_workers)){
     mc_ensure_workers(config)
   }
-  while (!config$queue$empty()){
+  while (mc_work_remains(config)){
     config <- mc_refresh_queue_lists(config)
     mc_conclude_done_targets(config)
     mc_assign_ready_targets(config)

--- a/R/priority_queue.R
+++ b/R/priority_queue.R
@@ -95,6 +95,16 @@ R6_priority_queue <- R6::R6Class(
         out
       }
     },
+    # Get all the ready targets
+    list0 = function(){
+      if (!self$empty() && self$data$ndeps[1] < 1){
+        self$data$target[self$data$ndeps < 1]
+      }
+    },
+    remove = function(targets){
+      self$data <- self$data[!(self$data$target %in% targets), ]
+      invisible()
+    },
     # This is all wrong and inefficient.
     # Needs the actual decrease-key algorithm
     decrease_key = function(targets){

--- a/tests/testthat/test-always-skipped.R
+++ b/tests/testthat/test-always-skipped.R
@@ -1,0 +1,31 @@
+drake_context("always skipped")
+
+# A more convenient master switch than testthat::skip():
+if (FALSE){
+
+test_with_dir("make() uses the worker column of the plan", {
+  future::plan(future::sequential)
+  envir <- new.env(parent = globalenv())
+  load_mtcars_example(envir = envir)
+  my_plan <- envir$my_plan
+  my_plan$priority <- seq_len(nrow(my_plan))
+  my_plan$worker <- 2
+  my_plan$worker[grepl("small", my_plan$target)] <- 4
+  make(my_plan, envir = envir, jobs = 4, verbose = 4,
+       session_info = FALSE, pruning_strategy = "memory")
+  expect_true(file_store("report.md") %in% cached())
+  q1 <- txtq::txtq(file.path(".drake", "workers", "worker_1_ready"))
+  q2 <- txtq::txtq(file.path(".drake", "workers", "worker_2_ready"))
+  q3 <- txtq::txtq(file.path(".drake", "workers", "worker_3_ready"))
+  q4 <- txtq::txtq(file.path(".drake", "workers", "worker_4_ready"))
+  expect_false(any(q1$log() %in% my_plan$target))
+  expect_false(any(q3$log() %in% my_plan$target))
+  expect_false(any(grepl("small", q2$log()$title)))
+  expect_true(any(grepl("small", q4$log()$title)))
+  expect_false(length(intersect(q1$log()$title, my_plan$target)) > 1)
+  expect_true(length(intersect(q2$log()$title, my_plan$target)) > 1)
+  expect_false(length(intersect(q3$log()$title, my_plan$target)) > 1)
+  expect_true(length(intersect(q4$log()$title, my_plan$target)) > 1)
+})
+
+} # For skipping all tests in this file.

--- a/tests/testthat/test-parallel.R
+++ b/tests/testthat/test-parallel.R
@@ -42,6 +42,7 @@ test_with_dir("targets_setting()", {
   expect_equal(targets_setting(c(imports = 8, targets = 12)), 12)
 })
 
+
 test_with_dir("parallelism not found for testrun()", {
   config <- list(parallelism = "not found", verbose = FALSE)
   suppressWarnings(expect_error(testrun(config)))
@@ -149,18 +150,6 @@ test_with_dir("lightly_parallelize_atomic() is correct", {
     y <- gsub("_text", "", unlist(out1))
     expect_identical(x, y)
   })
-})
-
-test_with_dir("worker & priority cols don't generate overt problems", {
-  future::plan(future::sequential)
-  envir <- new.env(parent = globalenv())
-  load_mtcars_example(envir = envir)
-  my_plan <- envir$my_plan
-  my_plan$priority <- seq_len(nrow(my_plan))
-  my_plan$worker <- 1
-  make(my_plan, envir = envir, parallelism = "future_lapply",
-       session_info = FALSE, pruning_strategy = "memory")
-  expect_true(file_store("report.md") %in% cached())
 })
 
 test_with_dir("preferred queue may not be there", {

--- a/tests/testthat/test-priority-queue.R
+++ b/tests/testthat/test-priority-queue.R
@@ -48,6 +48,7 @@ test_with_dir("the priority queue works", {
   )
   expect_equal(x$data, y)
   expect_equal(x$peek0(), "spren")
+  expect_equal(sort(x$list0()), sort(c("bar", "spren")))
   expect_equal(x$data, y)
   expect_equal(x$pop0(), "spren")
   expect_equal(x$peek0(), "bar")
@@ -85,6 +86,17 @@ test_with_dir("the priority queue works", {
   expect_null(x$peek0())
   expect_null(x$pop0())
   expect_equal(x$data, y[-1:-2, ])
+
+  expect_null(x$list0())
+  z <- y[-1:-2, ]
+  expect_true(all(c("soup", "Bob") %in% x$data$target))
+  expect_equal(nrow(x$data), 6)
+  x$remove(c("soup", "Bob"))
+  expect_false(all(c("soup", "Bob") %in% x$data$target))
+  expect_equal(nrow(x$data), 4)
+  expect_equal(x$data, z[-4:-5, ])
+  x$remove(c("soup", "Bob"))
+  expect_equal(x$data, z[-4:-5, ])
 })
 
 test_with_dir("queues with priorities", {


### PR DESCRIPTION
# Summary

Wait as long as possible to assign targets to workers, and then assign only to idle workers. This increases occupancy and reduces backlog without having to do anything fancy. This PR also extends `drake`'s priority queue to make this happen. All existing features remain in tact. Just need to finish a little testing on a couple real projects.

# Related GitHub issues

- Ref: #414

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [ ] I think this pull request is ready to merge.
