### PR TITLE
Update README to clarify CRAN lags but more stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ make(plan, parallelism = "future_lapply")
 Installation
 ============
 
-You can choose among different versions of `drake`. The CRAN release often lags behind the [online manual](https://ropenscilabs.github.io/drake-manual/) but may have more bugs.
+You can choose among different versions of `drake`. The CRAN release often lags behind the [online manual](https://ropenscilabs.github.io/drake-manual/) but may have fewer bugs.
 
 ``` r
 # Install the latest stable release from CRAN.


### PR DESCRIPTION
Presumably the CRAN version has _fewer_ bugs, not more?

# Summary

Documentation change so that README says CRAN release has _fewer_, not _more_, bugs.

# Related GitHub issues and pull requests

- trivial - I did not open an issue

# Checklist

- [X] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [X] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [ ] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [ ] I have tested this pull request locally with `devtools::check()`
- [X] This pull request is ready for review.
- [X] I think this pull request is ready to merge.
