### PR TITLE
Use garbage collection in persistent scheduling

### DIFF
--- a/R/mclapply.R
+++ b/R/mclapply.R
@@ -52,10 +52,7 @@ mc_process <- function(id, config){
 #' @param config `drake_config()` list
 #' @return nothing important
 mc_master <- function(config){
-  on.exit({
-    mc_conclude_workers(config)
-    gc()
-  })
+  on.exit(mc_conclude_workers(config))
   config$queue <- new_priority_queue(config = config)
   if (!identical(config$ensure_workers, FALSE)){
     mc_ensure_workers(config)
@@ -72,11 +69,11 @@ mc_master <- function(config){
 }
 
 mc_worker <- function(worker, config){
-  on.exit(gc())
   ready_queue <- mc_get_ready_queue(worker, config)
   done_queue <- mc_get_done_queue(worker, config)
   while (TRUE){
     while (nrow(msg <- ready_queue$list(1)) < 1){
+      gc()
       Sys.sleep(mc_wait)
     }
     if (identical(msg$message, "done")){

--- a/R/mclapply.R
+++ b/R/mclapply.R
@@ -52,7 +52,10 @@ mc_process <- function(id, config){
 #' @param config `drake_config()` list
 #' @return nothing important
 mc_master <- function(config){
-  on.exit(mc_conclude_workers(config))
+  on.exit({
+    mc_conclude_workers(config)
+    gc()
+  })
   config$queue <- new_priority_queue(config = config)
   if (!identical(config$ensure_workers, FALSE)){
     mc_ensure_workers(config)
@@ -69,6 +72,7 @@ mc_master <- function(config){
 }
 
 mc_worker <- function(worker, config){
+  on.exit(gc())
   ready_queue <- mc_get_ready_queue(worker, config)
   done_queue <- mc_get_done_queue(worker, config)
   while (TRUE){


### PR DESCRIPTION
# Summary

Call `gc()` on exit for persistent workers and the master process. cc @krlmlr.

# Related GitHub issues

- Ref: #428 

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [ ] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [ ] I think this pull request is ready to merge.
