### PR TITLE
Allow customization of sleeping between loop iterations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 - Enable the `caching` argument for the `"clustermq"` and `"clustermq_staged"` parallel backends. Now, `make(parallelism = "clustermq", caching = "master")` will do all the caching with the master process, and `make(parallelism = "clustermq", caching = "worker")` will do all the caching with the workers. The same is true for `parallelism = "clustermq_staged"`.
 - Add a new `drake_debug()` function to run a target's command in debug mode. Analogous to `drake_build()`.
 - Add a `mode` argument to `trigger()` to control how the `condition` trigger factors into the decision to build or skip a target. See the `?trigger` for details.
+- Add a new `sleep` argument to `make()` and `drake_config()` to help the master process consume fewer resources during parallel processing.
 
 ## Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -23,7 +23,7 @@
 - Allow the `condition` trigger to evaluate to non-logical values as long as those values can be coerced to logicals.
 - Require that the `condition` trigger evaluate to a vector of length 1.
 - Keep non-standard columns in `drake_plan_source()`.
-- `make(verbose = 4)` now prints to the console when a target or import is stored.
+- `make(verbose = 4)` now prints to the console when a target is stored.
 
 # Version 6.0.0
 

--- a/R/checksums.R
+++ b/R/checksums.R
@@ -73,11 +73,14 @@ mc_wait_checksum <- function(
   criterion = mc_is_good_checksum
 ){
   i <- 0
-  while (i < timeout / mc_wait){
+  time_left <- timeout
+  while (time_left > 0){
     if (criterion(target, checksum, config)){
       return()
     } else {
-      Sys.sleep(mc_wait)
+      sleep <- config$sleep(i)
+      Sys.sleep(sleep)
+      time_left <- time_left - sleep
     }
     i <- i + 1
   }

--- a/R/config.R
+++ b/R/config.R
@@ -396,6 +396,7 @@
 #'   The `sleep` argument is a function that takes an argument
 #'   `i` and returns a numeric scalar, the number of seconds to
 #'   supply to `Sys.sleep()` after iteration `i` of checking.
+#'   (Here, `i` starts at 1.)
 #'   If the checking loop does something other than sleeping
 #'   on iteration `i`, then `i` is reset back to 1.
 #'
@@ -404,7 +405,7 @@
 #'   But to avoid consuming too many resources during heavier
 #'   and longer workflows, you might use an exponential
 #'   backoff: say,
-#'   `function(i) { Sys.sleep(0.1 + 120 * pexp(i - 1, rate = 0.01)) }`.
+#'   `function(i) { 0.1 + 120 * pexp(i - 1, rate = 0.01) }`.
 #'
 #' @examples
 #' \dontrun{

--- a/R/future.R
+++ b/R/future.R
@@ -3,9 +3,11 @@ run_future <- function(config){
   queue <- new_priority_queue(config = config)
   workers <- initialize_workers(config)
   # While any targets are queued or running...
+  i <- 1
   while (work_remains(queue = queue, workers = workers, config = config)){
     for (id in seq_along(workers)){
       if (is_idle(workers[[id]])){
+        i <- 1
         # Also calls decrease-key on the queue.
         workers[[id]] <- conclude_worker(
           worker = workers[[id]],
@@ -31,7 +33,8 @@ run_future <- function(config){
         )
       }
     }
-    Sys.sleep(mc_wait)
+    Sys.sleep(config$sleep(i))
+    i <- i + 1
   }
 }
 

--- a/R/make.R
+++ b/R/make.R
@@ -115,7 +115,8 @@ make <- function(
   console_log_file = NULL,
   ensure_workers = TRUE,
   garbage_collection = FALSE,
-  template = list()
+  template = list(),
+  sleep = function(i) 0.01
 ){
   force(envir)
   if (!is.null(return_config)){
@@ -166,7 +167,8 @@ make <- function(
       console_log_file = console_log_file,
       ensure_workers = ensure_workers,
       garbage_collection = garbage_collection,
-      template = template
+      template = template,
+      sleep = sleep
     )
   }
   make_with_config(config = config)

--- a/R/mc_utils.R
+++ b/R/mc_utils.R
@@ -37,8 +37,12 @@ mc_ensure_workers <- function(config){
     },
     FUN.VALUE = character(1)
   )
+  i <- 1
   while (!all(file.exists(paths))){
-    Sys.sleep(mc_wait) # nocov
+    # nocov start
+    Sys.sleep(config$sleep(i))
+    i <- i + 1
+    # nocov end
   }
 }
 
@@ -141,8 +145,12 @@ mc_conclude_workers <- function(config){
 }
 
 mc_get_worker_queue <- function(worker, namespace, config){
+  i <- 1
   while (!config$cache$exists(key = worker, namespace = namespace)){
-    Sys.sleep(mc_wait) # nocov
+    # nocov start
+    Sys.sleep(config$sleep(i))
+    i <- i + 1
+    # nocov end
   }
   txtq::txtq(config$cache$get(key = worker, namespace = namespace))
 }
@@ -176,5 +184,3 @@ mc_abort_with_errored_workers <- function(config){
   }
   FALSE
 }
-
-mc_wait <- 0.01

--- a/R/store.R
+++ b/R/store.R
@@ -4,7 +4,9 @@ store_outputs <- function(target, value, meta, config){
   if (inherits(meta$error, "error")){
     return()
   }
-  console_store(target = target, config = config)
+  if (!meta$imported){
+    console_store(target = target, config = config)
+  }
   if (is.null(meta$command)){
     meta$command <- get_standardized_command(target = target, config = config)
   }

--- a/man/drake_config.Rd
+++ b/man/drake_config.Rd
@@ -24,7 +24,7 @@ drake_config(plan = read_drake_plan(), targets = NULL,
   pruning_strategy = c("lookahead", "speed", "memory"),
   makefile_path = "Makefile", console_log_file = NULL,
   ensure_workers = TRUE, garbage_collection = FALSE,
-  template = list())
+  template = list(), sleep = function(i) 0.01)
 }
 \arguments{
 \item{plan}{workflow plan data frame.
@@ -400,6 +400,27 @@ For more information, see the \code{clustermq} package:
 \url{https://github.com/mschubert/clustermq}.
 Some template placeholders such as \code{{{ job_name }}} and \code{{{ n_jobs }}}
 cannot be set this way.}
+
+\item{sleep}{In its parallel processing, \code{drake} uses
+a central master process to check what the parallel
+workers are doing. Between, the master process
+sleeps to avoid throttling.
+The \code{sleep} argument to \code{make()} and \code{drake_config()}
+allows you to customize how much time the master process spends
+sleeping.
+
+The \code{sleep} argument is a function that takes an argument
+\code{i} and returns a numeric scalar, the number of seconds to
+supply to \code{Sys.sleep()} after iteration \code{i} of checking.
+If the checking loop does something other than sleeping
+on iteration \code{i}, then \code{i} is reset back to 1.
+
+To sleep for the same amount of time between checks,
+you might supply something like \code{function(i) 0.01}.
+But to avoid consuming too many resources during heavier
+and longer workflows, you might use an exponential
+backoff: say,
+\code{function(i) { Sys.sleep(0.1 + 120 * pexp(i - 1, rate = 0.01)) }}.}
 }
 \value{
 The master internal configuration list of a project.

--- a/man/drake_config.Rd
+++ b/man/drake_config.Rd
@@ -412,6 +412,7 @@ sleeping.
 The \code{sleep} argument is a function that takes an argument
 \code{i} and returns a numeric scalar, the number of seconds to
 supply to \code{Sys.sleep()} after iteration \code{i} of checking.
+(Here, \code{i} starts at 1.)
 If the checking loop does something other than sleeping
 on iteration \code{i}, then \code{i} is reset back to 1.
 
@@ -420,7 +421,7 @@ you might supply something like \code{function(i) 0.01}.
 But to avoid consuming too many resources during heavier
 and longer workflows, you might use an exponential
 backoff: say,
-\code{function(i) { Sys.sleep(0.1 + 120 * pexp(i - 1, rate = 0.01)) }}.}
+\code{function(i) { 0.1 + 120 * pexp(i - 1, rate = 0.01) }}.}
 }
 \value{
 The master internal configuration list of a project.

--- a/man/make.Rd
+++ b/man/make.Rd
@@ -419,6 +419,7 @@ sleeping.
 The \code{sleep} argument is a function that takes an argument
 \code{i} and returns a numeric scalar, the number of seconds to
 supply to \code{Sys.sleep()} after iteration \code{i} of checking.
+(Here, \code{i} starts at 1.)
 If the checking loop does something other than sleeping
 on iteration \code{i}, then \code{i} is reset back to 1.
 
@@ -427,7 +428,7 @@ you might supply something like \code{function(i) 0.01}.
 But to avoid consuming too many resources during heavier
 and longer workflows, you might use an exponential
 backoff: say,
-\code{function(i) { Sys.sleep(0.1 + 120 * pexp(i - 1, rate = 0.01)) }}.}
+\code{function(i) { 0.1 + 120 * pexp(i - 1, rate = 0.01) }}.}
 }
 \value{
 The master internal configuration list, mostly

--- a/man/make.Rd
+++ b/man/make.Rd
@@ -23,7 +23,7 @@ make(plan = read_drake_plan(), targets = NULL,
   pruning_strategy = c("lookahead", "speed", "memory"),
   makefile_path = "Makefile", console_log_file = NULL,
   ensure_workers = TRUE, garbage_collection = FALSE,
-  template = list())
+  template = list(), sleep = function(i) 0.01)
 }
 \arguments{
 \item{plan}{workflow plan data frame.
@@ -407,6 +407,27 @@ For more information, see the \code{clustermq} package:
 \url{https://github.com/mschubert/clustermq}.
 Some template placeholders such as \code{{{ job_name }}} and \code{{{ n_jobs }}}
 cannot be set this way.}
+
+\item{sleep}{In its parallel processing, \code{drake} uses
+a central master process to check what the parallel
+workers are doing. Between, the master process
+sleeps to avoid throttling.
+The \code{sleep} argument to \code{make()} and \code{drake_config()}
+allows you to customize how much time the master process spends
+sleeping.
+
+The \code{sleep} argument is a function that takes an argument
+\code{i} and returns a numeric scalar, the number of seconds to
+supply to \code{Sys.sleep()} after iteration \code{i} of checking.
+If the checking loop does something other than sleeping
+on iteration \code{i}, then \code{i} is reset back to 1.
+
+To sleep for the same amount of time between checks,
+you might supply something like \code{function(i) 0.01}.
+But to avoid consuming too many resources during heavier
+and longer workflows, you might use an exponential
+backoff: say,
+\code{function(i) { Sys.sleep(0.1 + 120 * pexp(i - 1, rate = 0.01)) }}.}
 }
 \value{
 The master internal configuration list, mostly


### PR DESCRIPTION
# Summary

In its parallel processing, `drake` uses a central master process to check what the parallel workers are doing, and for the affected high-performance computing workflows, wait for data to arrive over a network. In between loop iterations, the master process sleeps to avoid throttling. The `sleep` argument to `make()` and `drake_config()` allows you to customize how much time the master process spends sleeping.

The `sleep` argument is a function that takes an argument `i` and returns a numeric scalar, the number of seconds to supply to `Sys.sleep()` after iteration `i` of checking. (Here, `i` starts at 1.) If the checking loop does something other than sleeping on iteration `i`, then `i` is reset back to 1.

To sleep for the same amount of time between checks, you might supply something like `function(i) 0.01`. But to avoid consuming too many resources during heavier and longer workflows, you might use an exponential backoff: say, `function(i) { 0.1 + 120 * pexp(i - 1, rate = 0.01) }`.

# Related GitHub issues and pull requests

- Ref: #537

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
