### PR TITLE
Some of the final steps before next CRAN submission

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -94,14 +94,11 @@ Suggests:
   abind,
   callr,
   DBI,
-  future.batchtools,
   MASS,
   methods,
   RSQLite,
   rmarkdown,
   tidyr
-Remotes:
-  wlandau/txtq
 VignetteBuilder: knitr
 Encoding: UTF-8
 RoxygenNote: 6.0.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Description: A general-purpose computational engine for data analysis,
   to practical examples and more, is available at the reference website
   (https://ropensci.github.io/drake/) and the online manual
   (https://ropenscilabs.github.io/drake-manual/).
-Version: 5.1.3.9001
+Version: 5.2.0
 License: GPL-3
 URL: https://github.com/ropensci/drake
 BugReports: https://github.com/ropensci/drake/issues

--- a/R/attempt.R
+++ b/R/attempt.R
@@ -8,7 +8,11 @@ get_attempt_flag <- function(config){
 
 # Allows different keys for thread safety.
 set_attempt_flag <- function(key = "_attempt", config){
-  config$cache$set(
-    key = as.character(key), value = TRUE, namespace = "attempt")
+  config$cache$duplicate(
+    key_src = "TRUE",
+    key_dest = as.character(key),
+    namespace_src = "common",
+    namespace_dest = "attempt"
+  )
   invisible()
 }

--- a/R/cache.R
+++ b/R/cache.R
@@ -484,6 +484,14 @@ safe_get <- function(key, namespace, config){
   out
 }
 
+safe_get_hash <- function(key, namespace, config){
+  out <- just_try(config$cache$get_hash(key = key, namespace = namespace))
+  if (inherits(out, "try-error")){
+    out <- NA
+  }
+  out
+}
+
 kernel_exists <- function(target, config){
   config$cache$exists(key = target, namespace = "kernels")
 }

--- a/R/cache.R
+++ b/R/cache.R
@@ -415,10 +415,7 @@ configure_cache <- function(
 # Pre-set the values to avoid https://github.com/richfitz/storr/issues/80.
 init_common_values <- function(cache){
   set_initial_drake_version(cache)
-  common_values <- list(
-    TRUE, FALSE, "finished", "in progress", "failed",
-    "not ready", "ready", "running", "idle", "done"
-  )
+  common_values <- list(TRUE, FALSE, "finished", "in progress", "failed")
   cache$mset(
     key = as.character(common_values),
     value = common_values,

--- a/R/future_lapply.R
+++ b/R/future_lapply.R
@@ -50,27 +50,3 @@ fl_worker <- function(worker, cache_path){
     }
   )
 }
-
-warn_future_lapply <- function(config){
-  if (!("future_lapply" %in% config$parallelism)){
-    return()
-  }
-  if (inherits(future::plan(), "batchtools")){
-    drake_warning(
-      "a batchtools-powered future::plan() and ",
-      "\"future_lapply\" parallelism are selected together.\n",
-      "For these settings, file latency issues ",
-      "among the nodes of your computing cluster ",
-      "could undermine the integrity of the results.\n",
-      "Also, the future_lapply()-style ",
-      "persistent workers could terminate early ",
-      "if your cluster has strict wall time limits.\n",
-      "Either continue at your own risk ",
-      "or select make(parallelism = \"future\") instead.\n",
-      "For more information, please visit ",
-      "https://github.com/ropensci/drake/issues/416 and ",
-      "https://github.com/ropensci/drake/issues/417",
-      config = config
-    )
-  }
-}

--- a/R/make.R
+++ b/R/make.R
@@ -352,6 +352,7 @@ make_imports_targets <- function(config){
 }
 
 initialize_session <- function(config){
+  init_common_values(config$cache)
   if (config$log_progress){
     clear_tmp_namespace(
       cache = config$cache,

--- a/R/mc_utils.R
+++ b/R/mc_utils.R
@@ -183,7 +183,7 @@ mc_is_good_checksum <- function(target, checksum, config){
   }
   all(
     vapply(
-      X = unlist(strsplit(stamp, " "))[1:3],
+      X = unlist(strsplit(stamp, " "))[1:3], # Exclude attempt flag (often NA).
       config$cache$exists_object,
       FUN.VALUE = logical(1)
     )

--- a/R/mc_utils.R
+++ b/R/mc_utils.R
@@ -171,6 +171,7 @@ mc_get_checksum <- function(target, config){
     ),
     safe_get_hash(key = target, namespace = "kernels", config = config),
     safe_get_hash(key = target, namespace = "meta", config = config),
+    safe_get_hash(key = target, namespace = "attempt", config = config),
     sep = " "
   )
 }
@@ -182,8 +183,8 @@ mc_is_good_checksum <- function(target, checksum, config){
   }
   all(
     vapply(
-      X = unlist(strsplit(stamp, " ")),
-      FUN = config$cache$exists_object,
+      X = unlist(strsplit(stamp, " "))[1:3],
+      config$cache$exists_object,
       FUN.VALUE = logical(1)
     )
   )

--- a/R/mc_utils.R
+++ b/R/mc_utils.R
@@ -108,15 +108,8 @@ mc_preferred_queue <- function(target, config){
 
 mc_conclude_done_targets <- function(config){
   for (queue in config$mc_done_queues){
-    while (nrow(messages <- queue$pop(-1)) > 0){
-      for (i in seq_len(nrow(messages))){
-        msg <- messages[i, ]
-        if (identical(msg$message, "target")){
-          mc_conclude_target(target = msg$title, config = config)
-        } else {
-          drake_error("illegal message type in the done queue", config = config) # nocov # nolint
-        }
-      }
+    while (nrow(msg <- queue$pop(1)) > 0){
+      mc_conclude_target(target = msg$title, config = config)
     }
   }
 }

--- a/R/mc_utils.R
+++ b/R/mc_utils.R
@@ -194,7 +194,7 @@ mc_wait_checksum <- function(target, checksum, config, timeout = 300){
   i <- 0
   while (i < timeout / interval){
     if (mc_is_good_checksum(target, checksum, config)){
-      return();
+      return()
     } else {
       Sys.sleep(interval)
     }

--- a/R/mc_utils.R
+++ b/R/mc_utils.R
@@ -190,13 +190,21 @@ mc_is_good_checksum <- function(target, checksum, config){
 }
 
 mc_wait_checksum <- function(target, checksum, config, timeout = 300){
-  R.utils::withTimeout(
-    while (!mc_is_good_checksum(target, checksum, config)){
-      Sys.sleep(mc_wait)
-    },
-    timeout = timeout
+  interval <- 0.01 # Should be longer than mc_wait.
+  i <- 0
+  while (i < timeout / interval){
+    if (mc_is_good_checksum(target, checksum, config)){
+      return();
+    } else {
+      Sys.sleep(interval)
+    }
+    i <- i + 1
+  }
+  drake_error(
+    "Target `", target, "` did not download from your ",
+    "network file system. Checksum verification timed out after about ",
+    timeout, " seconds.", config = config
   )
-  invisible()
 }
 
 mc_wait <- 1e-9

--- a/R/mclapply.R
+++ b/R/mclapply.R
@@ -87,7 +87,8 @@ mc_worker <- function(worker, config){
       flag_attempt = TRUE
     )
     ready_queue$pop(1)
-    done_queue$push(title = target, message = "target")
+    message <- mc_get_checksum(target = target, config = config)
+    done_queue$push(title = target, message = message)
   }
 }
 

--- a/R/parallel.R
+++ b/R/parallel.R
@@ -71,5 +71,4 @@ parallelism_warnings <- function(config){
     jobs = config$jobs,
     os = this_os()
   )
-  warn_future_lapply(config)
 }

--- a/R/predict_runtime.R
+++ b/R/predict_runtime.R
@@ -288,7 +288,7 @@ balance_load <- function(config, jobs){
   while (TRUE){
     # Run one iteration of mc_master()
     config <- mc_refresh_queue_lists(config)
-    mc_conclude_done_targets(config)
+    mc_conclude_done_targets(config, wait_for_checksums = FALSE)
     mc_assign_ready_targets(config)
     # List the running targets and their runtimes
     current_targets <- vapply(

--- a/tests/testthat/test-future.R
+++ b/tests/testthat/test-future.R
@@ -86,13 +86,3 @@ test_with_dir("can gracefully conclude a crashed worker", {
     clean(destroy = TRUE)
   }
 })
-
-test_with_dir("warning: future_lapply + batchtools", {
-  config <- drake_config(
-    drake_plan(x = 1), session_info = FALSE, verbose = FALSE)
-  config$parallelism <- "future_lapply"
-  future::plan(future::sequential)
-  expect_silent(tmp <- check_drake_config(config = config))
-  future::plan(future.batchtools::batchtools_local)
-  expect_warning(check_drake_config(config = config), regexp = "batchtools")
-})

--- a/tests/testthat/test-parallel.R
+++ b/tests/testthat/test-parallel.R
@@ -189,12 +189,9 @@ test_with_dir("checksum functionality", {
   config <- dbug()
   config$cache <- storr::storr_environment()
   make(config = config)
+  checksum <- mc_get_checksum(target = "combined", config = config)
   bad <- "askldfklhjsdfkj"
-  expect_false(
-    grepl("NA",
-      checksum <- mc_get_checksum(target = "combined", config = config)
-    )
-  )
+  expect_false(grepl("NA", checksum))
   expect_true(
     grepl("NA", mc_get_checksum(target = bad, config = config)))
   expect_true(
@@ -203,6 +200,9 @@ test_with_dir("checksum functionality", {
   expect_false(
     mc_is_good_checksum(
       target = "combined", checksum = bad, config = config))
+  expect_silent(
+    mc_wait_checksum(
+      target = "combined", checksum = checksum, config = config, timeout = 0.1))
   expect_error(
     mc_wait_checksum(
       target = "combined", checksum = bad, config = config, timeout = 0.1))

--- a/tests/testthat/test-parallel.R
+++ b/tests/testthat/test-parallel.R
@@ -91,6 +91,10 @@ test_with_dir("mclapply and lapply", {
   config$jobs <- 1
   config$debug <- TRUE
   suppressWarnings(out <- make(config = config))
+  expect_false(
+    grepl("NA", mc_get_checksum(target = "combined", config = config)))
+  expect_true(
+    grepl("NA", mc_get_checksum(target = "askldfklhjsdfkj", config = config)))
   expect_true(length(justbuilt(out)) > 0)
   expect_true(is.numeric(readd(final)))
   suppressWarnings(out <- make(config = config))
@@ -179,4 +183,30 @@ test_with_dir("ensure_workers can be disabled", {
     session_info = FALSE, ensure_workers = FALSE
   )
   expect_equal(outdated(config), character(0))
+})
+
+test_with_dir("checksum functionality", {
+  config <- dbug()
+  config$cache <- storr::storr_environment()
+  make(config = config)
+  bad <- "askldfklhjsdfkj"
+  expect_false(
+    grepl("NA",
+      checksum <- mc_get_checksum(target = "combined", config = config)
+    )
+  )
+  expect_true(
+    grepl("NA", mc_get_checksum(target = bad, config = config)))
+  expect_true(
+    mc_is_good_checksum(
+      target = "combined", checksum = checksum, config = config))
+  expect_false(
+    mc_is_good_checksum(
+      target = "combined", checksum = bad, config = config))
+  expect_silent(
+    mc_wait_checksum(
+      target = "combined", checksum = checksum, config = config))
+  expect_error(
+    mc_wait_checksum(
+      target = "combined", checksum = bad, config = config, timeout = 0.1))
 })

--- a/tests/testthat/test-parallel.R
+++ b/tests/testthat/test-parallel.R
@@ -203,9 +203,6 @@ test_with_dir("checksum functionality", {
   expect_false(
     mc_is_good_checksum(
       target = "combined", checksum = bad, config = config))
-  expect_silent(
-    mc_wait_checksum(
-      target = "combined", checksum = checksum, config = config))
   expect_error(
     mc_wait_checksum(
       target = "combined", checksum = bad, config = config, timeout = 0.1))


### PR DESCRIPTION
# Summary

- Add a safeguard for network file systems (on many clusters): use target hashes as checksums to make sure the right data objects gets written back to the master node at the right times.
- Remove the warning proposed in #416.
- Depend on CRAN's version of [`txtq`](https://github.com/wlandau/txtq).
- Bump the version to 5.2.0.
 
# Related GitHub issues

- Ref: #416, #417

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
