### PR TITLE
Remove URL from package title and shorten it

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -1,8 +1,8 @@
-#' drake is a pipeline toolkit
-#' (<https://github.com/pditommaso/awesome-pipeline>)
-#' and a scalable, R-focused solution for reproducibility
-#' and high-performance computing.
+#' drake: A pipeline toolkit for reproducible computation at scale.
 #' @docType package
+#' @description drake is a pipeline toolkit
+#' (<https://github.com/pditommaso/awesome-pipeline>)
+#' and a scalable, R-focused solution for reproducibility and high-performance computing.
 #' @name drake-package
 #' @aliases drake
 #' @author William Michael Landau \email{will.landau@@gmail.com}

--- a/man/drake-package.Rd
+++ b/man/drake-package.Rd
@@ -4,15 +4,11 @@
 \name{drake-package}
 \alias{drake-package}
 \alias{drake}
-\title{drake is a pipeline toolkit
-(\url{https://github.com/pditommaso/awesome-pipeline})
-and a scalable, R-focused solution for reproducibility
-and high-performance computing.}
+\title{drake: A pipeline toolkit for reproducible computation at scale.}
 \description{
 drake is a pipeline toolkit
 (\url{https://github.com/pditommaso/awesome-pipeline})
-and a scalable, R-focused solution for reproducibility
-and high-performance computing.
+and a scalable, R-focused solution for reproducibility and high-performance computing.
 }
 \examples{
 \dontrun{


### PR DESCRIPTION
# Summary

The current title on the `?drake` help page is very long and includes an URL. This PR moves the text to a `@description` field while shortening the title significantly to "drake: A pipeline toolkit for reproducible computation at scale". CRAN doesn't have specific requirements, but this seems more in line with most package help page conventions.

# Related GitHub issues and pull requests

- Ref: # n/a

# Checklist

- [X] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [ ] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [ ] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [X] I have tested this pull request locally with `devtools::check()`
- [X] This pull request is ready for review.
- [X] I think this pull request is ready to merge.