### PR TITLE
Documentation fixes and changes

### DIFF
--- a/R/build.R
+++ b/R/build.R
@@ -1,7 +1,7 @@
 #' @title Build/process a single target or import.
 #' @description Also load the target's dependencies beforehand.
 #' @export
-#' @seealso [drake_build()]
+#' @seealso [drake_debug()]
 #' @return The value of the target right after it is built.
 #' @param target name of the target
 #' @param meta list of metadata that tell which

--- a/R/config.R
+++ b/R/config.R
@@ -66,7 +66,7 @@
 #' @param parallelism character, type of parallelism to use.
 #'   To list the options, call [parallelism_choices()].
 #'   For detailed explanations, see the
-#'   [high-performance computing chapter](https://ropenscilabs.github.io/drake-manual/store.html) # nolint
+#'   [high-performance computing chapter](https://ropenscilabs.github.io/drake-manual/store.html)
 #'   of the user manual.
 #'
 #' @param jobs maximum number of parallel workers for processing the targets.
@@ -114,7 +114,7 @@
 #'   and then once again for each target right before that target is built.
 #'
 #' @param prepend lines to prepend to the Makefile if `parallelism`
-#'   is `"Makefile"`. See the [high-performance computing guide](https://ropenscilabs.github.io/drake-manual/store.html) # nolint
+#'   is `"Makefile"`. See the [high-performance computing guide](https://ropenscilabs.github.io/drake-manual/store.html)
 #'   to learn how to use `prepend`
 #'   to take advantage of multiple nodes of a supercomputer.
 #'
@@ -340,7 +340,7 @@
 #'   `make(parallelism = "Makefile")`. If you set this argument to a
 #'   non-default value, you are responsible for supplying this same
 #'   path to the `args` argument so `make` knows where to find it.
-#'   Example: `make(parallelism = "Makefile", makefile_path = ".drake/.makefile", command = "make", args = "--file=.drake/.makefile")` # nolint
+#'   Example: `make(parallelism = "Makefile", makefile_path = ".drake/.makefile", command = "make", args = "--file=.drake/.makefile")`
 #'
 #' @param console_log_file character scalar or `NULL`.
 #'   If `NULL`, console output will be printed

--- a/R/examples.R
+++ b/R/examples.R
@@ -92,10 +92,10 @@ drake_examples <- function(quiet = TRUE) {
   sort(out)
 }
 
-#' @title Load the mtcars example from `drake_example("mtcars")`
+#' @title Load the mtcars example. 
 #' @description Is there an association between
 #' the weight and the fuel efficiency of cars?
-#' To find out, we use the mtcars dataset.
+#' To find out, we use the mtcars example from `drake_example("mtcars")`.
 #' The mtcars dataset itself only has 32 rows,
 #' so we generate two larger bootstrapped datasets
 #' and then analyze them with regression models.
@@ -109,7 +109,7 @@ drake_examples <- function(quiet = TRUE) {
 #' This function also writes/overwrites
 #' the file, `report.Rmd`.
 #' @export
-#' @seealso [clean_mtcars_example()]
+#' @seealso [clean_mtcars_example()] [drake_examples()]
 #' @return Nothing.
 #' @inheritParams drake_config
 #' @param envir The environment to load the example into.
@@ -274,12 +274,12 @@ clean_mtcars_example <- function() {
   invisible()
 }
 
-#' @title Load the main example from `drake_example("main")`
-#' @description The main example itself lives at
-#' <https://github.com/wlandau/drake-examples/tree/master/main>. # nolint
-#' Use `drake_example("main")` to download the code.
+#' @title Load the main example.
+#' @description The main example lives at
+#' <https://github.com/wlandau/drake-examples/tree/master/main>.
+#' Use `drake_example("main")` to download its code.
 #' The chapter of the user manual at
-#' <https://ropenscilabs.github.io/drake-manual/main.html> # nolint
+#' <https://ropenscilabs.github.io/drake-manual/main.html>
 #' also walks through the main example.
 #' This function also writes/overwrites
 #' the files `report.Rmd` and `raw_data.xlsx`.

--- a/R/read.R
+++ b/R/read.R
@@ -26,9 +26,9 @@
 #'   and then treat those loaded targets as dependencies.
 #'   That way, [make()] will automatically (re)run the report if those
 #'   dependencies change.
-#' Please do not put calls to [loadd()] or [readd()] inside
+#' @note Please do not put calls to [loadd()] or [readd()] inside
 #' your custom (imported) functions or the commands in your [drake_plan()].
-#' This create confusion inside [make()], which has its own ways of
+#' This creates confusion inside [make()], which has its own ways of
 #' interacting with the cache.
 #' @seealso [cached()], [built()], [imported()], [drake_plan()], [make()]
 #' @export

--- a/man/drake_build.Rd
+++ b/man/drake_build.Rd
@@ -63,5 +63,5 @@ head(result)
 }
 }
 \seealso{
-\code{\link[=drake_build]{drake_build()}}
+\code{\link[=drake_debug]{drake_debug()}}
 }

--- a/man/drake_config.Rd
+++ b/man/drake_config.Rd
@@ -85,7 +85,7 @@ need to know how to load the cache.}
 \item{parallelism}{character, type of parallelism to use.
 To list the options, call \code{\link[=parallelism_choices]{parallelism_choices()}}.
 For detailed explanations, see the
-\href{https://ropenscilabs.github.io/drake-manual/store.html}{high-performance computing chapter} # nolint
+\href{https://ropenscilabs.github.io/drake-manual/store.html}{high-performance computing chapter}
 of the user manual.}
 
 \item{jobs}{maximum number of parallel workers for processing the targets.
@@ -133,7 +133,7 @@ is run once before any targets are built. If \code{parallelism} is
 and then once again for each target right before that target is built.}
 
 \item{prepend}{lines to prepend to the Makefile if \code{parallelism}
-is \code{"Makefile"}. See the \href{https://ropenscilabs.github.io/drake-manual/store.html}{high-performance computing guide} # nolint
+is \code{"Makefile"}. See the \href{https://ropenscilabs.github.io/drake-manual/store.html}{high-performance computing guide}
 to learn how to use \code{prepend}
 to take advantage of multiple nodes of a supercomputer.}
 
@@ -328,7 +328,7 @@ with the last few targets it builds.}
 \code{make(parallelism = "Makefile")}. If you set this argument to a
 non-default value, you are responsible for supplying this same
 path to the \code{args} argument so \code{make} knows where to find it.
-Example: \code{make(parallelism = "Makefile", makefile_path = ".drake/.makefile", command = "make", args = "--file=.drake/.makefile")} # nolint}
+Example: \code{make(parallelism = "Makefile", makefile_path = ".drake/.makefile", command = "make", args = "--file=.drake/.makefile")}}
 
 \item{console_log_file}{character scalar or \code{NULL}.
 If \code{NULL}, console output will be printed

--- a/man/load_main_example.Rd
+++ b/man/load_main_example.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/examples.R
 \name{load_main_example}
 \alias{load_main_example}
-\title{Load the main example from \code{drake_example("main")}}
+\title{Load the main example.}
 \usage{
 load_main_example(envir = parent.frame(), report_file = "report.Rmd",
   overwrite = FALSE, force = FALSE)
@@ -24,11 +24,11 @@ existing file \code{report.Rmd}}
 A \code{\link[=drake_config]{drake_config()}} configuration list.
 }
 \description{
-The main example itself lives at
-\url{https://github.com/wlandau/drake-examples/tree/master/main}. # nolint
-Use \code{drake_example("main")} to download the code.
+The main example lives at
+\url{https://github.com/wlandau/drake-examples/tree/master/main}.
+Use \code{drake_example("main")} to download its code.
 The chapter of the user manual at
-\url{https://ropenscilabs.github.io/drake-manual/main.html} # nolint
+\url{https://ropenscilabs.github.io/drake-manual/main.html}
 also walks through the main example.
 This function also writes/overwrites
 the files \code{report.Rmd} and \code{raw_data.xlsx}.

--- a/man/load_mtcars_example.Rd
+++ b/man/load_mtcars_example.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/examples.R
 \name{load_mtcars_example}
 \alias{load_mtcars_example}
-\title{Load the mtcars example from \code{drake_example("mtcars")}}
+\title{Load the mtcars example.}
 \usage{
 load_mtcars_example(envir = parent.frame(), report_file = NULL,
   overwrite = FALSE, force = FALSE)
@@ -29,7 +29,7 @@ Nothing.
 \description{
 Is there an association between
 the weight and the fuel efficiency of cars?
-To find out, we use the mtcars dataset.
+To find out, we use the mtcars example from \code{drake_example("mtcars")}.
 The mtcars dataset itself only has 32 rows,
 so we generate two larger bootstrapped datasets
 and then analyze them with regression models.
@@ -71,5 +71,5 @@ clean_mtcars_example()
 }
 }
 \seealso{
-\code{\link[=clean_mtcars_example]{clean_mtcars_example()}}
+\code{\link[=clean_mtcars_example]{clean_mtcars_example()}} \code{\link[=drake_examples]{drake_examples()}}
 }

--- a/man/make.Rd
+++ b/man/make.Rd
@@ -84,7 +84,7 @@ need to know how to load the cache.}
 \item{parallelism}{character, type of parallelism to use.
 To list the options, call \code{\link[=parallelism_choices]{parallelism_choices()}}.
 For detailed explanations, see the
-\href{https://ropenscilabs.github.io/drake-manual/store.html}{high-performance computing chapter} # nolint
+\href{https://ropenscilabs.github.io/drake-manual/store.html}{high-performance computing chapter}
 of the user manual.}
 
 \item{jobs}{maximum number of parallel workers for processing the targets.
@@ -132,7 +132,7 @@ is run once before any targets are built. If \code{parallelism} is
 and then once again for each target right before that target is built.}
 
 \item{prepend}{lines to prepend to the Makefile if \code{parallelism}
-is \code{"Makefile"}. See the \href{https://ropenscilabs.github.io/drake-manual/store.html}{high-performance computing guide} # nolint
+is \code{"Makefile"}. See the \href{https://ropenscilabs.github.io/drake-manual/store.html}{high-performance computing guide}
 to learn how to use \code{prepend}
 to take advantage of multiple nodes of a supercomputer.}
 
@@ -335,7 +335,7 @@ with the last few targets it builds.}
 \code{make(parallelism = "Makefile")}. If you set this argument to a
 non-default value, you are responsible for supplying this same
 path to the \code{args} argument so \code{make} knows where to find it.
-Example: \code{make(parallelism = "Makefile", makefile_path = ".drake/.makefile", command = "make", args = "--file=.drake/.makefile")} # nolint}
+Example: \code{make(parallelism = "Makefile", makefile_path = ".drake/.makefile", command = "make", args = "--file=.drake/.makefile")}}
 
 \item{console_log_file}{character scalar or \code{NULL}.
 If \code{NULL}, console output will be printed

--- a/man/readd.Rd
+++ b/man/readd.Rd
@@ -145,11 +145,13 @@ calls to \code{loadd()} and \code{readd()} in active code chunks,
 and then treat those loaded targets as dependencies.
 That way, \code{\link[=make]{make()}} will automatically (re)run the report if those
 dependencies change.
+}
+}
+\note{
 Please do not put calls to \code{\link[=loadd]{loadd()}} or \code{\link[=readd]{readd()}} inside
 your custom (imported) functions or the commands in your \code{\link[=drake_plan]{drake_plan()}}.
-This create confusion inside \code{\link[=make]{make()}}, which has its own ways of
+This creates confusion inside \code{\link[=make]{make()}}, which has its own ways of
 interacting with the cache.
-}
 }
 \examples{
 \dontrun{


### PR DESCRIPTION
# Summary

Fixes a few problems (`# nolint` showing up in build documentation, help pages `@seealso`ing themselves) and emphasizes, by breaking the text into a `@note`, recommended `loadd/readd` usage.
 
# Related GitHub issues and pull requests

- Ref: # n/a

# Checklist

- [X] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [ ] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [ ] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [X] I have tested this pull request locally with `devtools::check()`
- [X] This pull request is ready for review.
- [X] I think this pull request is ready to merge.