### PR TITLE
Add future_lapply_staged parallelism

### DIFF
--- a/R/distributed.R
+++ b/R/distributed.R
@@ -43,11 +43,16 @@ finish_distributed <- function(config){
   unlink(file, force = TRUE)
 }
 
-build_distributed <- function(target, cache_path){
+build_distributed <- function(target, cache_path, check = TRUE){
   config <- recover_drake_config(cache_path = cache_path)
   eval(parse(text = "base::require(drake, quietly = TRUE)"))
   do_prework(config = config, verbose_packages = FALSE)
-  build_check_store(target = target, config = config)
+  if (check){
+    build_check_store(target = target, config = config)
+  } else {
+    prune_envir(targets = target, config = config)
+    build_and_store(target = target, config = config)
+  }
   invisible()
 }
 

--- a/R/future.R
+++ b/R/future.R
@@ -71,24 +71,7 @@ new_worker <- function(id, target, config, protect){
   # Avoid potential name conflicts with other globals.
   # When we solve #296, the need for such a clumsy workaround
   # should go away.
-  globals <- list(
-    DRAKE_GLOBALS__ = list(
-      target = target,
-      meta = meta,
-      config = config
-    )
-  )
-  if (identical(config$envir, globalenv())){
-    # Unit tests should not modify global env # nocov
-    if (exists("DRAKE_GLOBALS__", config$envir)){ # nocov # nolint
-      warning( # nocov
-        "Do not define an object named `DRAKE_GLOBALS__` ", # nocov
-        "in the global environment", # nocov
-        call. = FALSE # nocov
-      ) # nocov
-    } # nocov
-    globals <- c(globals, as.list(config$envir, all.names = TRUE)) # nocov
-  }
+  globals <- future_globals(target = target, meta = meta, config = config)
   evaluator <- drake_plan_override(
     target = target,
     field = "evaluator",
@@ -109,6 +92,28 @@ new_worker <- function(id, target, config, protect){
     ),
     target = target
   )
+}
+
+future_globals <- function(target, meta, config){
+  globals <- list(
+    DRAKE_GLOBALS__ = list(
+      target = target,
+      meta = meta,
+      config = config
+    )
+  )
+  if (identical(config$envir, globalenv())){
+    # Unit tests should not modify global env # nocov
+    if (exists("DRAKE_GLOBALS__", config$envir)){ # nocov # nolint
+      warning( # nocov
+        "Do not define an object named `DRAKE_GLOBALS__` ", # nocov
+        "in the global environment", # nocov
+        call. = FALSE # nocov
+      ) # nocov
+    } # nocov
+    globals <- c(globals, as.list(config$envir, all.names = TRUE)) # nocov
+  }
+  globals
 }
 
 empty_worker <- function(target){

--- a/R/parallel_ui.R
+++ b/R/parallel_ui.R
@@ -107,6 +107,7 @@ parallelism_choices <- function(distributed_only = FALSE) {
   distributed <- c(
     "future",
     "future_lapply",
+    "future_lapply_staged",
     "Makefile"
   )
   if (distributed_only){

--- a/tests/testthat/test-future.R
+++ b/tests/testthat/test-future.R
@@ -6,8 +6,8 @@ test_with_dir("future package functionality", {
   scenario <- get_testing_scenario()
   e <- eval(parse(text = scenario$envir))
   load_mtcars_example(envir = e)
-  backends <- c("future_lapply", rep("future", 2))
-  caching <- c(rep("worker", 2), "master")
+  backends <- c("future_lapply", rep("future", 2), "future_lapply_staged")
+  caching <- c(rep("worker", 2), rep("master", 2))
   for (i in 1:3){
     clean(destroy = TRUE)
     config <- make(


### PR DESCRIPTION
# Summary

`make(parallelism = "future_lapply_staged")` is a partial workaround for #448. It will also give us a chance to compare the efficiency of the `"future"` and `"future_lapply"` backends against their staged alternative.

# Related GitHub issues

- Ref: #448 (not fixed)

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
