### PR TITLE
Remove rprojroot dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -98,7 +98,6 @@ Suggests:
   parallel,
   prettycode,
   RSQLite,
-  rprojroot,
   stats,
   testthat,
   tidyselect (>= 0.2.4),

--- a/R/test.R
+++ b/R/test.R
@@ -8,14 +8,14 @@ testrun <- function(config) {
   set_test_backend()
   invisible(
     make(plan = config$plan, targets = config$targets, envir = config$envir,
-      verbose = config$verbose, parallelism = config$parallelism,
-      jobs = config$jobs,
-      packages = config$packages, prework = config$prework,
-      prepend = config$prepend, command = config$command,
-      cache = config$cache, lazy_load = config$lazy_load,
-      session_info = config$session_info,
-      fetch_cache = config$fetch_cache,
-      caching = config$caching
+         verbose = config$verbose, parallelism = config$parallelism,
+         jobs = config$jobs,
+         packages = config$packages, prework = config$prework,
+         prepend = config$prepend, command = config$command,
+         cache = config$cache, lazy_load = config$lazy_load,
+         session_info = config$session_info,
+         fetch_cache = config$fetch_cache,
+         caching = config$caching
     )
   )
 }
@@ -94,9 +94,20 @@ set_test_backend <- function() {
 }
 
 unit_test_files <- function(path = getwd()) {
-  assert_pkg("rprojroot")
-  root <- rprojroot::find_root(criterion = "DESCRIPTION", path = path)
-  file.path(root, "tests", "testthat")
+  # find the package root 
+  p <- normalizePath(dirname(path))
+  MAX_DEPTH <- 100
+  CRITERION <- "DESCRIPTION"
+  for (i in seq_len(MAX_DEPTH)) {
+    if (length(list.files(p, pattern = CRITERION))) {
+      # found criterion file; make sure it's ours 
+      if (grepl("drake", readLines(file.path(p, CRITERION), n = 1))) {
+        return(file.path(p, "tests", "testthat"))
+      }
+    }
+    p <- dirname(p)
+  }
+  stop("Maximum search of ", MAX_DEPTH, " exceeded for ", path)
 }
 
 with_all_options <- function(code) {

--- a/codemeta.json
+++ b/codemeta.json
@@ -1,5 +1,8 @@
 {
-  "@context": ["https://doi.org/10.5063/schema/codemeta-2.0", "http://schema.org"],
+  "@context": [
+    "https://doi.org/10.5063/schema/codemeta-2.0",
+    "http://schema.org"
+  ],
   "@type": "SoftwareSourceCode",
   "identifier": "drake",
   "description": "A general-purpose computational engine for data analysis,\n  drake rebuilds intermediate data objects when their dependencies change,\n  and it skips work when the results are already up to date.\n  Not every execution starts from scratch,\n  and completed projects have tangible evidence\n  that they are reproducible.\n  Extensive documentation, from beginner-friendly tutorials\n  to practical examples and more, is available at the reference website\n  <https://ropensci.github.io/drake/> and the online manual\n  <https://ropenscilabs.github.io/drake-manual/>.",
@@ -306,18 +309,6 @@
     },
     {
       "@type": "SoftwareApplication",
-      "identifier": "rprojroot",
-      "name": "rprojroot",
-      "provider": {
-        "@id": "https://cran.r-project.org",
-        "@type": "Organization",
-        "name": "Comprehensive R Archive Network (CRAN)",
-        "url": "https://cran.r-project.org"
-      },
-      "sameAs": "https://CRAN.R-project.org/package=rprojroot"
-    },
-    {
-      "@type": "SoftwareApplication",
       "identifier": "stats",
       "name": "stats"
     },
@@ -525,14 +516,32 @@
   ],
   "releaseNotes": "https://github.com/bpbond/drake/blob/master/NEWS.md",
   "readme": "https://github.com/bpbond/drake/blob/master/README.md",
-  "fileSize": "399.059KB",
-  "contIntegration": ["https://ci.appveyor.com/project/ropensci/drake", "https://travis-ci.org/ropensci/drake", "https://codecov.io/github/ropensci/drake?branch=master"],
+  "fileSize": "399.211KB",
+  "contIntegration": [
+    "https://ci.appveyor.com/project/ropensci/drake",
+    "https://travis-ci.org/ropensci/drake",
+    "https://codecov.io/github/ropensci/drake?branch=master"
+  ],
   "developmentStatus": "http://www.repostatus.org/#active",
   "review": {
     "@type": "Review",
     "url": "https://github.com/ropensci/onboarding/issues/156",
     "provider": "http://ropensci.org"
   },
-  "keywords": ["reproducibility", "high-performance-computing", "r", "data-science", "drake", "makefile", "pipeline", "workflow", "reproducible-research", "rstats", "r-package", "ropensci", "peer-reviewed"],
+  "keywords": [
+    "reproducibility",
+    "high-performance-computing",
+    "r",
+    "data-science",
+    "drake",
+    "makefile",
+    "pipeline",
+    "workflow",
+    "reproducible-research",
+    "rstats",
+    "r-package",
+    "ropensci",
+    "peer-reviewed"
+  ],
   "relatedLink": "https://CRAN.R-project.org/package=drake"
 }

--- a/tests/testthat/test-testing.R
+++ b/tests/testthat/test-testing.R
@@ -32,9 +32,6 @@ test_with_dir("set_testing_scenario", {
 
 test_with_dir("testing utils", {
   skip_on_cran() # CRAN gets whitelist tests only (check time limits).
-  path <- system.file("DESCRIPTION", package = "drake")
-  testfiles <- unit_test_files(path = path)
-  expect_equal(basename(testfiles), "testthat")
   expect_true(is.character(this_os()))
   scenario <- default_testing_scenario
   expect_true(is.data.frame(get_testing_scenario()))
@@ -114,4 +111,36 @@ test_with_dir("test_scenarios()", {
   loggings <- grepl("logged scenario", log, fixed = TRUE)
   expect_false(any(loggings))
   expect_true(any(grepl("skip", log, fixed = TRUE)))
+})
+
+test_with_dir("unit_test_files works", {
+  skip_on_cran() # CRAN gets whitelist tests only (check time limits).
+  
+  # Find package root
+  path <- system.file("DESCRIPTION", package = "drake")
+  testfiles <- unit_test_files(path = path)
+  expect_equal(basename(testfiles), "testthat")
+  
+  # Does unit_test_files find a root with DESCRIPTION?
+  wd <- getwd()
+  writeLines(
+    text = "drake",
+    con = "DESCRIPTION"
+  )
+  subdir <- "subdir"
+  if (!file.exists(subdir)) {
+    dir.create(subdir)
+  }
+  expect_equal(basename(unit_test_files(subdir)), "testthat")
+  
+  # DESCRIPTION without 'drake' in first line
+  writeLines(
+    text = "ekard",
+    con = "DESCRIPTION"
+  )
+  expect_error(unit_test_files(wd))
+  
+  # Shouldn't find anything if there's no DESCRIPTION
+  unlink("DESCRIPTION")
+  expect_error(unit_test_files(wd))
 })


### PR DESCRIPTION
# Summary

Per suggestion, remove `rprojroot` as a suggested package. This meant implementing a simple version of `rprojroot::find_root` in `unit_test_files()`.

# Related GitHub issues and pull requests

- Ref: #593 

# Checklist

- [X] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [X] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [X] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [X] I have tested this pull request locally with `devtools::check()`
- [X] This pull request is ready for review.
- [X] I think this pull request is ready to merge.