### PR TITLE
Increase detail of dependency_profile()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,8 +2,7 @@
 
 - Smooth the edges in `vis_drake_graph()` and `render_drake_graph()`.
 - Make hover text slightly more readable in in `vis_drake_graph()` and `render_drake_graph()`.
-- Improve `dependency_profile()` show major trigger hashes side-by-side
-to tell the user if the command, a dependency, an input file, or an ouptut file changed since the last `make()`.
+- Improve `dependency_profile()`: show changes to dependencies and major trigger hashes in a nice `tibble`.
 - Choose more appropriate places to check that the `txtq` package is installed.
 - Expose the `template` argument of `clustermq` functions (e.g. `Q()` and `workers()`) as an argument of `make()` and `drake_config()`.
 

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -105,20 +105,14 @@ deps_targets <- function(
 }
 
 #' @title Find out why a target is out of date.
-#' @description The dependency profile can give you
-#'   a hint as to why a target is out of date.
-#'   It can tell you if
-#'   - at least one input file changed,
-#'   - at least one outupt file changed,
-#'   - or a non-file dependency changed. For this last part,
-#'     the imports need to be up to date in the cache,
-#'     which you can do with `outdated()` or
-#'     `make(skip_targets = TRUE)`.
-#'   Unfortunately, `dependency_profile()` does not
-#'   currently get more specific than that.
+#' @description The dependency profile can tell you
+#'   why a target is out of date. It tells you the specific
+#'   dependencies that changed since the last [make()],
+#'   as well as whether any of the built-in [trigger()]s
+#'   (the command, depend, and file triggers) will be activated.
 #' @return A data frame of the old hashes and
-#'   new hashes of the data frame, along with
-#'   an indication of which hashes changed since
+#'   new hashes of each dependency and trigger, along with
+#'   a logical column to indicate which hashes changed since
 #'   the last [make()].
 #' @export
 #' @seealso [diagnose()],
@@ -157,33 +151,49 @@ dependency_profile <- function(
   if (!config$cache$exists(key = target, namespace = "meta")){
     stop("no recorded metadata for target ", target, ".")
   }
-  meta <- config$cache$get(
-    key = target, namespace = "meta")
-  deps <- dependencies(target, config)
-  old_hashes <- meta[c(
-    "command",
-    "dependency_hash",
-    "input_file_hash",
-    "output_file_hash"
-  )] %>%
-    unlist() %>%
-    unname()
-  old_hashes[1] <- digest::digest(old_hashes[1], algo = config$long_hash_algo)
-  new_hashes <- c(
-    digest::digest(
-      get_standardized_command(target, config),
-      algo = config$long_hash_algo
-    ),
-    dependency_hash(target, config),
-    input_file_hash(target, config),
-    output_file_hash(target, config)
+  old_profile <- config$cache$get(
+    key = target, namespace = "meta") %>%
+    one_profile(config = config)
+  new_profile <- list(
+    command = get_standardized_command(target, config),
+    dependency_hash = dependency_hash(target, config),
+    input_file_hash = input_file_hash(target, config),
+    output_file_hash = output_file_hash(target, config)
+  ) %>%
+    one_profile(config = config)
+  out <- merge(
+    x = old_profile,
+    y = new_profile,
+    by = "ind",
+    all = TRUE
   )
   tibble::tibble(
-    hash = c("command", "depend", "file_in", "file_out"),
-    changed = old_hashes != new_hashes,
-    old_hash = old_hashes,
-    new_hash = new_hashes
+    hash = out$ind,
+    changed = out$values.x != out$values.y,
+    old = out$values.x,
+    new = out$values.y
   )
+}
+
+one_profile <- function(meta, config){
+  c(
+    `_command_trigger` = digest::digest(
+      meta$command,
+      algo = config$long_hash_algo
+    ),
+    `_depend_trigger` = digest::digest(
+      meta$dependency_hash,
+      algo = config$long_hash_algo
+    ),
+    `_file_trigger` = digest::digest(
+      c(meta$input_file_hash, meta$input_file_hash),
+      algo = config$long_hash_algo
+    ),
+    meta$dependency_hash,
+    meta$input_file_hash,
+    meta$output_file_hash
+  ) %>%
+    utils::stack()
 }
 
 #' @title List the targets and imports

--- a/R/meta.R
+++ b/R/meta.R
@@ -109,8 +109,7 @@ dependency_hash <- function(target, config) {
     deps <- c(deps, x$file_in, x$knitr_in)
   }
   sort(unique(deps)) %>%
-    self_hash(config = config) %>%
-    digest::digest(algo = config$long_hash_algo)
+    self_hash(config = config)
 }
 
 input_file_hash <- function(
@@ -130,8 +129,7 @@ input_file_hash <- function(
     FUN.VALUE = character(1),
     config = config,
     size_cutoff = size_cutoff
-  ) %>%
-    digest::digest(algo = config$long_hash_algo)
+  )
 }
 
 output_file_hash <- function(
@@ -151,8 +149,7 @@ output_file_hash <- function(
     FUN.VALUE = character(1),
     config = config,
     size_cutoff = size_cutoff
-  ) %>%
-    digest::digest(algo = config$long_hash_algo)
+  )
 }
 
 self_hash <- Vectorize(function(target, config) {
@@ -162,7 +159,7 @@ self_hash <- Vectorize(function(target, config) {
     as.character(NA)
   }
 },
-"target", USE.NAMES = FALSE)
+"target", USE.NAMES = TRUE)
 
 rehash_file <- function(target, config) {
   file <- drake::drake_unquote(target)

--- a/man/dependency_profile.Rd
+++ b/man/dependency_profile.Rd
@@ -18,24 +18,16 @@ is a character string rather than a symbol}
 }
 \value{
 A data frame of the old hashes and
-new hashes of the data frame, along with
-an indication of which hashes changed since
+new hashes of each dependency and trigger, along with
+a logical column to indicate which hashes changed since
 the last \code{\link[=make]{make()}}.
 }
 \description{
-The dependency profile can give you
-a hint as to why a target is out of date.
-It can tell you if
-\itemize{
-\item at least one input file changed,
-\item at least one outupt file changed,
-\item or a non-file dependency changed. For this last part,
-the imports need to be up to date in the cache,
-which you can do with \code{outdated()} or
-\code{make(skip_targets = TRUE)}.
-Unfortunately, \code{dependency_profile()} does not
-currently get more specific than that.
-}
+The dependency profile can tell you
+why a target is out of date. It tells you the specific
+dependencies that changed since the last \code{\link[=make]{make()}},
+as well as whether any of the built-in \code{\link[=trigger]{trigger()}}s
+(the command, depend, and file triggers) will be activated.
 }
 \examples{
 \dontrun{

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -14,12 +14,14 @@ test_with_dir("dependency profile", {
   config$skip_targets <- TRUE
   make(config = config)
   dp <- dependency_profile(target = a, config = config)
-  expect_true(as.logical(dp[dp$hash == "depend", "changed"]))
-  expect_equal(sum(dp$changed), 1)
+  expect_true(
+    all(as.logical(dp[dp$hash == c("_depend_trigger", "b"), "changed"]))
+  )
+  expect_equal(sum(dp$changed), 2)
   config$plan$command <- "b + c"
   dp <- dependency_profile(target = a, config = config)
-  expect_true(as.logical(dp[dp$hash == "command", "changed"]))
-  expect_equal(sum(dp$changed), 2)
+  expect_true(as.logical(dp[dp$hash == "_command_trigger", "changed"]))
+  expect_equal(sum(dp$changed), 3)
 })
 
 test_with_dir("Missing cache", {

--- a/tests/testthat/test-mtcars-example.R
+++ b/tests/testthat/test-mtcars-example.R
@@ -17,9 +17,6 @@ test_with_dir("mtcars example works", {
   dats <- c("small", "large")
   config$targets <- dats
   con <- testrun(config)
-
-  expect_true(is.list(dependency_profile(
-    target = "small", config = con)))
   expect_equal(parallelism == "Makefile", file.exists("Makefile"))
 
   expect_equal(sort(justbuilt(con)), sort(dats))

--- a/tests/testthat/test-plans.R
+++ b/tests/testthat/test-plans.R
@@ -373,7 +373,7 @@ test_with_dir("ignore() in imported functions", {
   expect_equal(justbuilt(config), "x")
   expect_equal(readd(f, cache = cache), f)
   expect_equal(
-    readd(f, cache = cache, namespace = "kernels")[3],
+    unname(readd(f, cache = cache, namespace = "kernels")[3]),
     "    (sqrt(ignore() + 123))"
   )
   f <- function(x){


### PR DESCRIPTION
# Changes

Previously, `dependency_profile()` only reported which triggers would fire on the next `make()`.

```r
library(drake)
load_mtcars_example()
config <- make(my_plan, verbose = FALSE)
dependency_profile(target = regression2_small, config = config)
## # A tibble: 4 x 4
##   hash     changed old_hash                    new_hash                   
##   <chr>    <lgl>   <chr>                       <chr>                      
## 1 command  FALSE   f08c9f154406ce85ab9834ffb1… f08c9f154406ce85ab9834ffb1…
## 2 depend   FALSE   ffe33a15d52e57557072fb9eb5… ffe33a15d52e57557072fb9eb5…
## 3 file_in  FALSE   01234566814cd2a2b3cd7c19c9… 01234566814cd2a2b3cd7c19c9…
## 4 file_out FALSE   01234566814cd2a2b3cd7c19c9… 01234566814cd2a2b3cd7c19c9…
```

In this PR, it also shows the exact dependencies that changed.

``` r
library(drake)
load_mtcars_example()
config <- make(my_plan, verbose = FALSE)
dependency_profile(report, config)
#> # A tibble: 9 x 4
#>   hash        changed old                        new                      
#>   <fct>       <lgl>   <chr>                      <chr>                    
#> 1 _command_t… FALSE   c01ff36c093c9671ad66e9305… c01ff36c093c9671ad66e930…
#> 2 _depend_tr… FALSE   25e8995a7c63c65151f5734ee… 25e8995a7c63c65151f5734e…
#> 3 _file_trig… FALSE   0d842cea3bd298b46929254b6… 0d842cea3bd298b46929254b…
#> 4 "\"report.… FALSE   4f96955c05b2b8d56e7ae383f… 4f96955c05b2b8d56e7ae383…
#> 5 "\"report.… FALSE   792052d30e6603187f9e274a5… 792052d30e6603187f9e274a…
#> 6 coef_regre… FALSE   2e52655d4d9ddb47           2e52655d4d9ddb47         
#> 7 knit        FALSE   286f3481b9173088           286f3481b9173088         
#> 8 large       FALSE   0feaa26f252dbfdd           0feaa26f252dbfdd         
#> 9 small       FALSE   7d836504e5060e6d           7d836504e5060e6d
```

# Performance considerations

As I said in https://github.com/ropensci/drake/issues/496#issuecomment-411609813, this enhancement has a potential performance penalty. Since we have to retain all the hashes of the dependencies, our target-level metadata is heavier, which theoretically could increase runtime and cache size.

To investigate, I constructed a project designed to maximize the strain on `drake`'s internals. The idea is to have lots of targets with lots of dependencies. Below, we have `2n` targets, each with `n` dependencies.

```r
n <- 4

library(drake)
library(magrittr)
x <- drake_plan(x = sqrt(y__)) %>%
  evaluate_plan(rules = list(y__ = seq_len(n)))
y <- gather_plan(x) %>%
  expand_plan(values = seq_len(n))
plan <- rbind(x, y)
vis_drake_graph(drake_config(plan))
```

![capture](https://user-images.githubusercontent.com/1580860/43909887-61547602-9bc9-11e8-93f3-da73574d198c.PNG)

I ran the workflow on the current CRAN `drake` ("old") and the version of `drake` ("new") for a few different values of `n`. Due to the large runtimes (again, this workflow deliberately maximized overhead) I only ran each combination once. The runtimes (in seconds) do not differ much between the new and old versions.

| n    | old      | new      |
|------|----------|----------|
| 10   | 3.957    | 3.728    |
| 100  | 34.141   | 37.034   |
| 1000 | 1741.985 | 1719.541 |

The cache sizes (in MB) do increase in size.

| n    | old      | new      | % increase |
|------|----------|----------|--------|
| 10   | 0.754 | 0.758 | 0.531 |
| 100  | 6.4 | 6.5 |  1.563 |
| 1000 | 449 | 510 |  13.586 |

The extra 61 MB between the old and new versions at `n = 1000` is disconcerting, but not entirely unexpected. And for most large workflows, I expect the increased storage to be small compared to the actual size of the user's output data objects. What do you think, @kendonB?

# Going forward

`dependency_profile()` aside, the slow runtime of this example is a huge concern and deserves serious profiling. I plan to add it to the [`drake-examples` repository](https://github.com/wlandau/drake-examples) so anyone can be download it with `drake_example("overhead")`.

# Related GitHub issues and pull requests

- Ref: #496 

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
