### PR TITLE
Some internal cleanup: custom plan columns and the timeout argument

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,7 @@
 - Change the names of the return value of `predict_load_balancing()` to `time` and `workers`.
 - Bring the documentation of `predict_runtime()` and `predict_load_balancing()` up to date.
 - Deprecate `drake_session()` and rename to `drake_get_session_info()`.
+- Deprecate the `timeout` argument in the API of `make()` and `drake_config()`. A value of `timeout` can be still passed to these functions without error, but only the `elapsed` and `cpu` arguments impose actual timeouts now.
 
 # Version 6.1.0
 

--- a/R/build.R
+++ b/R/build.R
@@ -160,12 +160,8 @@ build_target <- function(target, meta, config) {
     on.exit(gc())
   }
   retries <- 0
-  max_retries <- drake_plan_override(
-    target = target,
-    field = "retries",
-    config = config
-  )
-  max_retries <- as.numeric(max_retries)
+  layout <- config$layout[[target]] %||% list()
+  max_retries <- as.numeric(layout$retries %||NA% config$retries)
   while (retries <= max_retries) {
     build <- with_seed_timeout(
       target = target,

--- a/R/config.R
+++ b/R/config.R
@@ -167,18 +167,15 @@
 #'   or `"Makefile"`) because the distributed R sessions
 #'   need to know how to load the cache.
 #'
-#' @param timeout Seconds of overall time to allow before imposing
-#'   a timeout on a target.
-#'   Assign target-level timeout times with an optional `timeout`
-#'   column in `plan`.
+#' @param timeout `deprecated`. Use `elapsed` and `cpu` instead.
 #'
-#' @param cpu Seconds of cpu time to allow before imposing
-#'   a timeout on a target.
+#' @param cpu Same as the `cpu` argument of `setTimeLimit()`.
+#'   Seconds of cpu time before a target times out.
 #'   Assign target-level cpu timeout times with an optional `cpu`
 #'   column in `plan`.
 #'
-#' @param elapsed Seconds of elapsed time to allow before imposing
-#'   a timeout on a target.
+#' @param elapsed Same as the `elapsed` argument of `setTimeLimit()`.
+#'   Seconds of elapsed time before a target times out.
 #'   Assign target-level elapsed timeout times with an optional `elapsed`
 #'   column in `plan`.
 #'
@@ -459,9 +456,9 @@ drake_config <- function(
     verbose = verbose
   ),
   recipe_command = drake::default_recipe_command(),
-  timeout = Inf,
-  cpu = timeout,
-  elapsed = timeout,
+  timeout = NULL,
+  cpu = Inf,
+  elapsed = Inf,
   retries = 0,
   force = FALSE,
   log_progress = FALSE,
@@ -509,6 +506,14 @@ drake_config <- function(
       "Use `memory_strategy` instead.",
       call. = FALSE
     ) # 2018-11-01 # nolint
+  }
+  if (!is.null(timeout)) {
+    warning(
+      "Argument `timeout` is deprecated. ",
+      "Use `elapsed` and/or `cpu` instead.",
+      call. = FALSE
+      # 2018-12-07 # nolint
+    )
   }
   plan <- sanitize_plan(plan)
   if (is.null(targets)) {

--- a/R/drake_plan.R
+++ b/R/drake_plan.R
@@ -295,25 +295,6 @@ complete_target_names <- function(commands_list) {
   commands_list
 }
 
-drake_plan_override <- function(target, field, config) {
-  in_plan <- config$plan[[field]]
-  if (is.null(in_plan)) {
-    return(config[[field]])
-  } else {
-    # Should be length 0 or 1 because sanitize_plan()
-    # already screens for duplicate target names.
-    index <- which(config$plan$target == target)
-    if (!length(index)) {
-      stop("target ", target, " is not in the workflow plan.")
-    }
-    out <- in_plan[[index]]
-    if (safe_is_na(out)) {
-      out <- config[[field]]
-    }
-    out
-  }
-}
-
 #' @title Declare the file inputs of a workflow plan command.
 #' @description Use this function to help write the commands
 #'   in your workflow plan data frame. See the examples

--- a/R/make.R
+++ b/R/make.R
@@ -91,9 +91,9 @@ make <- function(
   recipe_command = drake::default_recipe_command(),
   log_progress = TRUE,
   skip_targets = FALSE,
-  timeout = Inf,
-  cpu = NULL,
-  elapsed = NULL,
+  timeout = NULL,
+  cpu = Inf,
+  elapsed = Inf,
   retries = 0,
   force = FALSE,
   return_config = NULL,
@@ -127,6 +127,14 @@ make <- function(
       "The return_config argument to make() is deprecated. ",
       "Now, an internal configuration list is always invisibly returned.",
       call. = FALSE
+    )
+  }
+  if (!is.null(timeout)) {
+    warning(
+      "Argument `timeout` is deprecated. ",
+      "Use `elapsed` and/or `cpu` instead.",
+      call. = FALSE
+      # 2018-12-07 # nolint
     )
   }
   if (is.null(config)) {

--- a/R/run.R
+++ b/R/run.R
@@ -9,8 +9,8 @@ with_seed_timeout <- function(target, meta, config) {
         config = config
       )
     ),
-    cpu = timeouts$cpu,
-    elapsed = timeouts$elapsed
+    cpu = timeouts[["cpu"]],
+    elapsed = timeouts[["elapsed"]]
   )
 }
 
@@ -82,23 +82,12 @@ with_timeout <- function(expr, cpu, elapsed) {
 }
 
 resolve_timeouts <- function(target, config) {
-  keys <- c("timeout", "cpu", "elapsed")
-  timeouts <- lapply(
-    X = keys,
-    FUN = function(field) {
-      out <- drake_plan_override(
-        target = target,
-        field = field,
-        config = config
-      )
-      as.numeric(out)
-    }
+  layout <- config$layout[[target]] %||% list()
+  vapply(
+    X = c("cpu", "elapsed"),
+    FUN = function(key) {
+      layout[[key]] %||NA% config[[key]]
+    },
+    FUN.VALUE = numeric(1)
   )
-  names(timeouts) <- keys
-  for (field in c("cpu", "elapsed")) {
-    if (!length(timeouts[[field]])) {
-      timeouts[[field]] <- timeouts$timeout
-    }
-  }
-  timeouts
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -7,6 +7,14 @@
   }
 }
 
+`%||NA%` <- function(x, y) {
+  if (is.null(x) || length(x) < 1 || is.na(x)) {
+    y
+  } else {
+    x
+  }
+}
+
 assert_pkg <- function(pkg, version = NULL, install = "install.packages") {
   if (!requireNamespace(pkg, quietly = TRUE)) {
     stop(

--- a/man/drake_config.Rd
+++ b/man/drake_config.Rd
@@ -13,8 +13,8 @@ drake_config(plan = drake::read_drake_plan(), targets = NULL,
   packages = rev(.packages()), prework = character(0),
   prepend = character(0), command = drake::default_Makefile_command(),
   args = drake::default_Makefile_args(jobs = jobs, verbose = verbose),
-  recipe_command = drake::default_recipe_command(), timeout = Inf,
-  cpu = timeout, elapsed = timeout, retries = 0, force = FALSE,
+  recipe_command = drake::default_recipe_command(), timeout = NULL,
+  cpu = Inf, elapsed = Inf, retries = 0, force = FALSE,
   log_progress = FALSE, graph = NULL, trigger = drake::trigger(),
   skip_targets = FALSE, skip_imports = FALSE,
   skip_safety_checks = FALSE, lazy_load = "eager",
@@ -165,18 +165,15 @@ wherever possible.}
 \item{recipe_command}{Character scalar, command for the
 Makefile recipe for each target.}
 
-\item{timeout}{Seconds of overall time to allow before imposing
-a timeout on a target.
-Assign target-level timeout times with an optional \code{timeout}
-column in \code{plan}.}
+\item{timeout}{\code{deprecated}. Use \code{elapsed} and \code{cpu} instead.}
 
-\item{cpu}{Seconds of cpu time to allow before imposing
-a timeout on a target.
+\item{cpu}{Same as the \code{cpu} argument of \code{setTimeLimit()}.
+Seconds of cpu time before a target times out.
 Assign target-level cpu timeout times with an optional \code{cpu}
 column in \code{plan}.}
 
-\item{elapsed}{Seconds of elapsed time to allow before imposing
-a timeout on a target.
+\item{elapsed}{Same as the \code{elapsed} argument of \code{setTimeLimit()}.
+Seconds of elapsed time before a target times out.
 Assign target-level elapsed timeout times with an optional \code{elapsed}
 column in \code{plan}.}
 

--- a/man/make.Rd
+++ b/man/make.Rd
@@ -13,8 +13,8 @@ make(plan = drake::read_drake_plan(), targets = NULL,
   prepend = character(0), command = drake::default_Makefile_command(),
   args = drake::default_Makefile_args(jobs = jobs, verbose = verbose),
   recipe_command = drake::default_recipe_command(),
-  log_progress = TRUE, skip_targets = FALSE, timeout = Inf,
-  cpu = NULL, elapsed = NULL, retries = 0, force = FALSE,
+  log_progress = TRUE, skip_targets = FALSE, timeout = NULL,
+  cpu = Inf, elapsed = Inf, retries = 0, force = FALSE,
   return_config = NULL, graph = NULL, trigger = drake::trigger(),
   skip_imports = FALSE, skip_safety_checks = FALSE, config = NULL,
   lazy_load = "eager", session_info = TRUE, cache_log_file = NULL,
@@ -176,18 +176,15 @@ will no longer work if you do that.}
 \item{skip_targets}{logical, whether to skip building the targets
 in \code{plan} and just import objects and files.}
 
-\item{timeout}{Seconds of overall time to allow before imposing
-a timeout on a target.
-Assign target-level timeout times with an optional \code{timeout}
-column in \code{plan}.}
+\item{timeout}{\code{deprecated}. Use \code{elapsed} and \code{cpu} instead.}
 
-\item{cpu}{Seconds of cpu time to allow before imposing
-a timeout on a target.
+\item{cpu}{Same as the \code{cpu} argument of \code{setTimeLimit()}.
+Seconds of cpu time before a target times out.
 Assign target-level cpu timeout times with an optional \code{cpu}
 column in \code{plan}.}
 
-\item{elapsed}{Seconds of elapsed time to allow before imposing
-a timeout on a target.
+\item{elapsed}{Same as the \code{elapsed} argument of \code{setTimeLimit()}.
+Seconds of elapsed time before a target times out.
 Assign target-level elapsed timeout times with an optional \code{elapsed}
 column in \code{plan}.}
 

--- a/tests/testthat/test-deprecate.R
+++ b/tests/testthat/test-deprecate.R
@@ -249,6 +249,17 @@ test_with_dir("deprecate the `force` argument", {
   expect_warning(load_mtcars_example(force = TRUE), regexp = "deprecated")
 })
 
+test_with_dir("timeout argument", {
+  expect_warning(
+    make(
+      drake_plan(x = 1),
+      timeout = 5,
+      session_info = FALSE,
+      cache = storr::storr_environment()
+    )
+  )
+})
+
 test_with_dir("old trigger interface", {
   skip_on_cran()
   for (old_trigger in suppressWarnings(triggers())) {

--- a/tests/testthat/test-edge-cases.R
+++ b/tests/testthat/test-edge-cases.R
@@ -84,16 +84,6 @@ test_with_dir("failed targets do not become up to date", {
   expect_equal(sort(outdated(con)), sort(c("a", "c")))
 })
 
-test_with_dir("drake_plan_override() quits correctly in error", {
-  skip_on_cran() # CRAN gets whitelist tests only (check time limits).
-  con <- dbug()
-  con$plan$missing <- "nope"
-  expect_error(
-    drake_plan_override(target = "missing", field = "missing", config = con),
-    regexp = "not in the workflow plan"
-  )
-})
-
 test_with_dir("config and make without safety checks", {
   skip_on_cran() # CRAN gets whitelist tests only (check time limits).
   x <- drake_plan(

--- a/tests/testthat/test-plans.R
+++ b/tests/testthat/test-plans.R
@@ -602,7 +602,7 @@ test_with_dir("drake_plan_source()", {
         command = FALSE,
         depend = FALSE
       ),
-      timeout = 1e3
+      elapsed = 1e3
     ),
     strings_in_dots = "literals"
   )

--- a/tests/testthat/test-retry.R
+++ b/tests/testthat/test-retry.R
@@ -89,7 +89,7 @@ test_with_dir("timeouts", {
         pl,
         envir = e,
         verbose = FALSE,
-        timeout = 1e-3,
+        elapsed = 1e-3,
         retries = 2,
         session_info = FALSE
       )
@@ -100,7 +100,7 @@ test_with_dir("timeouts", {
   # Should time out too. The workflow plan should override
   # the arguments to make().
   # CPU time should be similar, but testing it is elusive.
-  for (field in c("timeout", "elapsed")) {
+  for (field in c("elapsed")) {
     clean()
     pl2 <- pl
     pl2[[field]] <- 1e-3

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -40,3 +40,14 @@ test_with_dir("drake_pmap", {
   x[[2]] <- NULL
   expect_error(drake_pmap(list(x, y, z), sum))
 })
+
+test_with_dir("operators", {
+  expect_equal("a" %||% "b", "a")
+  expect_equal(NULL %||% "b", "b")
+  expect_true(is.numeric(Inf %||% "b"))
+  expect_true(is.na(NA %||% "b"))
+  expect_equal("a" %||NA% "b", "a")
+  expect_equal(NULL %||NA% "b", "b")
+  expect_true(is.numeric(Inf %||NA% "b"))
+  expect_false(is.na(NA %||NA% "b"))
+})


### PR DESCRIPTION
# Summary

`drake_plan_override()` was a slow, awkwardly-named function that handled custom columns in `drake` plans. This PR replaces it with a better alternative using the new `config$layout` (thanks to #440).

Also, this PR deprecates the `timeout` argument of `make()` and `drake_config()` in favor of `elapsed` and `cpu`. The API still accepts a `timeout` argument, but for the sake of expediency and simplicity, it is ignored.

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
