### PR TITLE
Do not modify config$envir during make()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 - Allow the `magrittr` dot symbol to appear in some commands sometimes.
 - Deprecate the `fetch_cache` argument in all functions 
 - Remove packages `DBI` and `RSQLite` from "Suggests".
+- Define a special `config$eval <- new.env(parent = config$envir)` for storing built targets and evaluating commands in the plan. This move increases the purity of `make()` calls.
 
 # Version 6.2.1
 

--- a/R/build.R
+++ b/R/build.R
@@ -36,7 +36,7 @@ drake_build <- function(
   config = drake::read_drake_config(envir = envir, jobs = jobs),
   meta = NULL,
   character_only = FALSE,
-  envir = parent.frame(),
+  envir = NULL,
   jobs = 1,
   replace = FALSE
 ) {
@@ -47,13 +47,19 @@ drake_build <- function(
       "Thus, the `meta` argument is deprecated."
     )
   }
+  if (!is.null(envir)) {
+    warning(
+      "In drake_build(), the envir argument is deprecated. ",
+      call. = FALSE
+    )
+  }
   if (!character_only) {
     target <- as.character(substitute(target))
   }
   loadd(
     list = target,
     deps = TRUE,
-    envir = envir,
+    envir = config$eval,
     cache = config$cache,
     graph = config$graph,
     jobs = jobs,

--- a/R/build.R
+++ b/R/build.R
@@ -33,10 +33,10 @@
 #' }
 drake_build <- function(
   target,
-  config = drake::read_drake_config(envir = envir, jobs = jobs),
+  config = NULL,
   meta = NULL,
   character_only = FALSE,
-  envir = NULL,
+  envir = parent.frame(),
   jobs = 1,
   replace = FALSE
 ) {
@@ -47,14 +47,13 @@ drake_build <- function(
       "Thus, the `meta` argument is deprecated."
     )
   }
-  if (!is.null(envir)) {
-    warning(
-      "In drake_build(), the envir argument is deprecated. ",
-      call. = FALSE
-    )
-  }
   if (!character_only) {
     target <- as.character(substitute(target))
+  }
+  force(envir)
+  if (is.null(config)) {
+    config <- drake::read_drake_config(envir = envir, jobs = jobs)
+    config$envir <- envir
   }
   loadd(
     list = target,

--- a/R/clustermq.R
+++ b/R/clustermq.R
@@ -93,7 +93,7 @@ cmq_deps_list <- function(target, config) {
   out <- lapply(
     X = deps,
     FUN = function(name) {
-      config$envir[[name]]
+      config$eval[[name]]
     }
   )
   names(out) <- deps
@@ -116,7 +116,7 @@ cmq_build <- function(target, meta, deps, config) {
   do_prework(config = config, verbose_packages = FALSE)
   if (identical(config$caching, "master")) {
     for (dep in names(deps)) {
-      config$envir[[dep]] <- deps[[dep]]
+      config$eval[[dep]] <- deps[[dep]]
     }
   } else {
     manage_memory(targets = target, config = config, jobs = 1)

--- a/R/config.R
+++ b/R/config.R
@@ -580,6 +580,7 @@ drake_config <- function(
     plan = plan,
     targets = targets,
     envir = envir,
+    eval = new.env(parent = envir),
     cache = cache,
     cache_path = cache_path,
     fetch_cache = fetch_cache,

--- a/R/config.R
+++ b/R/config.R
@@ -660,8 +660,9 @@ add_packages_to_prework <- function(packages, prework) {
 do_prework <- function(config, verbose_packages) {
   wrapper <- ifelse(verbose_packages, invisible,
     base::suppressPackageStartupMessages)
-  for (code in config$prework) wrapper(eval(parse(text = code),
-    envir = config$envir))
+  for (code in config$prework) {
+    wrapper(eval(parse(text = code), envir = config$eval))
+  }
   invisible()
 }
 

--- a/R/create_drake_layout.R
+++ b/R/create_drake_layout.R
@@ -116,7 +116,7 @@ cdl_analyze_commands <- function(config) {
     config$plan$trigger <- lapply(
       config$plan$trigger,
       parse_trigger,
-      envir = config$envir
+      envir = config$eval
     )
   }
   layout <- drake_pmap(.l = config$plan, .f = list, jobs = config$jobs)

--- a/R/distributed.R
+++ b/R/distributed.R
@@ -20,8 +20,6 @@ prepare_distributed <- function(config) {
   if (!file.exists(config$cache_path)) {
     dir.create(config$cache_path)
   }
-  # Always save globalenv() because config$envir could inherit from it
-  # and so drake might look for stuff there.
   save(
     list = setdiff(ls(globalenv(), all.names = TRUE), config$plan$target),
     envir = globalenv(),
@@ -55,8 +53,6 @@ build_distributed <- function(target, cache_path, check = TRUE) {
 recover_drake_config <- function(cache_path) {
   cache <- this_cache(cache_path, verbose = FALSE)
   config <- read_drake_config(cache = cache)
-  # Always load globalenv() because config$envir could inherit from it
-  # and so drake might look for stuff there.
   dir <- cache_path(cache = cache)
   file <- globalenv_file(dir)
   load(file = file, envir = globalenv())

--- a/R/drake_debug.R
+++ b/R/drake_debug.R
@@ -34,7 +34,7 @@
 #' }
 drake_debug <- function(
   target = NULL,
-  config = drake::read_drake_config(envir = envir, jobs = jobs),
+  config = NULL,
   character_only = FALSE,
   envir = parent.frame(),
   jobs = 1,
@@ -43,6 +43,11 @@ drake_debug <- function(
 ) {
   # Tested in tests/testthat/test-always-skipped.R.
   # nocov start
+  force(envir)
+  if (is.null(config)) {
+    config <- drake::read_drake_config(envir = envir, jobs = jobs)
+    config$envir <- envir
+  }
   if (!character_only) {
     target <- as.character(substitute(target))
   }
@@ -55,7 +60,7 @@ drake_debug <- function(
   loadd(
     list = target,
     deps = TRUE,
-    envir = envir,
+    envir = config$eval,
     cache = config$cache,
     graph = config$graph,
     jobs = jobs,

--- a/R/drake_graph_info_utils.R
+++ b/R/drake_graph_info_utils.R
@@ -160,7 +160,7 @@ filtered_legend_nodes <- function(all_nodes, full_legend, font_size) {
 
 function_hover_text <- Vectorize(function(function_name, envir) {
   x <- tryCatch(
-    eval(parse(text = function_name), envir = envir),
+    get(x = function_name, envir = envir),
     error = function(e) function_name
   )
   x <- unwrap_function(x)

--- a/R/future.R
+++ b/R/future.R
@@ -48,7 +48,7 @@ run_future <- function(config) {
 #' @param meta list of metadata
 #' @param config [drake_config()] list
 #' @param protect Names of targets that still need their
-#' dependencies available in `config$envir`.
+#' dependencies available in memory.
 drake_future_task <- function(target, meta, config, protect) {
   if (identical(config$caching, "worker")) {
     manage_memory(targets = target, config = config, downstream = protect)

--- a/R/hasty.R
+++ b/R/hasty.R
@@ -13,7 +13,7 @@ hasty_loop <- function(config) {
   targets <- igraph::topo_sort(config$schedule)$name
   for (target in targets) {
     console_target(target = target, config = config)
-    config$envir[[target]] <- config$hasty_build(
+    config$eval[[target]] <- config$hasty_build(
       target = target,
       config = config
     )
@@ -29,9 +29,9 @@ hasty_loop <- function(config) {
 default_hasty_build <- function(target, config) {
   tidy_expr <- eval(
     expr = config$layout[[target]]$command_build,
-    envir = config$envir
+    envir = config$eval
   )
-  eval(expr = tidy_expr, envir = config$envir)
+  eval(expr = tidy_expr, envir = config$eval)
 }
 
 hasty_parallel <- function(config) {
@@ -98,7 +98,7 @@ hasty_send_target <- function(config) {
 remote_hasty_build <- function(target, deps = NULL, config) {
   do_prework(config = config, verbose_packages = FALSE)
   for (dep in names(deps)) {
-    config$envir[[dep]] <- deps[[dep]]
+    config$eval[[dep]] <- deps[[dep]]
   }
   value <- config$hasty_build(target = target, config = config)
   invisible(list(target = target, value = value))
@@ -108,7 +108,7 @@ conclude_hasty_build <- function(msg, config) {
   if (is.null(msg$result)) {
     return()
   }
-  config$envir[[msg$result$target]] <- msg$result$value
+  config$eval[[msg$result$target]] <- msg$result$value
   revdeps <- dependencies(
     targets = msg$result$target,
     config = config,

--- a/R/make.R
+++ b/R/make.R
@@ -382,8 +382,8 @@ make_imports_targets <- function(config) {
 }
 
 conclude_session <- function(config) {
-  unmark_envir(config$envir)
-  suppressWarnings(remove(list = config$plan$target, envir = config$envir))
+  unmark_envir(config$eval)
+  remove(list = ls(config$eval, all.names = TRUE), envir = config$eval)
 }
 
 mark_envir <- function(envir) {

--- a/R/meta.R
+++ b/R/meta.R
@@ -76,7 +76,7 @@ drake_meta <- function(target, config = drake::read_drake_config()) {
   }
   if (!is.null(meta$trigger$change)) {
     ensure_loaded(layout$deps_change, config = config)
-    meta$trigger$value <- eval(meta$trigger$change, config$envir)
+    meta$trigger$value <- eval(meta$trigger$change, config$eval)
   }
   meta
 }

--- a/R/run.R
+++ b/R/run.R
@@ -59,11 +59,11 @@ with_call_stack <- function(target, config) {
     signalCondition(e)
   }
   expr <- config$layout[[target]]$command_build
-  tidy_expr <- eval(expr = expr, envir = config$envir) # tidy eval prep
+  tidy_expr <- eval(expr = expr, envir = config$eval) # tidy eval prep
   frame <- sys.nframe()
   tryCatch(
     withCallingHandlers(
-      eval(expr = tidy_expr, envir <- config$envir), # pure eval
+      eval(expr = tidy_expr, envir <- config$eval), # pure eval
       error = capture_calls
     ),
     error = identity

--- a/R/session.R
+++ b/R/session.R
@@ -48,7 +48,7 @@ drake_set_session_info <- function(
 
 initialize_session <- function(config) {
   init_common_values(config$cache)
-  mark_envir(config$envir)
+  mark_envir(config$eval)
   if (config$log_progress) {
     clear_tmp_namespace(
       cache = config$cache,

--- a/R/test.R
+++ b/R/test.R
@@ -6,24 +6,25 @@ drake_context <- function(x) {
 
 testrun <- function(config) {
   set_test_backend()
-  make(
-    plan = config$plan,
-    targets = config$targets,
-    envir = config$envir,
-    verbose = config$verbose,
-    parallelism = config$parallelism,
-    jobs = config$jobs,
-    packages = config$packages,
-    prework = config$prework,
-    prepend = config$prepend,
-    command = config$command,
-    cache = config$cache,
-    lazy_load = config$lazy_load,
-    session_info = config$session_info,
-    fetch_cache = config$fetch_cache,
-    caching = config$caching
+  invisible(
+    make(
+      plan = config$plan,
+      targets = config$targets,
+      envir = config$envir,
+      verbose = config$verbose,
+      parallelism = config$parallelism,
+      jobs = config$jobs,
+      packages = config$packages,
+      prework = config$prework,
+      prepend = config$prepend,
+      command = config$command,
+      cache = config$cache,
+      lazy_load = config$lazy_load,
+      session_info = config$session_info,
+      fetch_cache = config$fetch_cache,
+      caching = config$caching
+    )
   )
-  invisible()
 }
 
 justbuilt <- function(config) {

--- a/R/test.R
+++ b/R/test.R
@@ -6,18 +6,24 @@ drake_context <- function(x) {
 
 testrun <- function(config) {
   set_test_backend()
-  invisible(
-    make(plan = config$plan, targets = config$targets, envir = config$envir,
-         verbose = config$verbose, parallelism = config$parallelism,
-         jobs = config$jobs,
-         packages = config$packages, prework = config$prework,
-         prepend = config$prepend, command = config$command,
-         cache = config$cache, lazy_load = config$lazy_load,
-         session_info = config$session_info,
-         fetch_cache = config$fetch_cache,
-         caching = config$caching
-    )
+  make(
+    plan = config$plan,
+    targets = config$targets,
+    envir = config$envir,
+    verbose = config$verbose,
+    parallelism = config$parallelism,
+    jobs = config$jobs,
+    packages = config$packages,
+    prework = config$prework,
+    prepend = config$prepend,
+    command = config$command,
+    cache = config$cache,
+    lazy_load = config$lazy_load,
+    session_info = config$session_info,
+    fetch_cache = config$fetch_cache,
+    caching = config$caching
   )
+  invisible()
 }
 
 justbuilt <- function(config) {

--- a/R/triggers.R
+++ b/R/triggers.R
@@ -170,7 +170,7 @@ condition_trigger <- function(target, meta, config) {
   if (is.language(meta$trigger$condition)) {
     deps <- config$layout[[target]]$deps_condition
     deps <- ensure_loaded(deps, config = config)
-    value <- eval(meta$trigger$condition, envir = config$envir)
+    value <- eval(meta$trigger$condition, envir = config$eval)
     value <- as.logical(value)
   } else {
     value <- as.logical(meta$trigger$condition)

--- a/man/drake_build.Rd
+++ b/man/drake_build.Rd
@@ -4,9 +4,9 @@
 \alias{drake_build}
 \title{Build/process a single target or import.}
 \usage{
-drake_build(target, config = drake::read_drake_config(envir = envir, jobs
-  = jobs), meta = NULL, character_only = FALSE, envir = NULL,
-  jobs = 1, replace = FALSE)
+drake_build(target, config = NULL, meta = NULL,
+  character_only = FALSE, envir = parent.frame(), jobs = 1,
+  replace = FALSE)
 }
 \arguments{
 \item{target}{name of the target}

--- a/man/drake_build.Rd
+++ b/man/drake_build.Rd
@@ -5,8 +5,8 @@
 \title{Build/process a single target or import.}
 \usage{
 drake_build(target, config = drake::read_drake_config(envir = envir, jobs
-  = jobs), meta = NULL, character_only = FALSE,
-  envir = parent.frame(), jobs = 1, replace = FALSE)
+  = jobs), meta = NULL, character_only = FALSE, envir = NULL,
+  jobs = 1, replace = FALSE)
 }
 \arguments{
 \item{target}{name of the target}

--- a/man/drake_debug.Rd
+++ b/man/drake_debug.Rd
@@ -4,9 +4,9 @@
 \alias{drake_debug}
 \title{Run a single target's command in debug mode.}
 \usage{
-drake_debug(target = NULL, config = drake::read_drake_config(envir =
-  envir, jobs = jobs), character_only = FALSE, envir = parent.frame(),
-  jobs = 1, replace = FALSE, verbose = TRUE)
+drake_debug(target = NULL, config = NULL, character_only = FALSE,
+  envir = parent.frame(), jobs = 1, replace = FALSE,
+  verbose = TRUE)
 }
 \arguments{
 \item{target}{name of the target}

--- a/man/drake_future_task.Rd
+++ b/man/drake_future_task.Rd
@@ -14,7 +14,7 @@ drake_future_task(target, meta, config, protect)
 \item{config}{\code{\link[=drake_config]{drake_config()}} list}
 
 \item{protect}{Names of targets that still need their
-dependencies available in \code{config$envir}.}
+dependencies available in memory.}
 }
 \value{
 Either the target value or a list of build results.

--- a/tests/testthat/test-envir.R
+++ b/tests/testthat/test-envir.R
@@ -56,17 +56,17 @@ test_with_dir("manage_memory in full build", {
 
   # Check that the right targets are loaded and the right targets
   # are discarded
-  remove(list = ls(config$envir), envir = config$envir)
-  expect_equal(ls(config$envir), character(0))
+  remove(list = ls(config$eval), envir = config$eval)
+  expect_equal(ls(config$eval), character(0))
   manage_memory(datasets$target, config)
-  expect_equal(ls(config$envir), character(0))
+  expect_equal(ls(config$eval), character(0))
   manage_memory(analyses$target, config)
-  expect_equal(ls(config$envir), c("x", "y", "z"))
+  expect_equal(ls(config$eval), c("x", "y", "z"))
   manage_memory("waitforme", config)
 
   # keep y around for waitformetoo
   expect_equal(
-    ls(config$envir),
+    ls(config$eval),
     c("a_x", "c_y", "s_b_x", "t_a_z", "y")
   )
 })

--- a/tests/testthat/test-lazy-load.R
+++ b/tests/testthat/test-lazy-load.R
@@ -39,8 +39,9 @@ test_with_dir("lazy loading is actually lazy", {
   eagerly_loaded <- "combined"
   config <- dbug()
   unload_these <- c(lazily_loaded, eagerly_loaded)
-  unload_these <- intersect(unload_these, ls(envir = config$envir))
-  remove(list = unload_these, envir = config$envir)
+  unload_these <- intersect(unload_these, ls(envir = config$eval))
+  remove(list = unload_these, envir = config$eval)
+  eval <- config$eval
   config <- drake_config(
     lazy_load = TRUE,
     plan = config$plan,
@@ -49,9 +50,10 @@ test_with_dir("lazy loading is actually lazy", {
     verbose = FALSE,
     session_info = FALSE
   )
+  config$eval <- eval
   config$schedule <- config$graph
   run_loop(config)
-  loaded <- ls(envir = config$envir)
+  loaded <- ls(envir = config$eval)
   expect_true(all(lazily_loaded %in% loaded))
   expect_false(any(eagerly_loaded %in% loaded))
 })

--- a/tests/testthat/test-other-features.R
+++ b/tests/testthat/test-other-features.R
@@ -84,7 +84,7 @@ test_with_dir("drake_build works as expected", {
   o <- drake_build(b, config = con, replace = TRUE)
   expect_equal(con$eval$a, 1)
   expect_equal(o, 1)
-  
+
   # `replace` in loadd()
   e$b <- 1
   expect_equal(e$b, 1)

--- a/tests/testthat/test-other-features.R
+++ b/tests/testthat/test-other-features.R
@@ -61,29 +61,30 @@ test_with_dir("drake_build works as expected", {
 
   # can run before any make()
   o <- drake_build(
-    target = "a", character_only = TRUE, config = con, envir = e)
+    target = "a", character_only = TRUE, config = con)
   x <- cached()
   expect_equal(x, "a")
   o <- make(pl, envir = e)
   expect_equal(justbuilt(o), "b")
 
   # Can run without config
-  o <- drake_build(b, envir = e)
+  o <- drake_build(b)
   expect_equal(o, readd(b))
 
   # Replacing deps in environment
-  expect_equal(e$a, 1)
-  e$a <- 2
-  o <- drake_build(b, envir = e)
-  expect_equal(e$a, 2)
+  con$eval$a <- 2
+  o <- drake_build(b, config = con)
+  expect_equal(o, 2)
+  expect_equal(con$eval$a, 2)
   expect_equal(readd(a), 1)
-  o <- drake_build(b, envir = e, replace = FALSE)
-  expect_equal(e$a, 2)
+  o <- drake_build(b, config = con, replace = FALSE)
+  expect_equal(con$eval$a, 2)
   expect_equal(readd(a), 1)
-  e$a <- 3
-  o <- drake_build(b, envir = e, replace = TRUE)
-  expect_equal(e$a, 1)
-
+  con$eval$a <- 3
+  o <- drake_build(b, config = con, replace = TRUE)
+  expect_equal(con$eval$a, 1)
+  expect_equal(o, 1)
+  
   # `replace` in loadd()
   e$b <- 1
   expect_equal(e$b, 1)


### PR DESCRIPTION
# Summary

Define a separate `config$eval <- new.env(parent = config$envir)` for loading built targets keeping them in memory. That way, we avoid modifying the user's environment, `config$envir`. It is a step closer towards purity.

# Related GitHub issues and pull requests

- Ref: #619 (not fixed yet), #envir

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
