### PR TITLE
Name arguments of target()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# Version 5.3.1.9000
+
+- Name the arguments of `target()` so users do not have to (explicitly).
+
 # Version 5.3.0
 
 - Allow multiple output files per command.

--- a/man/target.Rd
+++ b/man/target.Rd
@@ -4,12 +4,36 @@
 \alias{target}
 \title{Define custom columns in a \code{\link[=drake_plan]{drake_plan()}}.}
 \usage{
-target(...)
+target(command = NULL, trigger = NULL, retries = NULL, timeout = NULL,
+  cpu = NULL, elapsed = NULL, priority = NULL, worker = NULL,
+  evaluator = NULL, ...)
 }
 \arguments{
-\item{...}{named arguments specifying fields of the workflow plan.
-Tidy evaluation will be applied to them, so the \code{!!} operator
-is evaluated immediately for expressions and language objects.}
+\item{command}{the command to build the target}
+
+\item{trigger}{the target's trigger}
+
+\item{retries}{number of retries in case of failure}
+
+\item{timeout}{overall timeout (in seconds) for building a target}
+
+\item{cpu}{cpu timeout (seconds) for building a target}
+
+\item{elapsed}{elapsed time (seconds) for building a target}
+
+\item{priority}{integer giving the build priority of a target.
+Given two targets about to be built at the same time,
+the one with the lesser priority (numerically speaking)
+will be built first.}
+
+\item{worker}{the preferred worker to be assigned the target
+(in parallel computing).}
+
+\item{evaluator}{the \code{future} evaluator of the target.
+Not yet supported.}
+
+\item{...}{named arguments specifying non-standard
+fields of the workflow plan.}
 }
 \value{
 A one-row workflow plan data frame with the named
@@ -19,13 +43,16 @@ arguments as columns.
 The \code{target()} function lets you define
 custom columns in a workflow plan data frame, both
 inside and outside calls to \code{\link[=drake_plan]{drake_plan()}}.
+@details Tidy evaluation is applied to the arguments,
+and the \code{!!} operator is evaluated immediately
+for expressions and language objects.
 }
 \examples{
 # Use target() to create your own custom columns in a drake plan.
 # See ?triggers for more on triggers.
 plan <- drake_plan(
   website_data = target(
-    command = download_data("www.your_url.com"),
+    download_data("www.your_url.com"),
     trigger = "always",
     custom_column = 5
   ),
@@ -36,7 +63,7 @@ plan
 # make(plan) # nolint
 # Call target() inside or outside drake_plan().
 target(
-  command = download_data("www.your_url.com"),
+  download_data("www.your_url.com"),
   trigger = "always",
   custom_column = 5
 )

--- a/tests/testthat/test-plan.R
+++ b/tests/testthat/test-plan.R
@@ -412,6 +412,27 @@ test_with_dir("ignore() in imported functions", {
 test_with_dir("custom column interface", {
   skip_on_cran() # CRAN gets whitelist tests only (check time limits).
   tidyvar <- 2
+  x <- target(
+    stop(!!tidyvar), worker = !!tidyvar, cpu = 4, custom = stop(), c2 = 5)
+  y <- tibble::tibble(
+    command = "stop(2)",
+    worker = 2,
+    cpu = 4,
+    custom = "stop()",
+    c2 = 5
+  )
+  expect_equal(x, y)
+  x <- drake_plan(x = target(
+    stop(!!tidyvar), worker = !!tidyvar, cpu = 4, custom = stop(), c2 = 5))
+  y <- tibble::tibble(
+    target = "x",
+    command = "stop(2)",
+    worker = 2,
+    cpu = 4,
+    custom = "stop()",
+    c2 = 5
+  )
+  expect_equal(x, y)
   plan <- drake_plan(
     x = target(
       command = 1 + !!tidyvar,


### PR DESCRIPTION
# Summary

Name the arguments of `target()` so users do not have to (explicitly).

```r
library(drake)
drake_plan(x = target(1 + 1))
#> # A tibble: 1 x 2
#>   target command
#> * <chr>  <chr>  
#> 1 x      1 + 1
```

# Related GitHub issues

- Ref: #473

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
