### PR TITLE
Avoid serialization where possible

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # Version 5.4.0.9001
 
 - Add a proper [`clustermq`](https://github.com/mschubert/clustermq)-based parallel backend: `make(parallelism = "clustermq")`.
+- Avoid serialization in `digest()` wherever possible. This puts old `drake` projects out of date, but it improves speed.
 - Smooth the edges in `vis_drake_graph()` and `render_drake_graph()`.
 - Make hover text slightly more readable in in `vis_drake_graph()` and `render_drake_graph()`.
 - Align hover text properly in `vis_drake_graph()` using the "title" node column.

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -168,11 +168,16 @@ dependency_profile <- function(
   )] %>%
     unlist() %>%
     unname()
-  old_hashes[1] <- digest::digest(old_hashes[1], algo = config$long_hash_algo)
+  old_hashes[1] <- digest::digest(
+    paste(old_hashes[1], collapse = ""),
+    algo = config$long_hash_algo,
+    serialize = FALSE
+  )
   new_hashes <- c(
     digest::digest(
-      get_standardized_command(target, config),
-      algo = config$long_hash_algo
+      paste(get_standardized_command(target, config), collapse = ""),
+      algo = config$long_hash_algo,
+      serialize = FALSE
     ),
     dependency_hash(target, config),
     input_file_hash(target, config),

--- a/R/generate_plans.R
+++ b/R/generate_plans.R
@@ -196,8 +196,8 @@ evaluate_single_wildcard <- function(
   if (!any(matches)){
     return(plan)
   }
-  major <- digest::digest(tempfile())
-  minor <- digest::digest(tempfile())
+  major <- make.names(tempfile())
+  minor <- make.names(tempfile())
   plan[[major]] <- seq_len(nrow(plan))
   plan[[minor]] <- plan[[major]]
   matching <- plan[matches, ]

--- a/R/knitr.R
+++ b/R/knitr.R
@@ -81,7 +81,7 @@ safe_get_tangled_frags <- function(target){
 # From https://github.com/duncantl/CodeDepends/blob/master/R/sweave.R#L15
 get_tangled_frags <- function(doc) {
   assert_pkg("knitr")
-  id <- digest::digest(tempfile)
+  id <- make.names(tempfile())
   con <- textConnection(id, "w", local = TRUE)
   on.exit(close(con))
   knitr::knit(doc, output = con, tangle = TRUE, quiet = TRUE)

--- a/R/mc_utils.R
+++ b/R/mc_utils.R
@@ -191,7 +191,8 @@ mc_output_file_checksum <- function(target, config){
     FUN.VALUE = character(1),
     config = config
   ) %>%
-    digest::digest(algo = config$long_hash_algo)
+    paste(collapse = "") %>%
+    digest::digest(algo = config$long_hash_algo, serialize = FALSE)
 }
 
 mc_is_good_checksum <- function(target, checksum, config){

--- a/R/meta.R
+++ b/R/meta.R
@@ -57,7 +57,7 @@ drake_meta <- function(target, config = drake::read_drake_config()) {
     imported = !(target %in% config$plan$target),
     foreign = !exists(x = target, envir = config$envir, inherits = FALSE),
     missing = !target_exists(target = target, config = config),
-    seed = seed_from_object(list(seed = config$seed, target = target))
+    seed = seed_from_basic_types(config$seed, target)
   )
   # For imported files.
   if (is_file(target)) {
@@ -110,7 +110,8 @@ dependency_hash <- function(target, config) {
   }
   sort(as.character(unique(deps))) %>%
     self_hash(config = config) %>%
-    digest::digest(algo = config$long_hash_algo)
+    paste(collapse = "") %>%
+    digest::digest(algo = config$long_hash_algo, serialize = FALSE)
 }
 
 input_file_hash <- function(
@@ -131,7 +132,8 @@ input_file_hash <- function(
     config = config,
     size_cutoff = size_cutoff
   ) %>%
-    digest::digest(algo = config$long_hash_algo)
+    paste(collapse = "") %>%
+    digest::digest(algo = config$long_hash_algo, serialize = FALSE)
 }
 
 output_file_hash <- function(
@@ -152,7 +154,8 @@ output_file_hash <- function(
     config = config,
     size_cutoff = size_cutoff
   ) %>%
-    digest::digest(algo = config$long_hash_algo)
+    paste(collapse = "") %>%
+    digest::digest(algo = config$long_hash_algo, serialize = FALSE)
 }
 
 self_hash <- Vectorize(function(target, config) {

--- a/R/random.R
+++ b/R/random.R
@@ -29,9 +29,11 @@ get_previous_seed <- function(cache){
 
 # A numeric hash that could be used as a
 # random number generator seed. Generated
-# from an arbitrary object x.
-seed_from_object <- function(x) {
-  hash <- digest::digest(x, algo = "murmur32")
+# from arguments of basic types such as
+# numerics and characters.
+seed_from_basic_types <- function(...) {
+  hash <- paste0(..., collapse = "") %>%
+    digest::digest(algo = "murmur32", serialize = FALSE)
   hexval <- paste0("0x", hash)
   utils::type.convert(hexval) %% .Machine$integer.max
 }

--- a/R/timestamp.R
+++ b/R/timestamp.R
@@ -38,7 +38,8 @@ safe_encode <- Vectorize(function(x, hash_algo){
   digest::digest(
     object = x,
     algo = hash_algo,
-    file = FALSE
+    file = FALSE,
+    serialize = FALSE
   )
 },
 "x")

--- a/tests/testthat/test-intermediate-file.R
+++ b/tests/testthat/test-intermediate-file.R
@@ -56,15 +56,30 @@ test_with_dir("responses to intermediate file", {
       expect_equal(val2, readRDS("out2.rds"))
     }
 
-    # change what out2.rds is supposed to be
-    config$plan$command[1] <- gsub("1", "2", plan$command[1])
+    # change what intermediatefile.rds is supposed to be
+    config$plan$command[1] <- gsub(
+      "combined,",
+      "combined + 5,",
+      config$plan$command[1]
+    )
     testrun(config)
     expect_equal(
       sort(justbuilt(config)),
       sort(c("drake_target_1", "final"))
     )
-    expect_equal(final0 + 1, readd(final, search = FALSE))
-    expect_equal(val, readRDS("intermediatefile.rds"))
+    expect_equal(final0 + 5, readd(final, search = FALSE))
+    expect_equal(val + 5, readRDS("intermediatefile.rds"))
+    expect_equal(val2, readRDS("out2.rds"))
+
+    # change what out2.rds is supposed to be
+    config$plan$command[1] <- gsub("1", "2", config$plan$command[1])
+    testrun(config)
+    expect_equal(
+      sort(justbuilt(config)),
+      sort(c("drake_target_1", "final"))
+    )
+    expect_equal(final0 + 6, readd(final, search = FALSE))
+    expect_equal(val + 5, readRDS("intermediatefile.rds"))
     expect_equal(val2 + 1, readRDS("out2.rds"))
     clean(destroy = TRUE)
   }

--- a/tests/testthat/test-mtcars-example.R
+++ b/tests/testthat/test-mtcars-example.R
@@ -39,6 +39,8 @@ test_with_dir("mtcars example works", {
     my_plan, envir = e, jobs = jobs, parallelism = parallelism,
     verbose = FALSE)
   expect_equal(outdated(config), character(0))
+
+  # Change an imported function
   e$reg2 <- function(d) {
     d$x3 <- d$x ^ 3
     lm(y ~ x3, data = d)
@@ -46,12 +48,14 @@ test_with_dir("mtcars example works", {
   config <- drake_config(
     my_plan, envir = e, jobs = jobs, parallelism = parallelism,
     verbose = FALSE)
-  expect_equal(
-    sort(outdated(config = config)),
-    sort(c("report", "coef_regression2_large",
-      "coef_regression2_small", "regression2_large", "regression2_small",
-      "summ_regression2_large", "summ_regression2_small")))
+  to_build <- sort(c(
+    "report", "coef_regression2_large",
+    "coef_regression2_small", "regression2_large", "regression2_small",
+    "summ_regression2_large", "summ_regression2_small"
+  ))
+  expect_equal(sort(outdated(config = config)), to_build)
   testrun(config)
+  expect_equal(sort(justbuilt(config)), to_build)
   config <- drake_config(
     my_plan, envir = e, jobs = jobs, parallelism = parallelism,
     verbose = FALSE)

--- a/tests/testthat/test-random.R
+++ b/tests/testthat/test-random.R
@@ -1,5 +1,18 @@
 drake_context("reproducible random numbers")
 
+test_with_dir("seed_from_basic_types", {
+  set.seed(0)
+  seed <- .Random.seed # nolint
+  s1 <- seed_from_basic_types(seed, "abc")
+  s2 <- seed_from_basic_types(seed, "abc")
+  s3 <- seed_from_basic_types(seed, "xyz")
+  rnorm(1)
+  s4 <- seed_from_basic_types(seed, "xyz")
+  expect_true(identical(s1, s2))
+  expect_false(identical(s1, s3))
+  expect_false(identical(s1, s4))
+})
+
 test_with_dir("Random targets are reproducible", {
   skip_on_cran() # CRAN gets whitelist tests only (check time limits).
   scenario <- get_testing_scenario()

--- a/tests/testthat/test-random.R
+++ b/tests/testthat/test-random.R
@@ -6,11 +6,13 @@ test_with_dir("seed_from_basic_types", {
   s1 <- seed_from_basic_types(seed, "abc")
   s2 <- seed_from_basic_types(seed, "abc")
   s3 <- seed_from_basic_types(seed, "xyz")
-  rnorm(1)
+  seed[length(seed)] <- seed[length(seed)] + 1
   s4 <- seed_from_basic_types(seed, "xyz")
   expect_true(identical(s1, s2))
   expect_false(identical(s1, s3))
   expect_false(identical(s1, s4))
+  expect_false(identical(s2, s4))
+  expect_false(identical(s3, s4))
 })
 
 test_with_dir("Random targets are reproducible", {


### PR DESCRIPTION
# Summary

I went back and set `serialization = FALSE` wherever possible in `digest()`. I also removed `digest()` altogether in places where we do not need it. The result is a mild speedup in the [overhead example](https://github.com/wlandau/drake-examples/tree/master/overhead). Compare the benchmarks below with the ones from https://github.com/ropensci/drake/issues/498#issuecomment-415999409. 

```r
Unit: milliseconds
           expr         min          lq        mean      median          uq
    overhead(8)    154.5515    168.6676    173.7764    176.0602    181.0810
   overhead(16)    269.5904    280.3506    291.7657    285.7488    294.3176
   overhead(32)    499.7459    532.4355    565.7931    566.1701    581.3911
   overhead(64)   1159.7330   1168.1976   1257.3333   1214.9683   1306.0603
  overhead(128)   3100.4387   3207.0103   3405.2388   3278.8028   3422.6477
  overhead(256)  10199.0150  10325.9877  10878.9682  10403.1810  10707.0694
  overhead(512)  39779.6898  40693.1264  42708.3793  41038.2288  41303.8510
 overhead(1024) 198521.5008 202248.1117 211531.5450 204567.2973 204972.7984
         max neval
    182.4444    10
    339.0435    10
    689.8749    10
   1586.9127    10
   4443.1843    10
  14895.6359    10
  59577.5015    10
 285253.7403    10
```

Sensitive pieces of the internals changed, so this PR needs extra scrutiny and testing before a merge.

# Related GitHub issues and pull requests

- Ref: #498 (still needs work)

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
