### PR TITLE
Add space after the folder path

### DIFF
--- a/R/cache.R
+++ b/R/cache.R
@@ -170,7 +170,7 @@ drake_try_fetch_rds <- function(path) {
     "Something is wrong with the file system of the cache. ",
     "If you downloaded it from an online repository, are you sure ",
     "all the files were downloaded correctly? ",
-    "If all else fails, remove the folder at ", path, "and try again.",
+    "If all else fails, remove the folder at ", path, " and try again.",
     call. = FALSE
   )
 }


### PR DESCRIPTION
# Summary

Just fixing a typo in `R/cache.R`

<details>

Before:
Path and explanatory text are connected.

```r
make(plan)
Error: drake failed to get the storr::storr_rds() cache at /Users/rstudio/drake_demo/.drake. Something is wrong with the file system of the cache. If you downloaded it from an online repository, are you sure all the files were downloaded correctly? If all else fails, remove the folder at /Users/rstudio/drake_demo/.drakeand try again.
```

After: 
Added space after the path.

```r
make(plan)
Error: drake failed to get the storr::storr_rds() cache at /Users/rstudio/drake_demo/.drake. Something is wrong with the file system of the cache. If you downloaded it from an online repository, are you sure all the files were downloaded correctly? If all else fails, remove the folder at /Users/rstudio/drake_demo/.drake and try again.
```

</details>

# Related GitHub issues and pull requests

NONE.

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [ ] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [ ] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.