### PR TITLE
Allow user-defined columns for wildcard expansion

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # Version 5.3.1.9000
 
+- Add a `columns` argument to `evaluate_plan()` so users can evaluate wildcards in columns other than the `command` column of `plan`. 
 - Name the arguments of `target()` so users do not have to (explicitly).
 
 # Version 5.3.0

--- a/R/generate.R
+++ b/R/generate.R
@@ -71,6 +71,9 @@ dataset_wildcard <- function(){
 #'   trace the wildcard expansion process. These new
 #'   columns indicate which targets were evaluated with which
 #'   wildcards.
+#'   
+#' @param columns character vector of names of columns
+#'   to look for and evaluate the wildcards.
 #'
 #' @examples
 #' # Create the part of the workflow plan for the datasets.
@@ -99,6 +102,17 @@ dataset_wildcard <- function(){
 #' # Except when expand is FALSE.
 #' x <- drake_plan(draws = rnorm(mean = Mean, sd = Sd))
 #' evaluate_plan(x, rules = list(Mean = 1:3, Sd = c(1, 10)))
+#' # You can use wildcards on columns other than "command"
+#' evaluate_plan(
+#'   drake_plan(
+#'     x = target("always", cpu = "any"),
+#'     y = target("any", cpu = "always"),
+#'     z = target("any", cpu = "any"),
+#'     strings_in_dots = "literals"
+#'   ),
+#'   rules = list(always = 1:2),
+#'   columns = c("command", "cpu")
+#' )
 #' # With the `trace` argument,
 #' # you can generate columns that show how the wildcards
 #' # were evaluated.
@@ -126,7 +140,8 @@ evaluate_plan <- function(
   values = NULL,
   expand = TRUE,
   rename = expand,
-  trace = FALSE
+  trace = FALSE,
+  columns = "command"
 ){
   if (!is.null(rules)){
     check_wildcard_rules(rules)
@@ -135,7 +150,8 @@ evaluate_plan <- function(
       rules = rules,
       expand = expand,
       rename = rename,
-      trace = trace
+      trace = trace,
+      columns = columns
     )
   } else if (!is.null(wildcard) && !is.null(values)){
     evaluate_single_wildcard(
@@ -144,7 +160,8 @@ evaluate_plan <- function(
       values = values,
       expand = expand,
       rename = rename,
-      trace = trace
+      trace = trace,
+      columns = columns
     )
   } else {
     plan
@@ -152,10 +169,30 @@ evaluate_plan <- function(
 }
 
 evaluate_single_wildcard <- function(
-  plan, wildcard, values, expand, rename, trace
+  plan, wildcard, values, expand, rename, trace, columns
 ){
+  if (!length(columns)){
+    return(plan)
+  }
+  if ("target" %in% columns){
+    stop(
+      "'target' cannot be in the `columns` argument of evaluate_plan().",
+      call = FALSE
+    )
+  }
+  missing_cols <- setdiff(columns, colnames(plan))
+  if (length(missing_cols)){
+    stop(
+      "some columns you selected for evaluate_plan() are not in the plan:\n",
+      multiline_message(missing_cols),
+      call. = FALSE
+    )
+  }
   values <- as.character(values)
-  matches <- grepl(wildcard, plan$command, fixed = TRUE)
+  matches <- rep(FALSE, nrow(plan))
+  for (col in columns){
+    matches <- matches | grepl(wildcard, plan[[col]], fixed = TRUE)
+  }
   if (!any(matches)){
     return(plan)
   }
@@ -170,11 +207,13 @@ evaluate_single_wildcard <- function(
     matching$target <- paste(matching$target, values, sep = "_")
   }
   values <- rep(values, length.out = nrow(matching))
-  matching$command <- Vectorize(
-    function(value, command){
-      gsub(wildcard, value, command, fixed = TRUE)
-    }
-  )(values, matching$command)
+  for (col in columns){
+    matching[[col]] <- Vectorize(
+      function(value, command){
+        gsub(wildcard, value, command, fixed = TRUE)
+      }
+    )(values, matching[[col]])
+  }
   if (trace){
     matching[[wildcard]] <- values
   }
@@ -196,7 +235,7 @@ evaluate_single_wildcard <- function(
 }
 
 evaluate_wildcard_rules <- function(
-  plan, rules, expand, rename, trace
+  plan, rules, expand, rename, trace, columns
 ){
   for (index in seq_len(length(rules))){
     plan <- evaluate_single_wildcard(
@@ -205,7 +244,8 @@ evaluate_wildcard_rules <- function(
       values = rules[[index]],
       expand = expand,
       rename = rename,
-      trace = trace
+      trace = trace,
+      columns = columns
     )
   }
   plan

--- a/man/evaluate_plan.Rd
+++ b/man/evaluate_plan.Rd
@@ -6,7 +6,7 @@
 workflow plan data frame from a template data frame.}
 \usage{
 evaluate_plan(plan, rules = NULL, wildcard = NULL, values = NULL,
-  expand = TRUE, rename = expand, trace = FALSE)
+  expand = TRUE, rename = expand, trace = FALSE, columns = "command")
 }
 \arguments{
 \item{plan}{workflow plan data frame, similar to one produced by
@@ -41,6 +41,9 @@ based on the values supplied for the wildcards
 trace the wildcard expansion process. These new
 columns indicate which targets were evaluated with which
 wildcards.}
+
+\item{columns}{character vector of names of columns
+to look for and evaluate the wildcards.}
 }
 \value{
 A workflow plan data frame with the wildcards evaluated.
@@ -87,6 +90,17 @@ my_plan
 # Except when expand is FALSE.
 x <- drake_plan(draws = rnorm(mean = Mean, sd = Sd))
 evaluate_plan(x, rules = list(Mean = 1:3, Sd = c(1, 10)))
+# You can use wildcards on columns other than "command"
+evaluate_plan(
+  drake_plan(
+    x = target("always", cpu = "any"),
+    y = target("any", cpu = "always"),
+    z = target("any", cpu = "any"),
+    strings_in_dots = "literals"
+  ),
+  rules = list(always = 1:2),
+  columns = c("command", "cpu")
+)
 # With the `trace` argument,
 # you can generate columns that show how the wildcards
 # were evaluated.

--- a/tests/testthat/test-plan.R
+++ b/tests/testthat/test-plan.R
@@ -550,6 +550,17 @@ test_with_dir("'columns' argument to evaluate_plan()", {
     out
   )
   out <- tibble::tibble(
+    target = c("x", "y_1", "y_2", "z"),
+    command = c("always", rep("any", 3)),
+    cpu = c("any", 1, 2, "any")
+  )
+  expect_equal(
+    evaluate_plan(
+      plan, wildcard = "always", values = 1:2, columns = "cpu"
+    ),
+    out
+  )
+  out <- tibble::tibble(
     target = c("x", "y", "z"),
     command = c(1, rep("any", 2)),
     cpu = c("any", 2, "any")


### PR DESCRIPTION
# Summary

You can now use wildcards for columns other than the `command` column of the plan.

```r
library(drake)
evaluate_plan(
  drake_plan(
    x = target("always", custom = "any"),
    y = target("any", custom = "always"),
    z = target("any", custom = "any"),
    strings_in_dots = "literals"
  ),
  rules = list(always = 1:2),
  columns = c("command", "custom")
)
#> # A tibble: 5 x 3
#>   target command custom
#> * <chr>  <chr>   <chr> 
#> 1 x_1    1       any   
#> 2 x_2    2       any   
#> 3 y_1    any     1     
#> 4 y_2    any     2     
#> 5 z      any     any
```

# Related GitHub issues

- Ref: #473

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
