### PR TITLE
Make bind_plans() work with lists of data frames.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # Version 6.2.1.9000
 
+## Bug fixes
+
+- Allow `bind_plans()` to work with lists of plans (`bind_plans(list(plan1, plan2))` was returning `NULL` in `drake` 6.2.0 and 6.2.1).
+
+## Enhancements
+
 - Allow the `magrittr` dot symbol to appear in some commands sometimes.
 
 # Version 6.2.1

--- a/R/drake_plan.R
+++ b/R/drake_plan.R
@@ -240,7 +240,11 @@ drake_plan <- function(
 #' your_plan
 #' # make(your_plan) # nolint
 bind_plans <- function(...) {
-  plans <- list(...)
+  args <- list(...)
+  plan_env <- new.env(parent = emptyenv())
+  plan_env$plans <- list()
+  flatten_plan_list(args, plan_env = plan_env)
+  plans <- plan_env$plans
   plans <- Filter(f = nrow, x = plans)
   plans <- Filter(f = ncol, x = plans)
   cols <- lapply(plans, colnames)
@@ -248,6 +252,15 @@ bind_plans <- function(...) {
   plans <- lapply(plans, fill_cols, cols = cols)
   plan <- do.call(rbind, plans)
   sanitize_plan(plan)
+}
+
+flatten_plan_list <- function(args, plan_env){
+  if (!is.null(dim(args))) {
+    index <- length(plan_env$plans) + 1
+    plan_env$plans[[index]] <- tibble::as_tibble(args)
+  } else {
+    lapply(args, flatten_plan_list, plan_env = plan_env)
+  }
 }
 
 fill_cols <- function(x, cols) {

--- a/tests/testthat/test-plans.R
+++ b/tests/testthat/test-plans.R
@@ -450,6 +450,7 @@ test_with_dir("custom column interface", {
 test_with_dir("bind_plans()", {
   skip_on_cran() # CRAN gets whitelist tests only (check time limits).
   plan1 <- drake_plan(x = 1, y = 2)
+  expect_equal(bind_plans(plan1, plan1), plan1) # targets should be unique
   plan2 <- drake_plan(
     z = target(
       command = download_data(),

--- a/tests/testthat/test-plans.R
+++ b/tests/testthat/test-plans.R
@@ -457,13 +457,26 @@ test_with_dir("bind_plans()", {
     ),
     strings_in_dots = "literals"
   )
-  plan3 <- bind_plans(plan1, plan2)
-  plan4 <- tibble::tibble(
+  plan3 <- drake_plan(u = 3, v = 4, w = 5)
+  out <- bind_plans(plan1, plan2)
+  exp <- tibble::tibble(
     target = c("x", "y", "z"),
     command = c("1", "2", "download_data()"),
     trigger = c(NA, NA, "trigger(condition = TRUE)")
   )
-  expect_equal(plan3, plan4)
+  expect_equal(out, exp)
+  exp <- tibble::tibble(
+    target = c("x", "y", "z", "u", "v", "w"),
+    command = c("1", "2", "download_data()", "3", "4", "5"),
+    trigger = c(NA, NA, "trigger(condition = TRUE)", NA, NA, NA)
+  )
+  expect_equal(bind_plans(plan1, plan2, plan3), exp)
+  expect_equal(bind_plans(list(plan1, plan2, plan3)), exp)
+  expect_equal(bind_plans(list(list(plan1, plan2, plan3))), exp)
+  expect_equal(bind_plans(list(plan1, list(plan2, plan3))), exp)
+  expect_equal(bind_plans(list(plan1, list(plan2, list(plan3)))), exp)
+  expect_equal(bind_plans(list(list(plan1), list(plan2, list(plan3)))), exp)
+  expect_equal(bind_plans(list(list(plan1), list(plan2), list(plan3))), exp)
 })
 
 test_with_dir("spaces in target names are replaced only when appropriate", {


### PR DESCRIPTION
# Summary

In `drake` versions 6.2.0 and 6.2.1, `bind_plans(list(plan1, plan2))` was returning `NULL`. This PR makes `bind_plans()` work with nested lists of data frames.

cc @pat-s. Thanks for opening #611.

``` r
library(drake)
plan1 <- drake_plan(a = 1, b = 2)
plan2 <- drake_plan(c = 3, d = 4)
plan3 <- drake_plan(e = 5, f = 6)
bind_plans(plan1, plan2, plan3)
#> # A tibble: 6 x 2
#>   target command
#>   <chr>  <chr>  
#> 1 a      1      
#> 2 b      2      
#> 3 c      3      
#> 4 d      4      
#> 5 e      5      
#> 6 f      6
bind_plans(list(plan1, plan2, plan3))
#> # A tibble: 6 x 2
#>   target command
#>   <chr>  <chr>  
#> 1 a      1      
#> 2 b      2      
#> 3 c      3      
#> 4 d      4      
#> 5 e      5      
#> 6 f      6
bind_plans(list(list(plan1, plan2, plan3)))
#> # A tibble: 6 x 2
#>   target command
#>   <chr>  <chr>  
#> 1 a      1      
#> 2 b      2      
#> 3 c      3      
#> 4 d      4      
#> 5 e      5      
#> 6 f      6
bind_plans(list(plan1, list(plan2, plan3)))
#> # A tibble: 6 x 2
#>   target command
#>   <chr>  <chr>  
#> 1 a      1      
#> 2 b      2      
#> 3 c      3      
#> 4 d      4      
#> 5 e      5      
#> 6 f      6
bind_plans(list(list(list(plan1)), list(list(plan2), plan3)))
#> # A tibble: 6 x 2
#>   target command
#>   <chr>  <chr>  
#> 1 a      1      
#> 2 b      2      
#> 3 c      3      
#> 4 d      4      
#> 5 e      5      
#> 6 f      6
```

<sup>Created on 2018-12-12 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

# Related GitHub issues and pull requests

- Ref: #611

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
