### PR TITLE
Skip long-running and low-priority tests on CRAN

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,6 @@ after_success:
 
 after_failure:
   - find *Rcheck -name '*fail' -print -exec cat '{}' \;
+
+env:
+  - NOT_CRAN=true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Description: A general-purpose computational engine for data analysis,
   to practical examples and more, is available at the reference website
   <https://ropensci.github.io/drake/> and the online manual
   <https://ropenscilabs.github.io/drake-manual/>.
-Version: 5.2.0
+Version: 5.2.1
 License: GPL-3
 URL: https://github.com/ropensci/drake
 BugReports: https://github.com/ropensci/drake/issues

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,6 +47,7 @@ artifacts:
     name: Bits
 
 environment:
+  NOT_CRAN: true
   global:
     WARNINGS_ARE_ERRORS: 1
     USE_RTOOLS: true

--- a/tests/testthat/test-dbi-cache.R
+++ b/tests/testthat/test-dbi-cache.R
@@ -1,6 +1,7 @@
 drake_context("dbi cache")
 
 test_with_dir("storr_dbi is usable", {
+  skip_on_cran() # low priority
   skip_if_not_installed("DBI")
   skip_if_not_installed("RSQLite")
 

--- a/tests/testthat/test-deprecate.R
+++ b/tests/testthat/test-deprecate.R
@@ -31,6 +31,7 @@ test_with_dir("deprecation: make() and config()", {
 })
 
 test_with_dir("deprecation: cache functions", {
+  skip_on_cran() # low priority
   plan <- drake_plan(x = 1)
   expect_error(expect_warning(tmp <- read_drake_meta(search = FALSE)))
   expect_silent(make(plan, verbose = FALSE, session_info = FALSE))
@@ -61,6 +62,7 @@ test_with_dir("drake_plan deprecation", {
 })
 
 test_with_dir("drake version checks in previous caches", {
+  skip_on_cran() # low priority
   # We need to be able to set the drake version
   # to check back compatibility.
   plan <- drake_plan(x = 1)
@@ -119,6 +121,7 @@ test_with_dir("deprecate misc utilities", {
 })
 
 test_with_dir("deprecated arguments", {
+  skip_on_cran() # low priority
   pl <- drake_plan(a = 1, b = a)
   expect_warning(
     con <- drake_config(
@@ -131,6 +134,7 @@ test_with_dir("deprecated arguments", {
 })
 
 test_with_dir("old file API", {
+  skip_on_cran() # low priority
   expect_warning(x <- drake_plan(
     file.csv = write.csv(mtcars, file = "file.csv"),
     strings_in_dots = "literals",

--- a/tests/testthat/test-future.R
+++ b/tests/testthat/test-future.R
@@ -1,6 +1,7 @@
 drake_context("future")
 
 test_with_dir("future package functionality", {
+  skip_on_cran() # too slow for CRAN
   future::plan(future::sequential)
   scenario <- get_testing_scenario()
   e <- eval(parse(text = scenario$envir))
@@ -59,6 +60,7 @@ test_with_dir("prepare_distributed() writes cache folder if nonexistent", {
 })
 
 test_with_dir("can gracefully conclude a crashed worker", {
+  skip_on_cran() # too slow for CRAN
   for (caching in c("master", "worker")){
     con <- dbug()
     con$caching <- caching

--- a/tests/testthat/test-graph.R
+++ b/tests/testthat/test-graph.R
@@ -91,6 +91,7 @@ test_with_dir("Supplied graph is pruned.", {
 })
 
 test_with_dir("graphing args are not ignored (mtcars example)", {
+  skip_on_cran() # too slow for CRAN
   scenario <- get_testing_scenario()
   e <- eval(parse(text = scenario$envir))
   jobs <- scenario$jobs

--- a/tests/testthat/test-migrate.R
+++ b/tests/testthat/test-migrate.R
@@ -1,6 +1,7 @@
 drake_context("migrate")
 
 test_with_dir("force loading a non-back-compatible cache", {
+  skip_on_cran() # low priority
   expect_null(assert_compatible_cache(NULL))
   expect_null(get_cache())
   expect_null(this_cache())
@@ -25,6 +26,7 @@ test_with_dir("force loading a non-back-compatible cache", {
 })
 
 test_with_dir("null cases for migrate_drake_project()", {
+  skip_on_cran() # low priority
   expect_true(suppressWarnings(migrate_drake_project(path = "not_found")))
   x <- new_cache(path = "path")
   expect_true(suppressWarnings(migrate_drake_project(path = "path")))
@@ -32,6 +34,7 @@ test_with_dir("null cases for migrate_drake_project()", {
 })
 
 test_with_dir("migrate_drake_project() an up to date cache", {
+  skip_on_cran() # low priority
   write_v4.3.0_project() # nolint
   file.rename(from = default_cache_path(), to = "old")
   expect_error(this_cache(path = "old"))
@@ -47,6 +50,7 @@ test_with_dir("migrate_drake_project() an up to date cache", {
 })
 
 test_with_dir("migrate_drake_project() a partially outdated cache", {
+  skip_on_cran() # low priority
   write_v4.3.0_project() # nolint
   file.rename(from = default_cache_path(), to = "old")
   cache <- this_cache(path = "old", force = TRUE)
@@ -64,11 +68,13 @@ test_with_dir("migrate_drake_project() a partially outdated cache", {
 })
 
 test_with_dir("migration_result()", {
+  skip_on_cran() # low priority
   expect_error(migration_result(FALSE, "backup"))
   expect_message(migration_result(TRUE, "backup"))
 })
 
 test_with_dir("Null cases in legacy functions", {
+  skip_on_cran() # low priority
   write_v4.3.0_project() # nolint
   cache <- this_cache(force = TRUE)
   cache$set(key = "\"report.md\"", value = Inf, namespace = "filemtime")
@@ -87,6 +93,7 @@ test_with_dir("Null cases in legacy functions", {
 })
 
 test_with_dir("edge cases in the legacy functions. (no glaring errors)", {
+  skip_on_cran() # low priority
   con <- dbug()
   testrun(con)
   target <- "\"intermediatefile.rds\""

--- a/tests/testthat/test-parallel.R
+++ b/tests/testthat/test-parallel.R
@@ -86,6 +86,7 @@ test_with_dir("shell_file() writes correctly", {
 })
 
 test_with_dir("mclapply and lapply", {
+  skip_on_cran() # too slow for CRAN
   config <- dbug()
   config$parallelism <- "parLapply"
   config$jobs <- 1
@@ -112,6 +113,7 @@ test_with_dir("mclapply and lapply", {
 })
 
 test_with_dir("staged mclapply and lapply", {
+  skip_on_cran() # too slow for CRAN
   config <- dbug()
   env <- config$envir
   config$parallelism <- "parLapply_staged"
@@ -172,6 +174,7 @@ test_with_dir("null cases for message queues", {
 })
 
 test_with_dir("ensure_workers can be disabled", {
+  skip_on_cran() # too slow for CRAN
   load_mtcars_example()
   future::plan(future::sequential)
   config <- drake_config(my_plan)

--- a/tests/testthat/test-time.R
+++ b/tests/testthat/test-time.R
@@ -56,6 +56,7 @@ test_with_dir("build time the same after superfluous make", {
 })
 
 test_with_dir("runtime predictions", {
+  skip_on_cran() # too slow for CRAN
   con <- dbug()
   expect_warning(p0 <- as.numeric(predict_runtime(con)))
   expect_true(p0 < 1e4)

--- a/tests/testthat/test-time.R
+++ b/tests/testthat/test-time.R
@@ -150,6 +150,7 @@ test_with_dir("runtime predictions", {
 })
 
 test_with_dir("load balancing with custom worker assignemnts", {
+  skip_on_cran() # low priority
   config <- load_mtcars_example()
   config$plan$worker <- 1
   config$plan$worker[grepl("large", config$plan$target)] <- 2

--- a/tests/testthat/test-triggers.R
+++ b/tests/testthat/test-triggers.R
@@ -7,6 +7,7 @@ test_with_dir("empty triggers return logical", {
 })
 
 test_with_dir("triggers work as expected", {
+  skip_on_cran() # too slow for CRAN
   con <- dbug()
   con$plan$trigger <- "missing"
   con <- testrun(config = con)

--- a/tests/testthat/test-with-processx.R
+++ b/tests/testthat/test-with-processx.R
@@ -1,6 +1,7 @@
 drake_context("with processx")
 
 if (!identical(getOption("drake_no_processx"), TRUE)){
+  skip_on_cran() # could mess up uses of parallel
   test_with_dir("make(session = callr::r_vanilla)", {
     con <- dbug()
     con$envir <- dbug_envir(globalenv())


### PR DESCRIPTION
# Summary

When I submitted `drake` 5.2.0 to CRAN this afternoon, the maintainers requested that I reduce testing time. This PR uses `testthat::skip_on_cran()` to skip several long-running and low-priority tests on CRAN. These tests still run on CI frameworks because the `NOT_CRAN` environment variable in `.travis.yml` and `appveyor.yml` is set.

# Related GitHub issues

- Ref: #412 

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
