### PR TITLE
Update pkgdown URL

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,4 @@
-url: https://github.com/ropensci/drake
+url: https://ropensci.github.io/drake
 destination: docs/
 navbar:
   title: drake


### PR DESCRIPTION
# Summary

The pkgdown url field must contain the website URL, not the repo URL. See for example how the [sitemap](https://ropensci.github.io/drake/sitemap.xml) is broken, which hinders search engine efficient crawling.

# Related GitHub issues and pull requests

*NA*

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
