### PR TITLE
Warn users about future changes to `append`

### DIFF
--- a/R/map_reduce.R
+++ b/R/map_reduce.R
@@ -170,18 +170,22 @@ gather_plan <- function(
 #'   bayes_model = bayesian_model_fit(data, prior_mu = mu__)
 #' )
 #' plan <- evaluate_plan(plan, rules = list(mu__ = 1:2), trace = TRUE)
-#' gather_by(plan, mu___from, gather = "dplyr::bind_rows")
+#' gather_by(plan, mu___from, gather = "dplyr::bind_rows", append = FALSE)
 #' gather_by(plan, mu___from, append = TRUE)
 #' gather_by(plan, mu___from, append = FALSE)
-#' gather_by(plan, mu__, mu___from, prefix = "x")
-#' gather_by(plan) # Gather everything and append a row.
+#' gather_by(plan, mu__, mu___from, prefix = "x", append = FALSE)
+#' gather_by(plan, append = FALSE) # Gather everything and append a row.
 gather_by <- function(
   plan,
   ...,
   prefix = "target",
   gather = "list",
-  append = TRUE
+  append = NULL
 ){
+  if (is.null(append)){
+    warn_append() # Warning added on 2018-10-18.
+    append <- TRUE # TODO: change to TRUE
+  }
   . <- NULL
   gathered <- dplyr::group_by(plan, ...) %>%
     dplyr::do(
@@ -312,13 +316,14 @@ reduce_plan <- function(
 #'   bayes_model = bayesian_model_fit(data, prior_mu = mu__)
 #' )
 #' plan <- evaluate_plan(plan, rules = list(mu__ = 1:2), trace = TRUE)
-#' reduce_by(plan, mu___from, begin = "list(", end = ")", op = ", ")
-#' reduce_by(plan, mu__)
+#' reduce_by(
+#'   plan, mu___from, begin = "list(", end = ")", op = ", ", append = FALSE
+#' )
 #' reduce_by(plan, mu__, append = TRUE)
 #' reduce_by(plan, mu__, append = FALSE)
-#' reduce_by(plan) # Reduce all the targets.
+#' reduce_by(plan, append = FALSE) # Reduce all the targets.
 #' reduce_by(plan, append = FALSE)
-#' reduce_by(plan, pairwise = FALSE)
+#' reduce_by(plan, pairwise = FALSE, append = FALSE)
 reduce_by <- function(
   plan,
   ...,
@@ -327,8 +332,12 @@ reduce_by <- function(
   op = " + ",
   end = "",
   pairwise = TRUE,
-  append = TRUE
+  append = NULL
 ){
+  if (is.null(append)){
+    warn_append() # Warning added on 2018-10-18.
+    append <- TRUE # TODO: change to TRUE
+  }
   . <- NULL
   reduced <- dplyr::group_by(plan, ...) %>%
     dplyr::do(
@@ -379,5 +388,14 @@ reduction_pairs <- function(x, pairs = NULL, base_name = "reduced_"){
     x = new_x,
     pairs = rbind(pairs, new_pairs),
     base_name = base_name
+  )
+}
+
+warn_append <- function(){
+  warning(
+    "Setting `append` to `TRUE`. ",
+    "The default `append` argument to `gather_by()` and `reduce_by()` ",
+    "will change to `FALSE` in a future release of `drake`.",
+    call. = FALSE
   )
 }

--- a/man/gather_by.Rd
+++ b/man/gather_by.Rd
@@ -5,7 +5,7 @@
 \title{Gather multiple groupings of targets}
 \usage{
 gather_by(plan, ..., prefix = "target", gather = "list",
-  append = TRUE)
+  append = NULL)
 }
 \arguments{
 \item{plan}{workflow plan data frame of prespecified targets}
@@ -42,11 +42,11 @@ plan <- drake_plan(
   bayes_model = bayesian_model_fit(data, prior_mu = mu__)
 )
 plan <- evaluate_plan(plan, rules = list(mu__ = 1:2), trace = TRUE)
-gather_by(plan, mu___from, gather = "dplyr::bind_rows")
+gather_by(plan, mu___from, gather = "dplyr::bind_rows", append = FALSE)
 gather_by(plan, mu___from, append = TRUE)
 gather_by(plan, mu___from, append = FALSE)
-gather_by(plan, mu__, mu___from, prefix = "x")
-gather_by(plan) # Gather everything and append a row.
+gather_by(plan, mu__, mu___from, prefix = "x", append = FALSE)
+gather_by(plan, append = FALSE) # Gather everything and append a row.
 }
 \seealso{
 drake_plan, map_plan, reduce_by, reduce_plan,

--- a/man/reduce_by.Rd
+++ b/man/reduce_by.Rd
@@ -5,7 +5,7 @@
 \title{Reduce multiple groupings of targets}
 \usage{
 reduce_by(plan, ..., prefix = "target", begin = "", op = " + ",
-  end = "", pairwise = TRUE, append = TRUE)
+  end = "", pairwise = TRUE, append = NULL)
 }
 \arguments{
 \item{plan}{workflow plan data frame of prespecified targets}
@@ -51,13 +51,14 @@ plan <- drake_plan(
   bayes_model = bayesian_model_fit(data, prior_mu = mu__)
 )
 plan <- evaluate_plan(plan, rules = list(mu__ = 1:2), trace = TRUE)
-reduce_by(plan, mu___from, begin = "list(", end = ")", op = ", ")
-reduce_by(plan, mu__)
+reduce_by(
+  plan, mu___from, begin = "list(", end = ")", op = ", ", append = FALSE
+)
 reduce_by(plan, mu__, append = TRUE)
 reduce_by(plan, mu__, append = FALSE)
-reduce_by(plan) # Reduce all the targets.
+reduce_by(plan, append = FALSE) # Reduce all the targets.
 reduce_by(plan, append = FALSE)
-reduce_by(plan, pairwise = FALSE)
+reduce_by(plan, pairwise = FALSE, append = FALSE)
 }
 \seealso{
 drake_plan, map_plan, gather_by, reduce_plan,

--- a/tests/testthat/test-deprecate.R
+++ b/tests/testthat/test-deprecate.R
@@ -281,3 +281,9 @@ test_with_dir("old trigger interface", {
     )
   }
 })
+
+test_with_dir("append in gather_by() and reduce_by()", {
+  plan <- drake_plan(x = 1)
+  expect_warning(gather_by(plan), regexp = "append")
+  expect_warning(reduce_by(plan), regexp = "append")
+})


### PR DESCRIPTION
# Summary

Currently, the default value of the `append` argument is `TRUE` in `gather_by()` and `reduce_by()` and `FALSE` in `gather_plan()` and `reduce_plan()`. In this PR, if `append` is not set by the user in `gather_by()` or `reduce_by()`, `drake` throws a warning that the default will become `FALSE` in a future release.

I will give this PR a few days before merging because some users might want to change the defaults of `gather_plan()` and `reduce_plan()` instead. cc @tmastny.

# Related GitHub issues and pull requests

- Ref: #554

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [ ] I think this pull request is ready to merge.
