### PR TITLE
Lay the groundwork for multiple output files per command

### DIFF
--- a/R/meta.R
+++ b/R/meta.R
@@ -51,7 +51,14 @@ drake_meta <- function(target, config = drake::read_drake_config()) {
     imported = !(target %in% config$plan$target),
     foreign = !exists(x = target, envir = config$envir, inherits = FALSE),
     missing = !target_exists(target = target, config = config),
-    seed = seed_from_object(list(seed = config$seed, target = target))
+    seed = seed_from_object(list(seed = config$seed, target = target)),
+    output_files = unlist(
+      igraph::vertex_attr(
+        graph = config$graph,
+        name = "output_files",
+        index = target
+      )
+    )
   )
   trigger <- get_trigger(target = target, config = config)
   # Need to make sure meta includes all these

--- a/R/utils.R
+++ b/R/utils.R
@@ -84,3 +84,13 @@ padded_scale <- function(x){
   pad <- 0.2 * (r[2] - r[1])
   c(r[1] - pad, r[2] + pad)
 }
+
+which_nonempty <- function(x){
+  vapply(
+    X = x,
+    FUN = function(y){
+      length(y) > 0
+    },
+    FUN.VALUE = logical(1)
+  )
+}


### PR DESCRIPTION
# Summary

This latest attempt to solve #283 will be as minimally invasive as possible. It will proceed step by step with small PRs like this one, and there will be no major additions or changes to internal data structures.

We keep main parts of `config$graph` just the way they are: no fooling around with nodes or edges, and no holding on to two graph representations. To keep track of output files, we use graph attributes instead. Then, each target's list of output files is stored in `drake_meta()`. 

# Related GitHub issues

- Ref: #283 (not fixed)

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
