### PR TITLE
Fixes issue where a misspelled target name would loadd all targets

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 to tell the user if the command, a dependency, an input file, or an ouptut file changed since the last `make()`.
 - Choose more appropriate places to check that the `txtq` package is installed.
 - Expose the `template` argument of `clustermq` functions (e.g. `Q()` and `workers()`) as an argument of `make()` and `drake_config()`.
+- Fix bug where `loadd(not_a_target)` would load every target in the cache.
 
 # Version 5.4.0
 

--- a/R/read.R
+++ b/R/read.R
@@ -194,7 +194,7 @@ loadd <- function(
   }
   targets <- drake_select(
     cache = cache, ..., namespaces = namespace, list = list)
-  if (!length(targets)){
+  if (!length(targets) && !length(list(...))){
     targets <- cache$list()
   }
   if (imported_only){

--- a/tests/testthat/test-mtcars-example.R
+++ b/tests/testthat/test-mtcars-example.R
@@ -63,6 +63,10 @@ test_with_dir("mtcars example works", {
   e <- new.env(parent = globalenv())
   coefs <- sort(c("coef_regression1_large", "coef_regression1_small",
              "coef_regression2_large", "coef_regression2_small"))
+  
+  expect_error(loadd(not_a_target, envir = e))
+  expect_equal(ls(envir = e), character(0))
+  
   loadd(starts_with("coef"), envir = e)
   expect_equal(sort(ls(envir = e)), coefs)
 


### PR DESCRIPTION
# Summary

I'm pretty sure this was an unintended consequence of #209. Doing `loadd(x)` where `x` was not a target name would load *all* targets. This got to be annoying when the project was full of very large targets.

# Related GitHub issues and pull requests

- Ref: #271 #263 #209 

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [ ] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md). **appears to be a dead link?**
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
