### PR TITLE
Make triggers less susceptible to false positives

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 Please explain the context and purpose of your contribution and list the changes you made to the code base or documentation.
 
-# Related GitHub issues
+# Related GitHub issues and pull requests
 
 - Ref: #
 

--- a/R/config.R
+++ b/R/config.R
@@ -457,6 +457,7 @@ drake_config <- function(
     init_common_values = TRUE
   )
   seed <- choose_seed(supplied = seed, cache = cache)
+  trigger <- convert_old_trigger(trigger)
   if (is.null(graph)){
     graph <- build_drake_graph(
       plan = plan,
@@ -465,7 +466,8 @@ drake_config <- function(
       verbose = verbose,
       jobs = jobs,
       sanitize_plan = FALSE,
-      console_log_file = console_log_file
+      console_log_file = console_log_file,
+      trigger = trigger
     )
   } else {
     graph <- prune_drake_graph(graph = graph, to = targets, jobs = jobs)

--- a/R/deprecate.R
+++ b/R/deprecate.R
@@ -1437,6 +1437,9 @@ triggers <- function(){
 }
 
 convert_old_trigger <- function(x){
+  if (!is.character(x)){
+    return(x)
+  }
   if (!(x %in% suppressWarnings(triggers()))){
     return(x)
   }

--- a/R/graph.R
+++ b/R/graph.R
@@ -72,10 +72,7 @@ build_drake_graph <- function(
     type = "target",
     config = config
   )
-  trigger_deps <- merge_lists(
-    code_dependencies(trigger$condition),
-    code_dependencies(trigger$change)
-  )
+  trigger_deps <- global_trigger_deps(trigger)
   plan_deps <- lightly_parallelize(
     X = seq_len(nrow(plan)),
     FUN = function(i){
@@ -314,4 +311,18 @@ drake_subcomponent <- function(...){
   on.exit(igraph::igraph_options(return.vs.es = opt))
   igraph::igraph_options(return.vs.es = TRUE)
   igraph::subcomponent(...)
+}
+
+global_trigger_deps <- function(trigger){
+  trigger <- convert_old_trigger(trigger)
+  if (is.character(trigger)){
+    trigger <- parse(text = trigger)
+  }
+  if (is.language(trigger) || is.expression(trigger)){
+    trigger <- eval(trigger)
+  }
+  merge_lists(
+    code_dependencies(trigger$condition),
+    code_dependencies(trigger$change)
+  )
 }

--- a/R/meta.R
+++ b/R/meta.R
@@ -95,7 +95,12 @@ drake_meta <- function(target, config = drake::read_drake_config()) {
 }
 
 dependency_hash <- function(target, config) {
-  deps <- dependencies(target, config)
+  deps <- dependencies(target, config) %>%
+    setdiff(y = igraph::vertex_attr(
+      graph = config$graph,
+      name = "ignore_changes",
+      index = target
+    )[[1]])
   if (target %in% config$plan$target){
     deps <- Filter(x = deps, f = is_not_file)
   }
@@ -115,7 +120,12 @@ file_dependency_hash <- function(
     graph = config$graph,
     name = which,
     index = target
-  ))
+  )) %>%
+    setdiff(y = igraph::vertex_attr(
+      graph = config$graph,
+      name = "ignore_changes",
+      index = target
+    )[[1]])
   vapply(
     X = sort(files),
     FUN = file_hash,

--- a/man/build_drake_graph.Rd
+++ b/man/build_drake_graph.Rd
@@ -6,7 +6,8 @@
 \usage{
 build_drake_graph(plan = read_drake_plan(), targets = plan$target,
   envir = parent.frame(), verbose = drake::default_verbose(), jobs = 1,
-  sanitize_plan = FALSE, console_log_file = NULL)
+  sanitize_plan = FALSE, console_log_file = NULL,
+  trigger = drake::trigger())
 }
 \arguments{
 \item{plan}{workflow plan data frame.
@@ -83,6 +84,9 @@ If \code{NULL}, console output will be printed
 to the R console using \code{message()}.
 Otherwise, \code{console_log_file} should be the name of a flat file.
 Console output will be appended to that file.}
+
+\item{trigger}{optional, a global trigger for building targets
+(see \code{\link[=trigger]{trigger()}}).}
 }
 \value{
 An igraph object representing


### PR DESCRIPTION
# Summary

cc @AlexAxthelm. In #478, we decided to detect dependencies from triggers: for example,

```r
f <- function(){
  1 + 1
}
g <- function(){
  TRUE
}
plan <- drake_plan(
  x = target(
    command = f(),
    trigger = trigger(condition = g())
  )
)
vis_drake_graph(drake_config(plan))
```

![graph](https://user-images.githubusercontent.com/1580860/43163817-54797b9e-8f5d-11e8-9977-507cc0659752.png)

`g()` may not be part of the command, but we should at least check and process it before we attempt `x`. The problem with this approach is that it is oversensitive to changes to `g()`. Clearly, if we change `g()` to `function(){FALSE}`, `x` should not build. But under #478, it does build because the `depend` trigger is still activated. And we don't want to use `trigger(depend = FALSE)` because we still want to react to changes to `f()`.

The solution in this PR is to ignore changes to dependencies that only show up in the triggers. Implementation details:

- Store a new `"ignore_changes"` `igraph` attribute in `build_drake_graph()` to keep track of these trigger-only dependencies.
- In `dependency_hash()` and `file_dependency_hash()`, exclude everything listed in `"ignore_changes"`.

The implementation admittedly added a little complexity to the code base, and it was not my most elegant work. However, it is consistent with the existing internals and design patterns.

# Related GitHub issues and pull requests

- Ref: #473, #478

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
