### PR TITLE
Reference Geneva RUG 2018/10/04

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -315,7 +315,7 @@ There are multiple `drake`-powered example projects [available here](https://git
 - [`drake` + cooking with Kirill](https://krlmlr.github.io/slides/drake-sib-zurich).
 - [`drake` + cooking exercises](https://krlmlr.github.io/slides/drake-sib-zurich/cooking.html).
 - [Christine Stawitz](https://github.com/cstawitz)'s [R-Ladies Seattle talk on June 25, 2018](https://github.com/cstawitz/RLadies_Sea_drake).
-- [Sina Rüeger](https://github.com/sinarueeger)'s [presentation to the Geneva R Users Group on October 4, 2018](https://sinarueeger.github.io/20181004-geneve-rug) and ([example code](https://github.com/sinarueeger/workflow-example)). The talk broadly focused on tidy workflows and divesity in the R community.
+- [Sina Rüeger](https://github.com/sinarueeger)'s [Geneva R Users Group presentation on October 4, 2018](https://sinarueeger.github.io/20181004-geneve-rug) ([example code](https://github.com/sinarueeger/workflow-example)). The talk broadly focused on tidy workflows and divesity in the R community.
 
 ## Real example projects
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -315,7 +315,7 @@ There are multiple `drake`-powered example projects [available here](https://git
 - [`drake` + cooking with Kirill](https://krlmlr.github.io/slides/drake-sib-zurich).
 - [`drake` + cooking exercises](https://krlmlr.github.io/slides/drake-sib-zurich/cooking.html).
 - [Christine Stawitz](https://github.com/cstawitz)'s [R-Ladies Seattle talk on June 25, 2018](https://github.com/cstawitz/RLadies_Sea_drake).
-- [Sina Rüeger](https://github.com/sinarueeger)'s [Geneva R Users Group presentation on October 4, 2018](https://sinarueeger.github.io/20181004-geneve-rug) ([example code](https://github.com/sinarueeger/workflow-example)). The talk broadly focused on tidy workflows and divesity in the R community.
+- [Sina Rüeger](https://github.com/sinarueeger)'s [Geneva R Users Group presentation on October 4, 2018](https://sinarueeger.github.io/20181004-geneve-rug) ([example code](https://github.com/sinarueeger/workflow-example)). The talk broadly focused on tidy workflows and diversity in the R community.
 
 ## Real example projects
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -312,9 +312,10 @@ There are multiple `drake`-powered example projects [available here](https://git
 ## Presentations
 
 - [Kirill's `drake` pitch](https://krlmlr.github.io/drake-pitch)
-- [`drake` + cooking with Kirill](https://krlmlr.github.io/slides/drake-sib-zurich)
-- [`drake` + cooking exercises](https://krlmlr.github.io/slides/drake-sib-zurich/cooking.html)
-- [Christine Stawitz](https://github.com/cstawitz)'s [R-Ladies Seattle talk on June 25, 2018](https://github.com/cstawitz/RLadies_Sea_drake)
+- [`drake` + cooking with Kirill](https://krlmlr.github.io/slides/drake-sib-zurich).
+- [`drake` + cooking exercises](https://krlmlr.github.io/slides/drake-sib-zurich/cooking.html).
+- [Christine Stawitz](https://github.com/cstawitz)'s [R-Ladies Seattle talk on June 25, 2018](https://github.com/cstawitz/RLadies_Sea_drake).
+- [Sina Rüeger](https://github.com/sinarueeger)'s [presentation to the Geneva R Users Group on October 4, 2018](https://sinarueeger.github.io/20181004-geneve-rug) and ([example code](https://github.com/sinarueeger/workflow-example)). The talk broadly focused on tidy workflows and divesity in the R community.
 
 ## Real example projects
 

--- a/README.md
+++ b/README.md
@@ -528,12 +528,18 @@ request](https://github.com/wlandau/drake-examples/pulls).
 
   - [Kirill’s `drake` pitch](https://krlmlr.github.io/drake-pitch)
   - [`drake` + cooking with
-    Kirill](https://krlmlr.github.io/slides/drake-sib-zurich)
+    Kirill](https://krlmlr.github.io/slides/drake-sib-zurich).
   - [`drake` + cooking
-    exercises](https://krlmlr.github.io/slides/drake-sib-zurich/cooking.html)
+    exercises](https://krlmlr.github.io/slides/drake-sib-zurich/cooking.html).
   - [Christine Stawitz](https://github.com/cstawitz)’s [R-Ladies Seattle
     talk on
-    June 25, 2018](https://github.com/cstawitz/RLadies_Sea_drake)
+    June 25, 2018](https://github.com/cstawitz/RLadies_Sea_drake).
+  - [Sina Rüeger](https://github.com/sinarueeger)’s [presentation to the
+    Geneva R Users Group on
+    October 4, 2018](https://sinarueeger.github.io/20181004-geneve-rug)
+    and ([example
+    code](https://github.com/sinarueeger/workflow-example)). The talk
+    broadly focused on tidy workflows and divesity in the R community.
 
 ## Real example projects
 

--- a/README.md
+++ b/README.md
@@ -534,12 +534,12 @@ request](https://github.com/wlandau/drake-examples/pulls).
   - [Christine Stawitz](https://github.com/cstawitz)’s [R-Ladies Seattle
     talk on
     June 25, 2018](https://github.com/cstawitz/RLadies_Sea_drake).
-  - [Sina Rüeger](https://github.com/sinarueeger)’s [presentation to the
-    Geneva R Users Group on
+  - [Sina Rüeger](https://github.com/sinarueeger)’s [Geneva R Users
+    Group presentation on
     October 4, 2018](https://sinarueeger.github.io/20181004-geneve-rug)
-    and ([example
-    code](https://github.com/sinarueeger/workflow-example)). The talk
-    broadly focused on tidy workflows and divesity in the R community.
+    ([example code](https://github.com/sinarueeger/workflow-example)).
+    The talk broadly focused on tidy workflows and divesity in the R
+    community.
 
 ## Real example projects
 

--- a/README.md
+++ b/README.md
@@ -538,7 +538,7 @@ request](https://github.com/wlandau/drake-examples/pulls).
     Group presentation on
     October 4, 2018](https://sinarueeger.github.io/20181004-geneve-rug)
     ([example code](https://github.com/sinarueeger/workflow-example)).
-    The talk broadly focused on tidy workflows and divesity in the R
+    The talk broadly focused on tidy workflows and diversity in the R
     community.
 
 ## Real example projects

--- a/vignettes/drake.Rmd
+++ b/vignettes/drake.Rmd
@@ -57,6 +57,7 @@ There are multiple `drake`-powered example projects [available here](https://git
 - [`drake` + cooking with Kirill](https://krlmlr.github.io/slides/drake-sib-zurich)
 - [`drake` + cooking exercises](https://krlmlr.github.io/slides/drake-sib-zurich/cooking.html)
 - [Christine Stawitz](https://github.com/cstawitz)'s [R-Ladies Seattle talk on June 25, 2018](https://github.com/cstawitz/RLadies_Sea_drake)
+- [Sina Rüeger](https://github.com/sinarueeger)'s [presentation to the Geneva R Users Group on October 4, 2018](https://sinarueeger.github.io/20181004-geneve-rug) and ([example code](https://github.com/sinarueeger/workflow-example)). The talk broadly focused on tidy workflows and divesity in the R community.
 
 ## Real example projects
 

--- a/vignettes/drake.Rmd
+++ b/vignettes/drake.Rmd
@@ -57,7 +57,7 @@ There are multiple `drake`-powered example projects [available here](https://git
 - [`drake` + cooking with Kirill](https://krlmlr.github.io/slides/drake-sib-zurich)
 - [`drake` + cooking exercises](https://krlmlr.github.io/slides/drake-sib-zurich/cooking.html)
 - [Christine Stawitz](https://github.com/cstawitz)'s [R-Ladies Seattle talk on June 25, 2018](https://github.com/cstawitz/RLadies_Sea_drake)
-- [Sina Rüeger](https://github.com/sinarueeger)'s [Geneva R Users Group presentation on October 4, 2018](https://sinarueeger.github.io/20181004-geneve-rug) ([example code](https://github.com/sinarueeger/workflow-example)). The talk broadly focused on tidy workflows and divesity in the R community.
+- [Sina Rüeger](https://github.com/sinarueeger)'s [Geneva R Users Group presentation on October 4, 2018](https://sinarueeger.github.io/20181004-geneve-rug) ([example code](https://github.com/sinarueeger/workflow-example)). The talk broadly focused on tidy workflows and diversity in the R community.
 
 ## Real example projects
 

--- a/vignettes/drake.Rmd
+++ b/vignettes/drake.Rmd
@@ -57,7 +57,7 @@ There are multiple `drake`-powered example projects [available here](https://git
 - [`drake` + cooking with Kirill](https://krlmlr.github.io/slides/drake-sib-zurich)
 - [`drake` + cooking exercises](https://krlmlr.github.io/slides/drake-sib-zurich/cooking.html)
 - [Christine Stawitz](https://github.com/cstawitz)'s [R-Ladies Seattle talk on June 25, 2018](https://github.com/cstawitz/RLadies_Sea_drake)
-- [Sina Rüeger](https://github.com/sinarueeger)'s [presentation to the Geneva R Users Group on October 4, 2018](https://sinarueeger.github.io/20181004-geneve-rug) and ([example code](https://github.com/sinarueeger/workflow-example)). The talk broadly focused on tidy workflows and divesity in the R community.
+- [Sina Rüeger](https://github.com/sinarueeger)'s [Geneva R Users Group presentation on October 4, 2018](https://sinarueeger.github.io/20181004-geneve-rug) ([example code](https://github.com/sinarueeger/workflow-example)). The talk broadly focused on tidy workflows and divesity in the R community.
 
 ## Real example projects
 


### PR DESCRIPTION
This PR adds Geneva RUG 2018/10/04 to the list of presentations featuring `drake`. @sinarueeger does this sound good to you? If so, I will also update the [manual](https://github.com/ropenscilabs/drake-manual).

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
