### PR TITLE
Prework for faster code analysis

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# Version 6.2.0.9000
+
+- Allow the `magrittr` dot symbol to appear in some commands sometimes.
+
 # Version 6.1.0.9000
 
 ## New features

--- a/R/code_analysis.R
+++ b/R/code_analysis.R
@@ -55,7 +55,6 @@ code_dependencies <- function(expr, exclude = character(0), allow = NULL) {
   if (!is.null(allow)) {
     results$globals <- intersect(results$globals, allow)
   }
-  exclude <- base::union(exclude, ".")
   results <- lapply(
     X = results,
     FUN = function(x) {
@@ -175,7 +174,6 @@ file_out_fns <- pair_text(drake_prefix, c("file_out"))
 ignored_fns <- pair_text(drake_prefix, c("drake_envir", "ignore"))
 knitr_in_fns <- pair_text(drake_prefix, c("knitr_in"))
 loadd_fns <- pair_text(drake_prefix, "loadd")
-misc_syms <- "."
 readd_fns <- pair_text(drake_prefix, "readd")
 target_fns <- pair_text(drake_prefix, "target")
 trigger_fns <- pair_text(drake_prefix, "trigger")
@@ -188,7 +186,6 @@ drake_symbols <- sort(
     ignored_fns,
     loadd_fns,
     knitr_in_fns,
-    misc_syms,
     readd_fns,
     target_fns,
     trigger_fns

--- a/R/code_analysis.R
+++ b/R/code_analysis.R
@@ -1,4 +1,4 @@
-code_dependencies <- function(expr, exclude = character(0), globals = NULL) {
+code_dependencies <- function(expr, exclude = character(0), allow = NULL) {
   if (
     !is.function(expr) &&
     !is.expression(expr) &&
@@ -52,8 +52,8 @@ code_dependencies <- function(expr, exclude = character(0), globals = NULL) {
   results$globals <- as.character(results$globals)
   non_locals <- find_non_locals(expr)
   results$globals <- intersect(results$globals, non_locals)
-  if (!is.null(globals)) {
-    results$globals <- intersect(results$globals, globals)
+  if (!is.null(allow)) {
+    results$globals <- intersect(results$globals, allow)
   }
   exclude <- base::union(exclude, ".")
   results <- lapply(

--- a/R/create_drake_layout.R
+++ b/R/create_drake_layout.R
@@ -18,7 +18,7 @@ create_drake_layout <- function(
     cache = cache,
     console_log_file = console_log_file,
     trigger = parse_trigger(trigger = trigger, envir = envir),
-    globals = sort(c(plan$target, ls(envir = envir, all.names = TRUE)))
+    allow = sort(c(plan$target, ls(envir = envir, all.names = TRUE)))
   )
   imports <- cdl_prepare_imports(config)
   imports_kernel <- cdl_imports_kernel(config, imports)
@@ -32,7 +32,7 @@ create_drake_layout <- function(
     config$cache,
     config$plan,
     config$trigger,
-    config$globals,
+    config$allow,
     import_layout
   )
   c(import_layout, command_layout)
@@ -93,7 +93,7 @@ cdl_analyze_imports <- function(config, imports) {
         deps_build = import_dependencies(
           expr = imports[[i]],
           exclude = names(imports)[[i]],
-          globals = config$globals
+          allow = config$allow
         ),
         imported = TRUE
       )
@@ -123,11 +123,11 @@ cdl_analyze_commands <- function(config) {
   names(layout) <- config$plan$target
   config$default_condition_deps <- import_dependencies(
     config$trigger$condition,
-    globals = config$globals
+    allow = config$allow
   )
   config$default_change_deps <- import_dependencies(
     config$trigger$change,
-    globals = config$globals
+    allow = config$allow
   )
   out <- lightly_parallelize(
     X = layout,
@@ -143,7 +143,7 @@ cdl_prepare_layout <- function(layout, config){
   layout$deps_build <- command_dependencies(
     command = layout$command,
     exclude = layout$target,
-    globals = config$globals
+    allow = config$allow
   )
   layout$command_standardized <- standardize_command(layout$command)
   layout$command_build <- preprocess_command(
@@ -158,12 +158,12 @@ cdl_prepare_layout <- function(layout, config){
     layout$deps_condition <- import_dependencies(
       layout$trigger$condition,
       exclude = layout$target,
-      globals = config$globals
+      allow = config$allow
     )
     layout$deps_change <- import_dependencies(
       layout$trigger$change,
       exclude = layout$target,
-      globals = config$globals
+      allow = config$allow
     )
   }
   layout

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -256,8 +256,8 @@ nonfile_target_dependencies <- function(targets, config, jobs = 1) {
   intersect(out, config$plan$target)
 }
 
-import_dependencies <- function(expr, exclude = character(0), globals = NULL) {
-  deps <- code_dependencies(expr, exclude = exclude, globals = globals)
+import_dependencies <- function(expr, exclude = character(0), allow = NULL) {
+  deps <- code_dependencies(expr, exclude = exclude, allow = allow)
   # Imported functions can't have file_out() deps # nolint
   # or target dependencies from knitr code chunks.
   # However, file_in()s are totally fine. # nolint
@@ -268,7 +268,7 @@ import_dependencies <- function(expr, exclude = character(0), globals = NULL) {
 command_dependencies <- function(
   command,
   exclude = character(0),
-  globals = NULL
+  allow = NULL
 ) {
   if (!length(command)) {
     return()
@@ -280,7 +280,7 @@ command_dependencies <- function(
   deps <- code_dependencies(
     expr,
     exclude = exclude,
-    globals = globals
+    allow = allow
   )
   deps$strings <- NULL
 

--- a/R/hash_table.R
+++ b/R/hash_table.R
@@ -1,0 +1,29 @@
+# Wanted to use reference classes here,
+# but they add computational overhead.
+# This is a part of the code that really needs to be fast.
+ht_new <- function() {
+  new.env(hash = TRUE, parent = emptyenv())
+}
+
+ht_add <- function(ht, x) {
+  lapply(
+    X = x,
+    FUN = assign,
+    value = TRUE,
+    envir = ht,
+    inherits = FALSE
+  )
+  invisible()
+}
+
+hd_del <- function(ht, x) {
+  remove(list = x, envir = ht, inherits = FALSE)
+}
+
+ht_exists <- function(ht, x) {
+  exists(x, envir = ht, inherits = FALSE)
+}
+
+ht_list <- function(ht) {
+  ls(envir = ht, all.names = TRUE, sorted = FALSE)
+}

--- a/R/hash_table.R
+++ b/R/hash_table.R
@@ -27,3 +27,7 @@ ht_exists <- function(ht, x) {
 ht_list <- function(ht) {
   ls(envir = ht, all.names = TRUE, sorted = FALSE)
 }
+
+ht_clone <- function(ht) {
+  list2env(as.list(ht), hash = TRUE, parent = emptyenv())
+}

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -34,6 +34,14 @@ test_with_dir("dot symbol is ignored at the right time", {
     clean_dependency_list(config$layout$b$deps_build),
     character(0)
   )
+  . <- 1
+  expect_true(exists(".", envir = e))
+  config <- drake_config(plan)
+  expect_equal(
+    sort(clean_dependency_list(config$layout$a$deps_build)),
+    sort(c(".", "x", "y"))
+  )
+  expect_equal(clean_dependency_list(config$layout$b$deps_build), ".")
 })
 
 test_with_dir("file_out() and knitr_in(): commands vs imports", {

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -6,16 +6,33 @@ test_with_dir("unparsable commands are handled correctly", {
   expect_error(deps_code(x))
 })
 
-test_with_dir("dot symbol is ignored", {
+test_with_dir("dot symbol is ignored at the right time", {
   skip_on_cran() # CRAN gets whitelist tests only (check time limits).
   expect_equal(
     sort(clean_dependency_list(deps_code("sqrt(x + y + .)"))),
-    sort(c("sqrt", "x", "y"))
+    sort(c(".", "sqrt", "x", "y"))
   )
   expect_equal(
     sort(clean_dependency_list(
       deps_code("subset(complete.cases(.))"))),
-    sort(c("complete.cases", "subset"))
+    sort(c("complete.cases", ".", "subset"))
+  )
+  plan <- drake_plan(
+    x = 1,
+    y = 2,
+    a = sqrt(x + y + .),
+    b = subset(complete.cases(.))
+  )
+  e <- environment()
+  expect_false(exists(".", envir = e))
+  config <- drake_config(plan)
+  expect_equal(
+    sort(clean_dependency_list(config$layout$a$deps_build)),
+    sort(c("x", "y"))
+  )
+  expect_equal(
+    clean_dependency_list(config$layout$b$deps_build),
+    character(0)
   )
 })
 

--- a/tests/testthat/test-hash-table.R
+++ b/tests/testthat/test-hash-table.R
@@ -12,4 +12,8 @@ test_that("hash tables work", {
   expect_false(ht_exists(e, "a"))
   expect_true(ht_exists(e, "b"))
   expect_equal(ht_list(e), "b")
+  f <- ht_clone(e)
+  ht_add(f, "xyz")
+  expect_false(ht_exists(e, "xyz"))
+  expect_true(ht_exists(f, "xyz"))
 })

--- a/tests/testthat/test-hash_table.R
+++ b/tests/testthat/test-hash_table.R
@@ -1,0 +1,15 @@
+context("hash tables")
+
+test_that("hash tables work", {
+  e <- ht_new()
+  expect_equal(ht_list(e), character(0))
+  expect_false(ht_exists(e, "a"))
+  expect_false(ht_exists(e, "b"))
+  ht_add(e, c("a", "b"))
+  expect_true(ht_exists(e, "a"))
+  expect_true(ht_exists(e, "b"))
+  hd_del(e, "a")
+  expect_false(ht_exists(e, "a"))
+  expect_true(ht_exists(e, "b"))
+  expect_equal(ht_list(e), "b")
+})


### PR DESCRIPTION
# Summary

- Add internal functions to work with hash tables. I could have used a more convenient interface with reference classes, but that would have added overhead. This part of the code needs to run super fast.
- Allow the `magrittr` dot to be detected sometimes. Ref: #320. As of `drake` version 6.0.0, imports have to actually be in the environment to be detected as dependencies, so we no longer have to categorically exclude `"."`.
- Change `globals` to `allow` (argument name of `code_dependencies()`).

# Related GitHub issues and pull requests

- Ref: #573 (not solved yet)

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
