### PR TITLE
Fix @details tag in `target` documentation

### DIFF
--- a/R/drake_plan.R
+++ b/R/drake_plan.R
@@ -494,7 +494,7 @@ detect_arrow <- function(command) {
 #' @description The `target()` function lets you define
 #'   custom columns in a workflow plan data frame, both
 #'   inside and outside calls to [drake_plan()].
-#'  @details Tidy evaluation is applied to the arguments,
+#' @details Tidy evaluation is applied to the arguments,
 #'    and the `!!` operator is evaluated immediately
 #'    for expressions and language objects.
 #' @export

--- a/man/target.Rd
+++ b/man/target.Rd
@@ -4,9 +4,9 @@
 \alias{target}
 \title{Define custom columns in a \code{\link[=drake_plan]{drake_plan()}}.}
 \usage{
-target(command = NULL, trigger = NULL, retries = NULL,
-  timeout = NULL, cpu = NULL, elapsed = NULL, priority = NULL,
-  worker = NULL, evaluator = NULL, ...)
+target(command = NULL, trigger = NULL, retries = NULL, timeout = NULL,
+  cpu = NULL, elapsed = NULL, priority = NULL, worker = NULL,
+  evaluator = NULL, ...)
 }
 \arguments{
 \item{command}{the command to build the target}
@@ -43,7 +43,9 @@ arguments as columns.
 The \code{target()} function lets you define
 custom columns in a workflow plan data frame, both
 inside and outside calls to \code{\link[=drake_plan]{drake_plan()}}.
-@details Tidy evaluation is applied to the arguments,
+}
+\details{
+Tidy evaluation is applied to the arguments,
 and the \code{!!} operator is evaluated immediately
 for expressions and language objects.
 }


### PR DESCRIPTION
# Summary

An extra space before a `@details` tag was mis-formatting the `target` help page (see first paragraph of `?target`).

# Related GitHub issues and pull requests

- Ref: #

# Checklist

- [X] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [ ] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [ ] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [X] I have tested this pull request locally with `devtools::check()`
- [X] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
