### PR TITLE
597

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,10 @@
 - Add a new `drake_envir()` function that returns the environment where `drake` builds targets. Can only be accessed from inside the commands in the workflow plan data frame. The primary use case is to allow users to remove individual targets from memory at predetermined build steps.
 - Add a `sep` argument to `gather_by()`, `reduce_by()`, `reduce_plan()`, `evaluate_plan()`, `expand_plan()`, `plan_analyses()`, and `plan_summaries()`. Allows the user to set the delimiter for generating new target names.
 
+## Bug fixes
+
+- Stop returning `0s` from `predict_runtime(targets_only = TRUE)` when some targets are outdated and others are not.
+
 ## Enhancements
 
 - **Large speed boost**: reduce repeated calls to `parse()` in `code_dependencies()`.
@@ -19,6 +23,9 @@
 - Deprecate and rename the `pruning_strategy` argument to `memory_strategy` (`make()` and `drake_config()`).
 - Print warnings and messages to the `console_log_file` in real time ([#588](https://github.com/ropensci/drake/issues/588)).
 - Use HTML line breaks in `vis_drake_graph()` hover text to display commands in the `drake` plan more elegantly.
+- Speed up `predict_load_balancing()` and remove its reliance on internals that will go away next year via [#561](https://github.com/ropensci/drake/issues/561).
+- Change the names of the return value of `predict_load_balancing()` to `time` and `workers`.
+- Bring the documentation of `predict_runtime()` and `predict_load_balancing()` up to date.
 
 
 # Version 6.1.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -23,7 +23,8 @@
 - Deprecate and rename the `pruning_strategy` argument to `memory_strategy` (`make()` and `drake_config()`).
 - Print warnings and messages to the `console_log_file` in real time ([#588](https://github.com/ropensci/drake/issues/588)).
 - Use HTML line breaks in `vis_drake_graph()` hover text to display commands in the `drake` plan more elegantly.
-- Speed up `predict_load_balancing()` and remove its reliance on internals that will go away next year via [#561](https://github.com/ropensci/drake/issues/561).
+- Speed up `predict_load_balancing()` and remove its reliance on internals that will go away in 2019 via [#561](https://github.com/ropensci/drake/issues/561).
+- Remove support for the `worker` column of `config$plan` in `predict_runtime()` and `predict_load_balancing()`. This functionality will go away in 2019 via [#561](https://github.com/ropensci/drake/issues/561).
 - Change the names of the return value of `predict_load_balancing()` to `time` and `workers`.
 - Bring the documentation of `predict_runtime()` and `predict_load_balancing()` up to date.
 

--- a/R/clustermq.R
+++ b/R/clustermq.R
@@ -168,12 +168,6 @@ cmq_conclude_build <- function(msg, config) {
 }
 
 cmq_conclude_target <- function(target, config) {
-  revdeps <- dependencies(
-    targets = target,
-    config = config,
-    reverse = TRUE
-  )
-  revdeps <- intersect(revdeps, y = config$queue$list())
-  config$queue$decrease_key(targets = revdeps)
+  decrease_revdep_keys(queue = config$queue, target = target, config = config)
   config$counter$remaining <- config$counter$remaining - 1
 }

--- a/R/future.R
+++ b/R/future.R
@@ -207,18 +207,12 @@ initialize_workers <- function(config) {
   out
 }
 
-decrease_revdep_keys <- function(worker, config, queue) {
+ft_decrease_revdep_keys <- function(worker, config, queue) {
   target <- attr(worker, "target")
   if (!length(target) || safe_is_na(target) || !is.character(target)) {
     return()
   }
-  revdeps <- dependencies(
-    targets = target,
-    config = config,
-    reverse = TRUE
-  )
-  revdeps <- intersect(revdeps, queue$list())
-  queue$decrease_key(targets = revdeps)
+  decrease_revdep_keys(queue, target, config)
 }
 
 conclude_worker <- function(worker, config, queue) {

--- a/R/future.R
+++ b/R/future.R
@@ -216,7 +216,7 @@ ft_decrease_revdep_keys <- function(worker, config, queue) {
 }
 
 conclude_worker <- function(worker, config, queue) {
-  decrease_revdep_keys(
+  ft_decrease_revdep_keys(
     worker = worker,
     queue = queue,
     config = config

--- a/R/mc_utils.R
+++ b/R/mc_utils.R
@@ -94,7 +94,7 @@ mc_preferred_queue <- function(target, config) {
       config$plan[["worker"]][config$plan$target == target]
     )
     if (worker %in% names(config$mc_ready_queues)) {
-      return(config$mc_ready_queues[[worker]])
+      return(config$mc_ready_queues[[worker]]) # nocov
     } else {
       drake_warning(
         "Preferred worker for target `",

--- a/R/predict_runtime.R
+++ b/R/predict_runtime.R
@@ -78,7 +78,7 @@ predict_runtime <- function(
   default_time = 0,
   warn = TRUE
 ) {
-  balance <- predict_load_balancing(
+  predict_load_balancing(
     config = config,
     targets = targets,
     from_scratch = from_scratch,
@@ -89,8 +89,7 @@ predict_runtime <- function(
     known_times = known_times,
     default_time = default_time,
     warn = warn
-  )
-  balance$total_runtime
+  )$time
 }
 
 #' @title Predict the load balancing of the next call to `make()`
@@ -203,6 +202,67 @@ predict_load_balancing <- function(
   default_time = 0,
   warn = TRUE
 ) {
+  assumptions <- timing_assumptions(
+    config = config,
+    targets = targets,
+    from_scratch = from_scratch,
+    targets_only = targets_only,
+    future_jobs = future_jobs,
+    digits = digits,
+    jobs = jobs,
+    known_times = known_times,
+    default_time = default_time,
+    warn = warn
+  )
+  config$schedule <- config$graph
+  queue <- new_priority_queue(config, jobs = 1)
+  running <- data.frame(
+    target = character(0),
+    time = numeric(0),
+    worker = integer(0),
+    stringsAsFactors = FALSE
+  )
+  time <- 0
+  workers <- replicate(jobs, character(0))
+  while (!queue$empty() || nrow(running)) {
+    while (length(queue$peek0()) && nrow(running) < jobs) {
+      new_target <- queue$pop0()
+      running <- rbind(running, data.frame(
+        target = new_target,
+        time = assumptions[new_target],
+        worker = min(which(!(seq_len(jobs) %in% running$worker))),
+        stringsAsFactors = FALSE
+      ))
+    }
+    running <- running[order(running$time), ]
+    time <- time + running$time[1]
+    running$time <- running$time - running$time[1]
+    workers[[running$worker[1]]] <- c(
+      workers[[running$worker[1]]],
+      running$target[1]
+    )
+    decrease_revdep_keys(
+      queue = queue,
+      target = running$target[1],
+      config = config
+    )
+    running <- running[-1, ]
+  }
+  list(time = lubridate::dseconds(time), workers = workers)
+}
+
+timing_assumptions <- function(
+  config,
+  targets,
+  from_scratch,
+  targets_only,
+  future_jobs,
+  digits,
+  jobs,
+  known_times,
+  default_time,
+  warn
+) {
   assert_pkg("lubridate")
   if (!is.null(future_jobs) || !is.null(digits)) {
     warning(
@@ -233,120 +293,10 @@ predict_load_balancing <- function(
   }
   keep_known_times <- intersect(names(known_times), V(config$graph)$name)
   known_times <- known_times[keep_known_times]
-  config$graph <- igraph::set_vertex_attr(
-    config$graph,
-    name = "time",
-    value = default_time
-  )
-  config$graph <- igraph::set_vertex_attr(
-    config$graph,
-    name = "time",
-    index = times$item,
-    value = times$elapsed
-  )
-  config$graph <- igraph::set_vertex_attr(
-    config$graph,
-    name = "time",
-    index = names(known_times),
-    value = known_times
-  )
-  if (!from_scratch) {
-    skip <- setdiff(config$plan$target, outdated(config))
-    config$graph <- igraph::set_vertex_attr(
-      config$graph,
-      name = "time",
-      index = skip,
-      value = 0
-    )
-  }
-  if (!is.null(targets)) {
-    config$graph <- prune_drake_graph(config$graph, to = targets)
-  }
-  balance_load(config = config, jobs = jobs)
-}
-
-# Taken directly from mc_master()
-# and modified to simulate the workers.
-balance_load <- function(config, jobs) {
-  # Mostly the same setup for mc_master().
-  config$cache <- configure_cache(
-    cache = storr::storr_environment(),
-    init_common_values = TRUE
-  )
-  config$jobs <- jobs
-  config$schedule <- config$graph
-  config$queue <- new_priority_queue(config = config)
-  mc_init_worker_cache(config)
-  workers <- config$cache$list("mc_ready_db")
-  targets <- lapply(workers, function(worker) {
-    character(0)
-  })
-  total_runtime <- 0
-  time_remaining <- rep(0, length(workers))
-  old_targets <- rep("", length(workers))
-  names(time_remaining) <- names(targets) <- names(old_targets) <- workers
-  lapply(workers, mc_get_ready_queue, config = config)
-  lapply(workers, mc_get_done_queue, config = config)
-  while (TRUE) {
-    # Run one iteration of mc_master()
-    config <- mc_refresh_queue_lists(config)
-    mc_conclude_done_targets(config, wait_for_checksums = FALSE)
-    mc_assign_ready_targets(config)
-    # List the running targets and their runtimes
-    current_targets <- vapply(
-      config$mc_ready_queues,
-      function(queue) {
-        messages <- queue$list(1)
-        if (nrow(messages)) {
-          messages$title[1]
-        } else {
-          ""
-        }
-      },
-      FUN.VALUE = character(1)
-    )
-    is_running <- nzchar(current_targets)
-    if (!any(is_running)) {
-      break
-    }
-    times <- vapply(
-      current_targets,
-      function(target) {
-        if (identical(target, "")) {
-          0
-        } else {
-          igraph::vertex_attr(
-            graph = config$graph,
-            name = "time",
-            index = target
-          )
-        }
-      },
-      FUN.VALUE = numeric(1)
-    )
-    # For the workers that just got new targets,
-    # increment the time they will remain running.
-    index <- current_targets != old_targets
-    time_remaining[index] <- time_remaining[index] + times[index]
-    old_targets <- current_targets
-    # Move time forward until soonest target finishes.
-    step <- min(time_remaining[is_running])
-    worker <- names(which.min(time_remaining[is_running]))
-    time_remaining[is_running] <- time_remaining[is_running] - step
-    total_runtime <- total_runtime + step
-    # Finish the target.
-    ready_queue <- config$mc_ready_queues[[worker]]
-    done_queue <- config$mc_done_queues[[worker]]
-    msg <- ready_queue$pop(1)
-    if (nrow(msg) > 0) {
-      target <- msg$title
-      targets[[worker]] <- c(targets[[worker]], target)
-      done_queue$push(title = target, message = "target")
-    }
-  }
-  eval(parse(text = "require(methods, quietly = TRUE)")) # needed for lubridate
-  list(
-    total_runtime = lubridate::dseconds(total_runtime),
-    targets = targets
-  )
+  names <- igraph::V(config$graph)$name
+  assumptions <- rep(default_time, length(names))
+  names(assumptions) <- names
+  assumptions[times$item] <- times$elapsed
+  assumptions[names(known_times)] <- known_times
+  assumptions
 }

--- a/R/predict_runtime.R
+++ b/R/predict_runtime.R
@@ -260,6 +260,9 @@ timing_assumptions <- function(
   if (targets_only) {
     config$graph <- targets_graph(config)
   }
+  if (!is.null(targets)) {
+    config$graph <- prune_drake_graph(config$graph, to = targets)
+  }
   times <- times[times$item %in% V(config$graph)$name, ]
   untimed <- setdiff(V(config$graph)$name, times$item)
   untimed <- setdiff(untimed, names(known_times))

--- a/R/priority_queue.R
+++ b/R/priority_queue.R
@@ -116,3 +116,15 @@ R6_priority_queue <- R6::R6Class(
     }
   )
 )
+
+# Very specific to drake, does not belong inside
+# a generic priority queue.
+decrease_revdep_keys <- function(queue, target, config) {
+  revdeps <- dependencies(
+    targets = target,
+    config = config,
+    reverse = TRUE
+  )
+  revdeps <- intersect(revdeps, queue$list())
+  queue$decrease_key(targets = revdeps)
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -103,6 +103,10 @@ file_extn <- function(x) {
   x[1]
 }
 
+in_hash_table <- function(x, table) {
+  exists(x, envir = table, inherits = FALSE)
+}
+
 is_file <- function(x) {
   x <- substr(x = x, start = 0, stop = 1)
   x == "\"" | x == "'" # TODO: get rid fo the single quote next major release
@@ -145,6 +149,12 @@ merge_lists <- function(x, y) {
   )
   names(x) <- names
   x
+}
+
+new_hash_table <- function(x){
+  out <- new.env(hash = TRUE, parent = emptyenv())
+  lapply(x, assign, value = TRUE, envir = out)
+  out
 }
 
 padded_scale <- function(x) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -103,10 +103,6 @@ file_extn <- function(x) {
   x[1]
 }
 
-in_hash_table <- function(x, table) {
-  exists(x, envir = table, inherits = FALSE)
-}
-
 is_file <- function(x) {
   x <- substr(x = x, start = 0, stop = 1)
   x == "\"" | x == "'" # TODO: get rid fo the single quote next major release
@@ -149,12 +145,6 @@ merge_lists <- function(x, y) {
   )
   names(x) <- names
   x
-}
-
-new_hash_table <- function(x){
-  out <- new.env(hash = TRUE, parent = emptyenv())
-  lapply(x, assign, value = TRUE, envir = out)
-  out
 }
 
 padded_scale <- function(x) {

--- a/man/predict_load_balancing.Rd
+++ b/man/predict_load_balancing.Rd
@@ -83,9 +83,6 @@ to adjust the assumptions as needed.
 test_with_dir("Quarantine side effects.", {
 load_mtcars_example() # Get the code with drake_example("mtcars").
 config <- make(my_plan) # Run the project, build the targets.
-# The predictions use the cached build times of the targets,
-# but if you expect your target runtimes
-# to be different, you can specify them (in seconds).
 known_times <- c(5, rep(7200, nrow(my_plan) - 1))
 names(known_times) <- c(file_store("report.md"), my_plan$target[-1])
 known_times
@@ -102,10 +99,6 @@ predict_runtime(
   from_scratch = TRUE,
   known_times = known_times
 )
-# Why isn't 8 jobs any better?
-# 8 would be a good guess based on the layout of the workflow graph.
-# It's because of load balancing.
-# Below, each row is a persistent worker.
 balance <- predict_load_balancing(
   config,
   jobs = 7,
@@ -114,11 +107,6 @@ balance <- predict_load_balancing(
   targets_only = TRUE
 )
 balance
-max(balance$time)
-# Each worker gets 2 rate-limiting targets.
-balance$time
-# Even if you add another worker, there will be still be workers
-# with two heavy targets.
 })
 }
 }

--- a/man/predict_runtime.Rd
+++ b/man/predict_runtime.Rd
@@ -80,9 +80,6 @@ to adjust the assumptions as needed.
 test_with_dir("Quarantine side effects.", {
 load_mtcars_example() # Get the code with drake_example("mtcars").
 config <- make(my_plan) # Run the project, build the targets.
-# The predictions use the cached build times of the targets,
-# but if you expect your target runtimes
-# to be different, you can specify them (in seconds).
 known_times <- c(5, rep(7200, nrow(my_plan) - 1))
 names(known_times) <- c(file_store("report.md"), my_plan$target[-1])
 known_times
@@ -99,10 +96,6 @@ predict_runtime(
   from_scratch = TRUE,
   known_times = known_times
 )
-# Why isn't 8 jobs any better?
-# 8 would be a good guess based on the layout of the workflow graph.
-# It's because of load balancing.
-# Below, each row is a persistent worker.
 balance <- predict_load_balancing(
   config,
   jobs = 7,
@@ -111,11 +104,6 @@ balance <- predict_load_balancing(
   targets_only = TRUE
 )
 balance
-max(balance$time)
-# Each worker gets 2 rate-limiting targets.
-balance$time
-# Even if you add another worker, there will be still be workers
-# with two heavy targets.
 })
 }
 }

--- a/tests/testthat/test-time.R
+++ b/tests/testthat/test-time.R
@@ -66,7 +66,6 @@ test_with_dir("build time the same after superfluous make", {
 test_with_dir("runtime predictions", {
   skip_on_cran() # CRAN gets whitelist tests only (check time limits).
   skip_if_not_installed("lubridate")
-  skip_if_not_installed("txtq")
   con <- dbug()
   expect_warning(p0 <- as.numeric(predict_runtime(con)))
   expect_true(p0 < 1e4)

--- a/tests/testthat/test-time.R
+++ b/tests/testthat/test-time.R
@@ -140,19 +140,8 @@ test_with_dir("runtime predictions", {
     targets = targets
   )
   p7 <- as.numeric(p7)
-  con$plan$worker <- 1
-  p8 <- predict_runtime(
-    config = con,
-    jobs = 2,
-    default_time = Inf,
-    from_scratch = TRUE,
-    known_times = known_times,
-    targets = targets
-  )
-  p8 <- as.numeric(p8)
   expect_true(all(is.finite(c(p1, p2, p3, p4))))
   expect_equal(p5, 0, tolerance = 1e-6)
   expect_equal(p6, 70, tolerance = 1e-6)
   expect_equal(p7, 43, tolerance = 1e-6)
-  expect_equal(p8, 70, tolerance = 1e-6)
 })

--- a/tests/testthat/test-time.R
+++ b/tests/testthat/test-time.R
@@ -157,26 +157,3 @@ test_with_dir("runtime predictions", {
   expect_equal(p7, 43, tolerance = 1e-6)
   expect_equal(p8, 70, tolerance = 1e-6)
 })
-
-test_with_dir("load balancing with custom worker assignemnts", {
-  skip_on_cran() # CRAN gets whitelist tests only (check time limits).
-  skip_if_not_installed("lubridate")
-  load_mtcars_example()
-  config <- drake_config(my_plan)
-  config$plan$worker <- 1
-  config$plan$worker[grepl("large", config$plan$target)] <- 2
-  suppressWarnings(
-    x <- predict_load_balancing(config, default_time = 2, jobs = 2))
-  expect_false(any(grep("large", x$targets[[1]])))
-  expect_true(any(grep("large", x$targets[[2]])))
-  expect_false(any(grep("small", x$targets[[2]])))
-  expect_true(any(grep("small", x$targets[[1]])))
-  config$plan$worker <- 1
-  config$plan$worker[grepl("small", config$plan$target)] <- 2
-  suppressWarnings(
-    x <- predict_load_balancing(config, default_time = 2, jobs = 2))
-  expect_false(any(grep("large", x$targets[[2]])))
-  expect_true(any(grep("large", x$targets[[1]])))
-  expect_false(any(grep("small", x$targets[[1]])))
-  expect_true(any(grep("small", x$targets[[2]])))
-})


### PR DESCRIPTION
# Summary

This PR improves the internals of `predict_runtime()` and `predict_load_balancing()`. These functions are much faster and cleaner now, and they no longer depend on internals that will go away in #561.

Also, list element names returned by `predict_load_balancing()` are now `time` and `workers`.

# Related GitHub issues and pull requests

- Ref: #597 

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [ ] I think this pull request is ready to merge.
