### PR TITLE
get make to obey jobs = c(imports = x, targets = y) for mclapply parallelism

### DIFF
--- a/R/make.R
+++ b/R/make.R
@@ -250,7 +250,7 @@ make_with_schedules <- function(config){
     make_imports(config = config)
     make_targets(config = config)
   } else {
-    # config$jobs_imports == config$jobs_targets here 
+    # config$jobs_imports == config$jobs_targets here
     config$jobs <- config$jobs_imports
     make_imports_targets(config = config)
   }

--- a/R/make.R
+++ b/R/make.R
@@ -250,6 +250,8 @@ make_with_schedules <- function(config){
     make_imports(config = config)
     make_targets(config = config)
   } else {
+    # config$jobs_imports == config$jobs_targets here 
+    config$jobs <- config$jobs_imports
     make_imports_targets(config = config)
   }
 }
@@ -346,7 +348,6 @@ make_targets <- function(config = drake::read_drake_config()){
 make_imports_targets <- function(config){
   config$schedule <- config$graph
   config$parallelism <- config$parallelism[1]
-  config$jobs <- max(config$jobs)
   run_parallel_backend(config = config)
   console_up_to_date(config = config)
   invisible(config)

--- a/R/make.R
+++ b/R/make.R
@@ -244,7 +244,8 @@ make_with_schedules <- function(config){
   } else if (config$skip_imports){
     make_targets(config = config)
   } else if (
-    length(unique(config$parallelism)) > 1
+    (length(unique(config$parallelism)) > 1) |
+      (config$jobs_imports != config$jobs_targets)
   ){
     make_imports(config = config)
     make_targets(config = config)


### PR DESCRIPTION
# Summary

This PR fixes a problem where make_imports_targets assumes the maximum value of jobs_imports and jobs_targets when using mclapply parallelism. This blows the computer up when one specifies e.g. `jobs = c(imports = 16, targets = 1)` on memory hungry jobs. I found it while trying to debug a project which I didn't want to build targets using parallelism.

# Related GitHub issues

- Ref: #None

# Checklist

- [X] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [X] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
- [X] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [NA] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [Travis did] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
