### PR TITLE
Set lock_envir to TRUE by default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# Version 7.0.0
+
+## Breaking changes
+
+- Set the default value of `lock_envir` to `TRUE` in `make()` and `drake_config()`. So `make()` will automatically quit in error if the act of building a target tries to change upstream dependencies.
+
+
 # Version 6.2.1.9000
 
 ## Bug fixes

--- a/R/config.R
+++ b/R/config.R
@@ -494,7 +494,7 @@ drake_config <- function(
   hasty_build = drake::default_hasty_build,
   memory_strategy = c("speed", "memory", "lookahead"),
   layout = NULL,
-  lock_envir = FALSE
+  lock_envir = TRUE
 ) {
   force(envir)
   unlink(console_log_file)

--- a/R/make.R
+++ b/R/make.R
@@ -120,7 +120,7 @@ make <- function(
   hasty_build = drake::default_hasty_build,
   memory_strategy = c("speed", "memory", "lookahead"),
   layout = NULL,
-  lock_envir = FALSE
+  lock_envir = TRUE
 ) {
   force(envir)
   if (!is.null(return_config)) {

--- a/man/drake_config.Rd
+++ b/man/drake_config.Rd
@@ -26,7 +26,7 @@ drake_config(plan = drake::read_drake_plan(), targets = NULL,
   template = list(), sleep = function(i) 0.01,
   hasty_build = drake::default_hasty_build,
   memory_strategy = c("speed", "memory", "lookahead"), layout = NULL,
-  lock_envir = FALSE)
+  lock_envir = TRUE)
 }
 \arguments{
 \item{plan}{workflow plan data frame.

--- a/man/make.Rd
+++ b/man/make.Rd
@@ -25,7 +25,7 @@ make(plan = drake::read_drake_plan(), targets = NULL,
   template = list(), sleep = function(i) 0.01,
   hasty_build = drake::default_hasty_build,
   memory_strategy = c("speed", "memory", "lookahead"), layout = NULL,
-  lock_envir = FALSE)
+  lock_envir = TRUE)
 }
 \arguments{
 \item{plan}{workflow plan data frame.


### PR DESCRIPTION
cc @krlmlr, @pat-s, @rkrug

## Work up to this point

If a user implements impure commands/functions as in https://github.com/ropensci/drake/issues/615#issuecomment-447585359, the act of building a target threatens to change upstream dependencies. To solve this problem, I implemented a `lock_envir` argument to `make()` and `drake_config()`. If set to `TRUE`, `drake` locks the user's environment and all its non-hidden bindings to prevent imported functions etc. from being modified.

Also, `drake` itself no longer inserts built targets into the user's environment. Instead, it uses a separate `config$eval <- new.env(parent = config$envir)`.

## This PR

I believe `make(lock_envir = TRUE)` is super important for reproducibility. However, it is a disruptive change, and existing impure projects may error out. That is why I think `drake` version 7.0.0 will be a great time to merge this PR to set the `lock_envir` default value to `TRUE`.

# Summary

Please explain the context and purpose of your contribution and list the changes you made to the code base or documentation.

# Related GitHub issues and pull requests

- Ref: #619, #269

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [ ] I think this pull request is ready to merge.
