### PR TITLE
add future::nbrOfWorkers to future.R

### DIFF
--- a/R/future.R
+++ b/R/future.R
@@ -169,9 +169,9 @@ running_targets <- function(workers, config){
     unlist
 }
 
-initialize_workers <- function(config){
+initialize_workers <- function(){
   out <- list()
-  for (i in seq_len(config$jobs))
+  for (i in seq_len(future::nbrOfWorkers()))
     out[[i]] <- empty_worker(target = NA)
   out
 }

--- a/R/future.R
+++ b/R/future.R
@@ -1,6 +1,6 @@
 run_future <- function(config){
   queue <- new_priority_queue(config = config)
-  workers <- initialize_workers(config)
+  workers <- initialize_workers()
   # While any targets are queued or running...
   while (work_remains(queue = queue, workers = workers, config = config)){
     for (id in seq_along(workers)){


### PR DESCRIPTION
# Summary

future parallelism incorrectly uses the `jobs` argument to `make`. This PR fixes it so that it uses `future::nbrOfWorkers`.

# Related GitHub issues

- Ref: # None.

# Checklist

- [X] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [X] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
- [X] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [NA] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [Travis did] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
