### PR TITLE
A large speed boost: reduce calls to parse()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,11 +8,13 @@
 
 ## Enhancements
 
-- Remove strict dependencies on packages `evaluate`, `fs`, `future`, `parallel`, `R.utils`, `stats`, and `stringi`.
+- **Large speed boost**: reduce repeated calls to `parse()` in `code_dependencies()`.
+- **Large speed boost**: change the default value of `memory_strategy` (previously `pruning_strategy`) to `"speed"` (previously `"lookahead"`).
+- Remove strict dependencies on packages `evaluate`, `fs`, `future`, `magrittr`, `parallel`, `R.utils`, `stats`, and `stringi`.
 - Deprecate the `force` argument to `make()` and related functions.
 - Change the name of `prune_envir()` to `manage_memory()`.
 - Deprecate and rename the `pruning_strategy` argument to `memory_strategy` (`make()` and `drake_config()`).
-- Change the default value of `memory_strategy` (previously `pruning_strategy`) to `"speed"` (previously `"lookahead"`).
+
 
 # Version 6.1.0
 

--- a/R/commands.R
+++ b/R/commands.R
@@ -1,13 +1,3 @@
-is_parsable <- Vectorize(function(x) {
-  tryCatch({
-      parse(text = x)
-      TRUE
-    },
-    error = error_false
-  )
-},
-"x")
-
 extract_filenames <- function(command) {
   if (!safe_grepl("'", command, fixed = TRUE)) {
     return(character(0))

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -461,7 +461,7 @@ find_globals <- function(fun) {
       codetools::findGlobals(fun = fun, merge = TRUE)  # nocov
     }
   )
-  setdiff(out, c(ignored_symbols, ignored_globals))
+  setdiff(out, c(ignored_symbols))
 }
 
 analyze_loadd <- function(expr) {
@@ -550,6 +550,7 @@ file_out_fns <- pair_text(drake_prefix, c("file_out"))
 ignored_fns <- pair_text(drake_prefix, c("drake_envir", "ignore"))
 knitr_in_fns <- pair_text(drake_prefix, c("knitr_in"))
 loadd_fns <- pair_text(drake_prefix, "loadd")
+misc_syms <- "."
 readd_fns <- pair_text(drake_prefix, "readd")
 target_fns <- pair_text(drake_prefix, "target")
 trigger_fns <- pair_text(drake_prefix, "trigger")
@@ -561,19 +562,11 @@ ignored_symbols <- c(
   ignored_fns,
   loadd_fns,
   knitr_in_fns,
+  misc_syms,
   readd_fns,
   target_fns,
   trigger_fns
 )
-
-base_operators <- grep(
-  pattern = "^\\[|\\]|[a-zA-Z]",
-  x = ls("package:base"),
-  invert = TRUE,
-  value = TRUE
-)
-
-ignored_globals <- c(base_operators, ".")
 
 is_ignored_call <- function(expr) {
   wide_deparse(expr[[1]]) %in% ignored_fns

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -401,6 +401,8 @@ code_dependencies <- function(expr, exclude = character(0), globals = NULL) {
         expr <- function() {} # nolint: curly braces are necessary
       }
       walk(body(expr))
+    } else if (is.name(expr)) {
+      results$globals <<- c(results$globals, expr)
     } else if (is.character(expr)) {
       results$strings <<- c(results$strings, expr)
     } else if (is.language(expr) && (is.call(expr) || is.recursive(expr))) {
@@ -418,7 +420,7 @@ code_dependencies <- function(expr, exclude = character(0), globals = NULL) {
       } else if (!is_ignored_call(expr)) {
         if (wide_deparse(expr[[1]]) %in% c("::", ":::")) {
           new_results <- list(
-            namespaced = setdiff(wide_deparse(expr), ignored_symbols)
+            namespaced = setdiff(wide_deparse(expr), drake_symbols)
           )
         } else {
           lapply(X = expr, FUN = walk)
@@ -428,7 +430,9 @@ code_dependencies <- function(expr, exclude = character(0), globals = NULL) {
     }
   }
   walk(expr)
-  results$globals <- find_globals(expr)
+  results$globals <- as.character(results$globals)
+  non_locals <- find_non_locals(expr)
+  results$globals <- intersect(results$globals, non_locals)
   if (!is.null(globals)) {
     results$globals <- intersect(results$globals, globals)
   }
@@ -442,7 +446,7 @@ code_dependencies <- function(expr, exclude = character(0), globals = NULL) {
   results[purrr::map_int(results, length) > 0]
 }
 
-find_globals <- function(fun) {
+find_non_locals <- function(fun) {
   if (!is.function(fun)) {
     f <- function() {} # nolint
     body(f) <- as.call(append(as.list(body(f)), fun))
@@ -461,7 +465,7 @@ find_globals <- function(fun) {
       codetools::findGlobals(fun = fun, merge = TRUE)  # nocov
     }
   )
-  setdiff(out, c(ignored_symbols))
+  setdiff(out, ignored_symbols)
 }
 
 analyze_loadd <- function(expr) {
@@ -476,13 +480,13 @@ analyze_loadd <- function(expr) {
     unnamed$strings,
     code_dependencies(expr["list"])$strings
   )
-  list(loadd = setdiff(out, ignored_symbols))
+  list(loadd = setdiff(out, drake_symbols))
 }
 
 analyze_readd <- function(expr) {
   expr <- match.call(drake::readd, as.call(expr))
   deps <- unlist(code_dependencies(expr["target"])[c("globals", "strings")])
-  list(readd = setdiff(deps, ignored_symbols))
+  list(readd = setdiff(deps, drake_symbols))
 }
 
 analyze_file_in <- function(expr) {
@@ -555,18 +559,29 @@ readd_fns <- pair_text(drake_prefix, "readd")
 target_fns <- pair_text(drake_prefix, "target")
 trigger_fns <- pair_text(drake_prefix, "trigger")
 
-ignored_symbols <- c(
-  drake_envir_marker,
-  file_in_fns,
-  file_out_fns,
-  ignored_fns,
-  loadd_fns,
-  knitr_in_fns,
-  misc_syms,
-  readd_fns,
-  target_fns,
-  trigger_fns
+drake_symbols <- sort(
+  c(
+    drake_envir_marker,
+    file_in_fns,
+    file_out_fns,
+    ignored_fns,
+    loadd_fns,
+    knitr_in_fns,
+    misc_syms,
+    readd_fns,
+    target_fns,
+    trigger_fns
+  )
 )
+base_symbols <- sort(
+  grep(
+    pattern = "[a-zA-Z]",
+    x = ls("package:base"),
+    value = TRUE,
+    invert = TRUE
+  )
+)
+ignored_symbols <- sort(c(drake_symbols, base_symbols))
 
 is_ignored_call <- function(expr) {
   wide_deparse(expr[[1]]) %in% ignored_fns

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -426,10 +426,11 @@ code_dependencies <- function(expr, exclude = character(0), globals = NULL) {
           lapply(X = expr, FUN = walk)
         }
       }
-      results <<- merge_lists(x = results, y = new_results)
+      results <<- zip_lists(x = results, y = new_results)
     }
   }
   walk(expr)
+  results <- lapply(results, unique)
   results$globals <- as.character(results$globals)
   non_locals <- find_non_locals(expr)
   results$globals <- intersect(results$globals, non_locals)

--- a/R/deprecate.R
+++ b/R/deprecate.R
@@ -712,6 +712,15 @@ gather <- function(
 
 # Deprecated on 2018-02-15
 find_knitr_doc <- function(expr, result = character(0)) {
+  is_parsable <- Vectorize(function(x) {
+    tryCatch({
+      parse(text = x)
+      TRUE
+    },
+    error = error_false
+    )
+  },
+  "x")
   if (!length(expr)) {
     return(result)
   }

--- a/R/deprecate.R
+++ b/R/deprecate.R
@@ -755,7 +755,7 @@ find_knitr_doc <- function(expr, result = character(0)) {
     )
     result <- clean_dependency_list(result)
   }
-  setdiff(result, ignored_symbols)
+  setdiff(result, drake_symbols)
 }
 
 # Deprecated on 2018-02-15

--- a/R/utils.R
+++ b/R/utils.R
@@ -96,6 +96,18 @@ merge_lists <- function(x, y) {
   x
 }
 
+zip_lists <- function(x, y) {
+  names <- base::union(names(x), names(y))
+  x <- lapply(
+    X = names,
+    function(name) {
+      c(x[[name]], y[[name]])
+    }
+  )
+  names(x) <- names
+  x
+}
+
 padded_scale <- function(x) {
   r <- range(x)
   pad <- 0.2 * (r[2] - r[1])

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -107,10 +107,14 @@ test_with_dir(
     clean_dependency_list(deps_code(my_plan$command[2]))),
     sort(c("\"tracked_input_file.rds\"", "x", "readRDS")))
   expect_equal(sort(
-    clean_dependency_list(deps_code(my_plan$command[3]))), sort(c("f", "g", "w",
-    "x", "y", "z")))
+    clean_dependency_list(deps_code(my_plan$command[3]))),
+    sort(c("f", "g", "w", "x", "y", "z"))
+  )
   expect_equal(sort(
-    clean_dependency_list(deps_code(my_plan$command[4]))), sort(c("read.csv")))
+    clean_dependency_list(
+      deps_code(my_plan$command[4]))),
+    sort(c("read.csv"))
+  )
   expect_equal(
     sort(clean_dependency_list(deps_code(my_plan$command[5]))),
     sort(c("read.table", "\"file_in\"")))
@@ -231,10 +235,10 @@ test_with_dir("self-referential commands and imports", {
 })
 
 test_with_dir("._drake_envir and drake_envir() are not dependencies", {
-  deps1 <- deps_code(quote(drake_envir(x)))$globals
+  deps1 <- deps_code(quote(drake_envir()))$globals
   deps2 <- deps_code(quote(rm(x, envir = ._drake_envir)))$globals
-  deps3 <- deps_code(quote(drake_envir(x)))$globals
-  expect_equal(deps1, NULL)
-  expect_equal(sort(deps2), sort(c("rm", "x")))
-  expect_equal(deps3, NULL)
+  expect_false("drake_envir" %in% deps1)
+  expect_false("drake_envir" %in% deps2)
+  expect_false("._drake_envir" %in% deps1)
+  expect_false("._drake_envir" %in% deps2)
 })

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -3,7 +3,6 @@ drake_context("dependencies")
 test_with_dir("unparsable commands are handled correctly", {
   skip_on_cran() # CRAN gets whitelist tests only (check time limits).
   x <- "bluh$"
-  expect_false(is_parsable(x))
   expect_error(deps_code(x))
 })
 

--- a/tests/testthat/test-knitr.R
+++ b/tests/testthat/test-knitr.R
@@ -69,7 +69,7 @@ test_with_dir("empty cases", {
 test_with_dir("unparsable pieces of commands are handled correctly", {
   skip_on_cran() # CRAN gets whitelist tests only (check time limits).
   x <- "bluh$"
-  expect_false(is_parsable(x))
+  expect_error(parse(text = x))
   expect_equal(find_knitr_doc(x), character(0))
 })
 


### PR DESCRIPTION
# Summary

As it turns out, much of the overhead in the code analysis was from repeated calls to `parse()`. Simply removing those calls speeds up `drake`'s preprocessing.

Before:

``` r
library(drake)
library(microbenchmark)
library(storr)

plan <- function(n){
  plan <- drake_plan(target_1 = 1)
  for (i in seq_len(n - 1) + 1){
    target <- paste0("target_", i)
    dependencies <- paste0("target_", seq_len(i - 1))
    command <- paste0("max(", paste0(dependencies, collapse = ", "), ")")
    plan <- rbind(plan, data.frame(target = target, command = command))
  }
  plan
}

overhead <- function(config){
  make(config = config)
  clean(cache = config$cache)
}

benchmarks <- microbenchmark(
  config <- drake_config(
    plan(500),
    verbose = 0,
    cache = storr_rds(tempfile())
  ),
  times = 10
)

print(benchmarks)
#> Unit: seconds
#>                                                                           expr
#>  config <- drake_config(plan(500), verbose = 0, cache = storr_rds(tempfile()))
#>       min       lq     mean   median       uq      max neval
#>  32.59912 32.81557 32.87748 32.87952 32.93013 33.20924    10
```

<sup>Created on 2018-11-04 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

After:

```r
#> Unit: seconds
#>                                                                           expr
#>  config <- drake_config(plan(500), verbose = 0, cache = storr_rds(tempfile()))
#>       min       lq     mean   median       uq      max neval
#>  10.63075 10.77363 10.85274 10.87701 10.94084 11.00136    10
```

# Related GitHub issues and pull requests

- Ref: #573

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
