### PR TITLE
fix bug in future_lapply where it takes jobs from config

### DIFF
--- a/R/future_lapply.R
+++ b/R/future_lapply.R
@@ -1,6 +1,6 @@
 run_future_lapply <- function(config){
   prepare_distributed(config = config)
-  mc_init_worker_cache(config)
+  mc_init_worker_cache(config, jobs = future::nbrOfWorkers())
   console_persistent_workers(config)
   path <- normalizePath(config$cache_path, winslash = "/")
   rscript <- grep(

--- a/R/future_lapply.R
+++ b/R/future_lapply.R
@@ -14,7 +14,7 @@ run_future_lapply <- function(config){
     wait = FALSE
   )
   future.apply::future_lapply(
-    X = mc_worker_id(seq_len(config$jobs)),
+    X = mc_worker_id(seq_len(future::nbrOfWorkers)),
     FUN = fl_worker,
     cache_path = config$cache$driver$path,
     future.globals = FALSE

--- a/R/future_lapply.R
+++ b/R/future_lapply.R
@@ -14,7 +14,7 @@ run_future_lapply <- function(config){
     wait = FALSE
   )
   future.apply::future_lapply(
-    X = mc_worker_id(seq_len(future::nbrOfWorkers)),
+    X = mc_worker_id(seq_len(future::nbrOfWorkers())),
     FUN = fl_worker,
     cache_path = config$cache$driver$path,
     future.globals = FALSE

--- a/R/mc_utils.R
+++ b/R/mc_utils.R
@@ -1,5 +1,5 @@
 mc_init_worker_cache <- function(config, jobs = NULL){
-  if(is.null(jobs)){
+  if (is.null(jobs)){
     jobs <- config$jobs
   }
   namespaces <- c(

--- a/R/mc_utils.R
+++ b/R/mc_utils.R
@@ -1,4 +1,7 @@
-mc_init_worker_cache <- function(config){
+mc_init_worker_cache <- function(config, jobs = NULL){
+  if(is.null(jobs)){
+    jobs <- config$jobs
+  }
   namespaces <- c(
     "mc_protect", "mc_ready_db", "mc_done_db", "mc_error")
   for (namespace in namespaces){
@@ -6,7 +9,7 @@ mc_init_worker_cache <- function(config){
   }
   dir_empty(worker_dir <- file.path(config$cache_path, "workers"))
   lapply(
-    X = seq_len(config$jobs),
+    X = seq_len(jobs),
     FUN = function(worker){
       worker <- mc_worker_id(worker)
       for (type in c("ready", "done")){


### PR DESCRIPTION
# Summary

`run_future_lapply` would incorrectly take the number of workers from `config$jobs`. I modified the worker setup function as well as the call to `future_lapply`

# Related GitHub issues

- Ref: None

# Checklist

- [X] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [X] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
- [NA] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [NA] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [Travis did] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
