### PR TITLE
Caching options for clustermq parallelism

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # Version 6.0.0.9000
 
+## New features
+
+- Enable the `caching` argument for `"clustermq"` parallelism. Now, `make(parallelism = "clustermq", caching = "master")` will do all the caching with the master process, and `make(parallelism = "clustermq", caching = "worker")` will do all the caching with the workers.
+
 ## Bug fixes
 
 - Call `path.expand()` on the `file` argument to `render_drake_graph()` and `render_sankey_drake_graph()`. That way, tildes in file paths no longer interfere with the rendering of static image files. Compensates for https://github.com/wch/webshot.

--- a/R/build.R
+++ b/R/build.R
@@ -86,6 +86,7 @@ build_check_store <- function(
   if (flag_attempt && target %in% config$plan$target){
     set_attempt_flag(key = target, config = config)
   }
+  invisible()
 }
 
 build_and_store <- function(target, config, meta = NULL, announce = TRUE){

--- a/R/config.R
+++ b/R/config.R
@@ -304,8 +304,9 @@
 #'   To reset the random number generator seed for a project,
 #'   use `clean(destroy = TRUE)`.
 #'
-#' @param caching character string, only applies to `"future"` parallelism.
-#'   Can be either `"master"` or `"worker"`.
+#' @param caching character string, only applies to
+#'   `"clustermq"` and `"future"` parallelism.
+#'   The `caching` argument can be either `"master"` or `"worker"`.
 #'   - `"master"`: Targets are built by remote workers and sent back to
 #'     the master process. Then, the master process saves them to the
 #'     cache (`config$cache`, usually a file system `storr`).

--- a/man/drake_config.Rd
+++ b/man/drake_config.Rd
@@ -314,8 +314,9 @@ seed from the project's cache (usually the \code{.drake/} folder).
 To reset the random number generator seed for a project,
 use \code{clean(destroy = TRUE)}.}
 
-\item{caching}{character string, only applies to \code{"future"} parallelism.
-Can be either \code{"master"} or \code{"worker"}.
+\item{caching}{character string, only applies to
+\code{"clustermq"} and \code{"future"} parallelism.
+The \code{caching} argument can be either \code{"master"} or \code{"worker"}.
 \itemize{
 \item \code{"master"}: Targets are built by remote workers and sent back to
 the master process. Then, the master process saves them to the

--- a/man/make.Rd
+++ b/man/make.Rd
@@ -321,8 +321,9 @@ seed from the project's cache (usually the \code{.drake/} folder).
 To reset the random number generator seed for a project,
 use \code{clean(destroy = TRUE)}.}
 
-\item{caching}{character string, only applies to \code{"future"} parallelism.
-Can be either \code{"master"} or \code{"worker"}.
+\item{caching}{character string, only applies to
+\code{"clustermq"} and \code{"future"} parallelism.
+The \code{caching} argument can be either \code{"master"} or \code{"worker"}.
 \itemize{
 \item \code{"master"}: Targets are built by remote workers and sent back to
 the master process. Then, the master process saves them to the

--- a/tests/testthat/test-clustermq.R
+++ b/tests/testthat/test-clustermq.R
@@ -13,25 +13,29 @@ test_with_dir("clustermq parallelism", {
   jobs <- scenario$jobs # ignoring for now, using 2 jobs
   load_mtcars_example(envir = e)
   for (parallelism in c("clustermq", "clustermq_staged")){
-    make(
-      e$my_plan,
-      parallelism = parallelism,
-      jobs = jobs,
-      envir = e,
-      verbose = 4,
-      garbage_collection = TRUE
-    )
-    config <- drake_config(e$my_plan, envir = e)
-    expect_equal(outdated(config), character(0))
-    make(
-      e$my_plan,
-      parallelism = parallelism,
-      jobs = jobs,
-      envir = e,
-      verbose = 4
-    )
-    expect_equal(justbuilt(config), character(0))
-    clean(destroy = TRUE)
+    for (caching in c("master", "worker")){
+      make(
+        e$my_plan,
+        parallelism = parallelism,
+        jobs = jobs,
+        caching = caching,
+        envir = e,
+        verbose = 4,
+        garbage_collection = TRUE
+      )
+      config <- drake_config(e$my_plan, envir = e)
+      expect_equal(outdated(config), character(0))
+      make(
+        e$my_plan,
+        parallelism = parallelism,
+        jobs = jobs,
+        caching = caching,
+        envir = e,
+        verbose = 4
+      )
+      expect_equal(justbuilt(config), character(0))
+      clean(destroy = TRUE)
+    }
   }
   if ("package:clustermq" %in% search()){
     eval(parse(text = "detach('package:clustermq', unload = TRUE)"))


### PR DESCRIPTION
# Summary

In this PR, we have caching options for `clustermq` parallelism. `make(parallelism = "clustermq", caching = "master")` does all the caching on the master process, and `make(parallelism = "clustermq", caching = "worker")` does the caching on the workers. Unfortunately, `caching = "worker"` does not take advantage of the speed of ZeroMQ sockets for writing data to the cache, but `clustermq` is still *awesome* because worker arrays spin up super fast.

cc @kendonB, @mschubert, @huizhang-lilly

# Related GitHub issues and pull requests

- Ref: #531

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
