### PR TITLE
Caching options for clustermq_staged parallelism

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## New features
 
-- Enable the `caching` argument for `"clustermq"` parallelism. Now, `make(parallelism = "clustermq", caching = "master")` will do all the caching with the master process, and `make(parallelism = "clustermq", caching = "worker")` will do all the caching with the workers.
+- Enable the `caching` argument for the `"clustermq"` and `"clustermq_staged"` parallel backends. Now, `make(parallelism = "clustermq", caching = "master")` will do all the caching with the master process, and `make(parallelism = "clustermq", caching = "worker")` will do all the caching with the workers. The same is true for `parallelism = "clustermq_staged"`.
 
 ## Bug fixes
 

--- a/R/clustermq.R
+++ b/R/clustermq.R
@@ -21,6 +21,7 @@ cmq_set_common_data <- function(config){
   if (identical(config$envir, globalenv())){
     export <- as.list(config$envir, all.names = TRUE) # nocov
   }
+  config$cache$flush_cache()
   export$config <- config
   config$workers$set_common_data(
     export = export,
@@ -134,7 +135,10 @@ cmq_conclude_build <- function(msg, config){
   cmq_conclude_target(target = build$target, config = config)
   if (identical(config$caching, "worker")){
     mc_wait_checksum(
-      target = build$target, checksum = build$checksum, config = config)
+      target = build$target,
+      checksum = build$checksum,
+      config = config
+    )
     return()
   }
   set_attempt_flag(key = build$target, config = config)

--- a/R/config.R
+++ b/R/config.R
@@ -305,7 +305,7 @@
 #'   use `clean(destroy = TRUE)`.
 #'
 #' @param caching character string, only applies to
-#'   `"clustermq"` and `"future"` parallelism.
+#'   `"clustermq"`, `"clustermq_staged"`, and `"future"` parallel backends.
 #'   The `caching` argument can be either `"master"` or `"worker"`.
 #'   - `"master"`: Targets are built by remote workers and sent back to
 #'     the master process. Then, the master process saves them to the

--- a/inst/testing/scenarios.csv
+++ b/inst/testing/scenarios.csv
@@ -5,8 +5,8 @@ envir,parallelism,jobs,backend,caching
 "local","mclapply",1,,
 "local","mclapply",9,,
 "local","mclapply_staged",2,,
-"local","clustermq",2,,
-"local","clustermq_staged",9,,
+"local","clustermq",2,,"master"
+"local","clustermq_staged",9,,"worker"
 "local","Makefile",9,,
 "local","future_lapply",2,"future::multisession",
 "local","future_lapply_staged",1,"future::multisession",
@@ -17,8 +17,8 @@ envir,parallelism,jobs,backend,caching
 "global","mclapply",1,,
 "global","mclapply",2,,
 "global","mclapply_staged",9,,
-"global","clustermq",9,,
-"global","clustermq_staged",2,,
+"global","clustermq",9,,"worker"
+"global","clustermq_staged",2,,"master"
 "global","Makefile",2,,
 "global","future_lapply",1,"future::multisession",
 "global","future_lapply_staged",2,"future::multisession",

--- a/man/drake_config.Rd
+++ b/man/drake_config.Rd
@@ -315,7 +315,7 @@ To reset the random number generator seed for a project,
 use \code{clean(destroy = TRUE)}.}
 
 \item{caching}{character string, only applies to
-\code{"clustermq"} and \code{"future"} parallelism.
+\code{"clustermq"}, \code{"clustermq_staged"}, and \code{"future"} parallel backends.
 The \code{caching} argument can be either \code{"master"} or \code{"worker"}.
 \itemize{
 \item \code{"master"}: Targets are built by remote workers and sent back to

--- a/man/make.Rd
+++ b/man/make.Rd
@@ -322,7 +322,7 @@ To reset the random number generator seed for a project,
 use \code{clean(destroy = TRUE)}.}
 
 \item{caching}{character string, only applies to
-\code{"clustermq"} and \code{"future"} parallelism.
+\code{"clustermq"}, \code{"clustermq_staged"}, and \code{"future"} parallel backends.
 The \code{caching} argument can be either \code{"master"} or \code{"worker"}.
 \itemize{
 \item \code{"master"}: Targets are built by remote workers and sent back to

--- a/tests/testthat/test-clustermq.R
+++ b/tests/testthat/test-clustermq.R
@@ -14,6 +14,8 @@ test_with_dir("clustermq parallelism", {
   load_mtcars_example(envir = e)
   for (parallelism in c("clustermq", "clustermq_staged")){
     for (caching in c("master", "worker")){
+      config <- drake_config(e$my_plan, envir = e)
+      expect_equal(length(outdated(config)), nrow(config$plan))
       make(
         e$my_plan,
         parallelism = parallelism,
@@ -23,7 +25,6 @@ test_with_dir("clustermq parallelism", {
         verbose = 4,
         garbage_collection = TRUE
       )
-      config <- drake_config(e$my_plan, envir = e)
       expect_equal(outdated(config), character(0))
       make(
         e$my_plan,


### PR DESCRIPTION
# Summary

Same as #532, but for `parallelism = "clustermq_staged"`

# Related GitHub issues and pull requests

- Ref: #531

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have read the [guidelines for contributing](https://github.com/ropensci/drake/blob/master/CONTRIBUTING.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
