### PR TITLE
Memoize config$cache$get_hash() on up-to-date targets

### DIFF
--- a/R/api-make.R
+++ b/R/api-make.R
@@ -141,15 +141,14 @@ make <- function(
     )
   }
   initialize_session(config = config)
-  config$ht_hash <- ht_new()
+  config$ht_hash <- ht_new() # Memoize getting hashes from the cache.
+  on.exit(ht_clear(config$ht_hash)) # Needs to be empty afterwards.
   if (!config$skip_imports) {
     process_imports(config)
   }
   if (!config$skip_targets) {
     process_targets(config)
   }
-  ht_clear(config$ht_hash)
-  config$ht_hash <- NULL
   conclude_session(config)
   invisible()
 }

--- a/R/api-make.R
+++ b/R/api-make.R
@@ -141,12 +141,15 @@ make <- function(
     )
   }
   initialize_session(config = config)
+  config$ht_hash <- ht_new()
   if (!config$skip_imports) {
     process_imports(config)
   }
   if (!config$skip_targets) {
     process_targets(config)
   }
+  ht_clear(config$ht_hash)
+  config$ht_hash <- NULL
   conclude_session(config)
   invisible()
 }

--- a/R/api-outdated.R
+++ b/R/api-outdated.R
@@ -1,4 +1,6 @@
 first_outdated <- function(config) {
+  config$ht_hash <- ht_new() # Memoize getting hashes from the cache.
+  on.exit(ht_clear(config$ht_hash)) # Needs to be empty afterwards.
   schedule <- config$schedule
   out <- character(0)
   old_leaves <- NULL

--- a/R/exec-meta.R
+++ b/R/exec-meta.R
@@ -97,10 +97,10 @@ dependency_hash <- function(target, config) {
   deps <- as.character(deps)
   deps <- unique(deps)
   deps <- sort(deps)
-  out <- vapply(
-    X = deps,
-    FUN = self_hash,
-    FUN.VALUE = character(1),
+  out <- ht_memo(
+    ht = config$ht_hash,
+    x = deps,
+    fun = self_hash,
     config = config
   )
   out <- paste(out, collapse = "")

--- a/R/exec-meta.R
+++ b/R/exec-meta.R
@@ -129,10 +129,10 @@ input_file_hash <- function(
   if (!length(files)) {
     return("")
   }
-  out <- vapply(
-    X = files,
-    FUN = file_hash,
-    FUN.VALUE = character(1),
+  out <- ht_memo(
+    ht = config$ht_hash,
+    x = files,
+    fun = file_hash,
     config = config,
     size_cutoff = size_cutoff
   )

--- a/R/exec-session.R
+++ b/R/exec-session.R
@@ -77,7 +77,7 @@ conclude_session <- function(config) {
     cache = config$cache,
     jobs = config$jobs
   )
-  remove(list = ls(config$eval, all.names = TRUE), envir = config$eval)
+  remove(list = names(config$eval), envir = config$eval)
   console_edge_cases(config)
   invisible()
 }

--- a/R/exec-session.R
+++ b/R/exec-session.R
@@ -54,20 +54,6 @@ drake_set_session_info <- function(
   invisible()
 }
 
-mark_envir <- function(envir) {
-  assign(x = drake_envir_marker, value = TRUE, envir = envir)
-}
-
-conclude_session <- function(config) {
-  drake_cache_log_file(
-    file = config$cache_log_file,
-    cache = config$cache,
-    jobs = config$jobs
-  )
-  remove(list = ls(config$eval, all.names = TRUE), envir = config$eval)
-  console_edge_cases(config)
-}
-
 initialize_session <- function(config) {
   runtime_checks(config = config)
   config$cache$set(key = "seed", value = config$seed, namespace = "session")
@@ -82,4 +68,20 @@ initialize_session <- function(config) {
   }
   drake_set_session_info(cache = config$cache, full = config$session_info)
   do_prework(config = config, verbose_packages = config$verbose)
+  invisible()
+}
+
+conclude_session <- function(config) {
+  drake_cache_log_file(
+    file = config$cache_log_file,
+    cache = config$cache,
+    jobs = config$jobs
+  )
+  remove(list = ls(config$eval, all.names = TRUE), envir = config$eval)
+  console_edge_cases(config)
+  invisible()
+}
+
+mark_envir <- function(envir) {
+  assign(x = drake_envir_marker, value = TRUE, envir = envir)
 }

--- a/R/utils-hashtable.R
+++ b/R/utils-hashtable.R
@@ -36,6 +36,10 @@ ht_list <- function(ht) {
   names(ht)
 }
 
+ht_clear <- function(ht) {
+  rm(list = names(ht), envir = ht)
+}
+
 ht_clone <- function(ht) {
   list2env(as.list(ht), hash = TRUE, parent = emptyenv())
 }
@@ -57,6 +61,9 @@ ht_merge <- function(x, y) {
 
 # hash-table-based memoization for characters
 ht_memo <- function(ht, x, fun, ...) {
+  if (is.null(ht)) {
+    return(lapply(X = x, FUN = fun, ...))
+  }
   vapply(
     X = x,
     FUN = ht_memo_single,

--- a/README.md
+++ b/README.md
@@ -163,16 +163,6 @@ So far, we have just been setting the stage. Use `make()` to do the real work. T
 
 ``` r
 make(plan)
-#> Warning: Running make() in a subdirectory of your project. 
-#> This could cause problems if your file_in()/file_out()/knitr_in() files are relative paths.
-#> Please either
-#>   (1) run make() from your drake project root, or
-#>   (2) create a cache in your working directory with new_cache('path_name'), or
-#>   (3) supply a cache of your own (e.g. make(cache = your_cache))
-#>       whose folder name is not '.drake'.
-#>   running make() from: /home/landau/projects/drake
-#>   drake project root:  /home/landau
-#>   cache directory:     /home/landau/.drake
 #> target raw_data
 #> target data
 #> target fit
@@ -227,16 +217,6 @@ The next `make()` just builds `hist` and `report.html`. No point in wasting time
 
 ``` r
 make(plan)
-#> Warning: Running make() in a subdirectory of your project. 
-#> This could cause problems if your file_in()/file_out()/knitr_in() files are relative paths.
-#> Please either
-#>   (1) run make() from your drake project root, or
-#>   (2) create a cache in your working directory with new_cache('path_name'), or
-#>   (3) supply a cache of your own (e.g. make(cache = your_cache))
-#>       whose folder name is not '.drake'.
-#>   running make() from: /home/landau/projects/drake
-#>   drake project root:  /home/landau
-#>   cache directory:     /home/landau/.drake
 #> target hist
 #> target report
 ```
@@ -260,16 +240,6 @@ Suppose you are reviewing someone else's data analysis project for reproducibili
 
 ``` r
 make(plan)
-#> Warning: Running make() in a subdirectory of your project. 
-#> This could cause problems if your file_in()/file_out()/knitr_in() files are relative paths.
-#> Please either
-#>   (1) run make() from your drake project root, or
-#>   (2) create a cache in your working directory with new_cache('path_name'), or
-#>   (3) supply a cache of your own (e.g. make(cache = your_cache))
-#>       whose folder name is not '.drake'.
-#>   running make() from: /home/landau/projects/drake
-#>   drake project root:  /home/landau
-#>   cache directory:     /home/landau/.drake
 #> All targets are already up to date.
 
 config <- drake_config(plan)
@@ -287,16 +257,6 @@ When it comes time to actually rerun the entire project, you have much more conf
 ``` r
 clean()       # Remove the original author's results.
 make(plan) # Independently re-create the results from the code and input data.
-#> Warning: Running make() in a subdirectory of your project. 
-#> This could cause problems if your file_in()/file_out()/knitr_in() files are relative paths.
-#> Please either
-#>   (1) run make() from your drake project root, or
-#>   (2) create a cache in your working directory with new_cache('path_name'), or
-#>   (3) supply a cache of your own (e.g. make(cache = your_cache))
-#>       whose folder name is not '.drake'.
-#>   running make() from: /home/landau/projects/drake
-#>   drake project root:  /home/landau
-#>   cache directory:     /home/landau/.drake
 #> target raw_data
 #> target data
 #> target fit

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
-
 <center>
 <img src="https://ropensci.github.io/drake/images/infographic.svg" alt="infographic" align="center" style = "border: none; float: center;">
 </center>
-
 <table class="table">
 <thead>
 <tr class="header">
@@ -68,50 +66,36 @@ Development
 </table>
 <br>
 
-# The drake R package <img src="https://ropensci.github.io/drake/images/logo.svg" align="right" alt="logo" width="120" height = "139" style = "border: none; float: right;">
+The drake R package <img src="https://ropensci.github.io/drake/images/logo.svg" align="right" alt="logo" width="120" height = "139" style = "border: none; float: right;">
+==========================================================================================================================================================================
 
-`drake` — or, Data Frames in R for Make — is a general-purpose workflow
-manager for data-driven tasks. It rebuilds intermediate data objects
-when their dependencies change, and it skips work when the results are
-already up to date. Not every runthrough starts from scratch, there is
-native support for parallel and distributed computing, and completed
-workflows have tangible evidence of reproducibility.
+`drake` — or, Data Frames in R for Make — is a general-purpose workflow manager for data-driven tasks. It rebuilds intermediate data objects when their dependencies change, and it skips work when the results are already up to date. Not every runthrough starts from scratch, there is native support for parallel and distributed computing, and completed workflows have tangible evidence of reproducibility.
 
-# 6-minute video
+6-minute video
+==============
 
-Visit the [first page of the
-manual](https://ropenscilabs.github.io/drake-manual/) to watch a short
-introduction.
+Visit the [first page of the manual](https://ropenscilabs.github.io/drake-manual/) to watch a short introduction.
 
 <center>
-
-<a href="https://ropenscilabs.github.io/drake-manual">
-<img src="https://ropensci.github.io/drake/images/video.png" alt="video" align="center" style = "border: none; float: center;">
-</a>
-
+<a href="https://ropenscilabs.github.io/drake-manual"> <img src="https://ropensci.github.io/drake/images/video.png" alt="video" align="center" style = "border: none; float: center;"> </a>
 </center>
-
 <br>
 
-# What gets done stays done.
+What gets done stays done.
+==========================
 
-Too many data science projects follow a [Sisyphean
-loop](https://en.wikipedia.org/wiki/Sisyphus):
+Too many data science projects follow a [Sisyphean loop](https://en.wikipedia.org/wiki/Sisyphus):
 
 1.  Launch the code.
 2.  Wait while it runs.
 3.  Discover an issue.
 4.  Rerun from scratch.
 
-Ordinarily, it is hard to avoid rerunning the code from scratch.
-<br>
+Ordinarily, it is hard to avoid rerunning the code from scratch. <br>
 
 <center>
-
 <img src="https://ropensci.github.io/drake/images/tweet.png" alt="tweet" align="center" style = "border: none; float: center;">
-
 </center>
-
 <br>
 
 But with `drake`, you can automatically
@@ -119,7 +103,8 @@ But with `drake`, you can automatically
 1.  Launch the parts that changed since last time.
 2.  Skip the rest.
 
-# How it works
+How it works
+============
 
 To set up a project, load your packages,
 
@@ -164,8 +149,6 @@ plan <- drake_plan(
   )
 )
 plan
-#> Warning in seq.default(along = x): partial argument match of 'along' to
-#> 'along.with'
 #> # A tibble: 5 x 2
 #>   target   command                                                         
 #>   <chr>    <chr>                                                           
@@ -176,12 +159,20 @@ plan
 #> 5 report   "rmarkdown::render(knitr_in(\"report.Rmd\"), output_file = file…
 ```
 
-So far, we have just been setting the stage. Use `make()` to do the real
-work. Targets are built in the correct order regardless of the row order
-of `plan`.
+So far, we have just been setting the stage. Use `make()` to do the real work. Targets are built in the correct order regardless of the row order of `plan`.
 
 ``` r
 make(plan)
+#> Warning: Running make() in a subdirectory of your project. 
+#> This could cause problems if your file_in()/file_out()/knitr_in() files are relative paths.
+#> Please either
+#>   (1) run make() from your drake project root, or
+#>   (2) create a cache in your working directory with new_cache('path_name'), or
+#>   (3) supply a cache of your own (e.g. make(cache = your_cache))
+#>       whose folder name is not '.drake'.
+#>   running make() from: /home/landau/projects/drake
+#>   drake project root:  /home/landau
+#>   cache directory:     /home/landau/.drake
 #> target raw_data
 #> target data
 #> target fit
@@ -189,8 +180,7 @@ make(plan)
 #> target report
 ```
 
-Except for files like `report.html`, your output is stored in a hidden
-`.drake/` folder. Reading it back is easy.
+Except for files like `report.html`, your output is stored in a hidden `.drake/` folder. Reading it back is easy.
 
 ``` r
 readd(data) # See also loadd().
@@ -205,10 +195,7 @@ readd(data) # See also loadd().
 #> # … with 145 more rows
 ```
 
-You may look back on your work and see room for improvement, but it’s
-all good\! The whole point of `drake` is to help you go back and change
-things quickly and painlessly. For example, we forgot to give our
-histogram a bin width.
+You may look back on your work and see room for improvement, but it's all good! The whole point of `drake` is to help you go back and change things quickly and painlessly. For example, we forgot to give our histogram a bin width.
 
 ``` r
 readd(hist)
@@ -217,7 +204,7 @@ readd(hist)
 
 <img src="https://ropensci.github.io/drake/images/hist1.png" alt="hist1" align="center" style = "border: none; float: center;" width = "500px">
 
-So let’s fix the plotting function.
+So let's fix the plotting function.
 
 ``` r
 create_plot <- function(data) {
@@ -236,11 +223,20 @@ vis_drake_graph(config) # Interactive graph: hover, zoom, drag, etc.
 
 <img src="https://ropensci.github.io/drake/images/graph.png" alt="hist1" align="center" style = "border: none; float: center;" width = "500px">
 
-The next `make()` just builds `hist` and `report.html`. No point in
-wasting time on the data or model.
+The next `make()` just builds `hist` and `report.html`. No point in wasting time on the data or model.
 
 ``` r
 make(plan)
+#> Warning: Running make() in a subdirectory of your project. 
+#> This could cause problems if your file_in()/file_out()/knitr_in() files are relative paths.
+#> Please either
+#>   (1) run make() from your drake project root, or
+#>   (2) create a cache in your working directory with new_cache('path_name'), or
+#>   (3) supply a cache of your own (e.g. make(cache = your_cache))
+#>       whose folder name is not '.drake'.
+#>   running make() from: /home/landau/projects/drake
+#>   drake project root:  /home/landau
+#>   cache directory:     /home/landau/.drake
 #> target hist
 #> target report
 ```
@@ -252,32 +248,28 @@ hist
 
 <img src="https://ropensci.github.io/drake/images/hist2.png" alt="hist1" align="center" style = "border: none; float: center;" width = "500px">
 
-# Reproducibility with confidence
+Reproducibility with confidence
+===============================
 
-The R community emphasizes reproducibility. Traditional themes include
-[scientific
-replicability](https://en.wikipedia.org/wiki/Replication_crisis),
-literate programming with [knitr](https://yihui.name/knitr/), and
-version control with
-[git](https://git-scm.com/book/en/v2/Getting-Started-About-Version-Control).
-But internal consistency is important too. Reproducibility carries the
-promise that your output matches the code and data you say you used.
-With the exception of [non-default
-triggers](https://ropenscilabs.github.io/drake-manual/triggers.html) and
-[hasty
-mode](https://ropenscilabs.github.io/drake-manual/hpc.html#hasty-mode),
-`drake` strives to keep this promise.
+The R community emphasizes reproducibility. Traditional themes include [scientific replicability](https://en.wikipedia.org/wiki/Replication_crisis), literate programming with [knitr](https://yihui.name/knitr/), and version control with [git](https://git-scm.com/book/en/v2/Getting-Started-About-Version-Control). But internal consistency is important too. Reproducibility carries the promise that your output matches the code and data you say you used. With the exception of [non-default triggers](https://ropenscilabs.github.io/drake-manual/triggers.html) and [hasty mode](https://ropenscilabs.github.io/drake-manual/hpc.html#hasty-mode), `drake` strives to keep this promise.
 
-## Evidence
+Evidence
+--------
 
-Suppose you are reviewing someone else’s data analysis project for
-reproducibility. You scrutinize it carefully, checking that the datasets
-are available and the documentation is thorough. But could you re-create
-the results without the help of the original author? With `drake`, it is
-quick and easy to find out.
+Suppose you are reviewing someone else's data analysis project for reproducibility. You scrutinize it carefully, checking that the datasets are available and the documentation is thorough. But could you re-create the results without the help of the original author? With `drake`, it is quick and easy to find out.
 
 ``` r
 make(plan)
+#> Warning: Running make() in a subdirectory of your project. 
+#> This could cause problems if your file_in()/file_out()/knitr_in() files are relative paths.
+#> Please either
+#>   (1) run make() from your drake project root, or
+#>   (2) create a cache in your working directory with new_cache('path_name'), or
+#>   (3) supply a cache of your own (e.g. make(cache = your_cache))
+#>       whose folder name is not '.drake'.
+#>   running make() from: /home/landau/projects/drake
+#>   drake project root:  /home/landau
+#>   cache directory:     /home/landau/.drake
 #> All targets are already up to date.
 
 config <- drake_config(plan)
@@ -285,22 +277,26 @@ outdated(config)
 #> character(0)
 ```
 
-With everything already up to date, you have **tangible evidence** of
-reproducibility. Even though you did not re-create the results, you know
-the results are re-creatable. They **faithfully show** what the code is
-producing. Given the right [package
-environment](https://rstudio.github.io/packrat/) and [system
-configuration](https://stat.ethz.ch/R-manual/R-devel/library/utils/html/sessionInfo.html),
-you have everything you need to reproduce all the output by yourself.
+With everything already up to date, you have **tangible evidence** of reproducibility. Even though you did not re-create the results, you know the results are re-creatable. They **faithfully show** what the code is producing. Given the right [package environment](https://rstudio.github.io/packrat/) and [system configuration](https://stat.ethz.ch/R-manual/R-devel/library/utils/html/sessionInfo.html), you have everything you need to reproduce all the output by yourself.
 
-## Ease
+Ease
+----
 
-When it comes time to actually rerun the entire project, you have much
-more confidence. Starting over from scratch is trivially easy.
+When it comes time to actually rerun the entire project, you have much more confidence. Starting over from scratch is trivially easy.
 
 ``` r
 clean()       # Remove the original author's results.
 make(plan) # Independently re-create the results from the code and input data.
+#> Warning: Running make() in a subdirectory of your project. 
+#> This could cause problems if your file_in()/file_out()/knitr_in() files are relative paths.
+#> Please either
+#>   (1) run make() from your drake project root, or
+#>   (2) create a cache in your working directory with new_cache('path_name'), or
+#>   (3) supply a cache of your own (e.g. make(cache = your_cache))
+#>       whose folder name is not '.drake'.
+#>   running make() from: /home/landau/projects/drake
+#>   drake project root:  /home/landau
+#>   cache directory:     /home/landau/.drake
 #> target raw_data
 #> target data
 #> target fit
@@ -308,46 +304,24 @@ make(plan) # Independently re-create the results from the code and input data.
 #> target report
 ```
 
-## Independent replication
+Independent replication
+-----------------------
 
-With even more evidence and confidence, you can invest the time to
-independently replicate the original code base if necessary. Up until
-this point, you relied on basic `drake` functions such as `make()`, so
-you may not have needed to peek at any substantive author-defined code
-in advance. In that case, you can stay usefully ignorant as you
-reimplement the original author’s methodology. In other words, `drake`
-could potentially improve the integrity of independent replication.
+With even more evidence and confidence, you can invest the time to independently replicate the original code base if necessary. Up until this point, you relied on basic `drake` functions such as `make()`, so you may not have needed to peek at any substantive author-defined code in advance. In that case, you can stay usefully ignorant as you reimplement the original author's methodology. In other words, `drake` could potentially improve the integrity of independent replication.
 
-## Readability and transparency
+Readability and transparency
+----------------------------
 
-Ideally, independent observers should be able to read your code and
-understand it. `drake` helps in several ways.
+Ideally, independent observers should be able to read your code and understand it. `drake` helps in several ways.
 
-  - The [workflow plan data
-    frame](https://ropensci.github.io/drake/reference/drake_plan.html)
-    explicitly outlines the steps of the analysis, and
-    [`vis_drake_graph()`](https://ropensci.github.io/drake/reference/vis_drake_graph.html)
-    visualizes how those steps depend on each other.
-  - `drake` takes care of the parallel scheduling and high-performance
-    computing (HPC) for you. That means the HPC code is no longer
-    tangled up with the code that actually expresses your ideas.
-  - You can [generate large collections of
-    targets](https://ropenscilabs.github.io/drake-manual/mtcars.html#generate-the-workflow-plan)
-    without necessarily changing your code base of imported functions,
-    another nice separation between the concepts and the execution of
-    your workflow
+-   The [workflow plan data frame](https://ropensci.github.io/drake/reference/drake_plan.html) explicitly outlines the steps of the analysis, and [`vis_drake_graph()`](https://ropensci.github.io/drake/reference/vis_drake_graph.html) visualizes how those steps depend on each other.
+-   `drake` takes care of the parallel scheduling and high-performance computing (HPC) for you. That means the HPC code is no longer tangled up with the code that actually expresses your ideas.
+-   You can [generate large collections of targets](https://ropenscilabs.github.io/drake-manual/mtcars.html#generate-the-workflow-plan) without necessarily changing your code base of imported functions, another nice separation between the concepts and the execution of your workflow
 
-# Aggressively scale up.
+Aggressively scale up.
+======================
 
-Not every project can complete in a single R session on your laptop.
-Some projects need more speed or computing power. Some require a few
-local processor cores, and some need large high-performance computing
-systems. But parallel computing is hard. Your tables and figures depend
-on your analysis results, and your analyses depend on your datasets, so
-some tasks must finish before others even begin. `drake` knows what to
-do. Parallelism is implicit and automatic. See the [high-performance
-computing guide](https://ropenscilabs.github.io/drake-manual/hpc.html)
-for all the details.
+Not every project can complete in a single R session on your laptop. Some projects need more speed or computing power. Some require a few local processor cores, and some need large high-performance computing systems. But parallel computing is hard. Your tables and figures depend on your analysis results, and your analyses depend on your datasets, so some tasks must finish before others even begin. `drake` knows what to do. Parallelism is implicit and automatic. See the [high-performance computing guide](https://ropenscilabs.github.io/drake-manual/hpc.html) for all the details.
 
 ``` r
 # Use the spare cores on your local machine.
@@ -360,12 +334,10 @@ future::plan(batchtools_slurm, template = "batchtools.slurm.tmpl", workers = 100
 make(plan, parallelism = "future_lapply")
 ```
 
-# Installation
+Installation
+============
 
-You can choose among different versions of `drake`. The CRAN release
-often lags behind the [online
-manual](https://ropenscilabs.github.io/drake-manual/) but may have fewer
-bugs.
+You can choose among different versions of `drake`. The CRAN release often lags behind the [online manual](https://ropenscilabs.github.io/drake-manual/) but may have fewer bugs.
 
 ``` r
 # Install the latest stable release from CRAN.
@@ -379,387 +351,192 @@ install_github("ropensci/drake")
 
 A few technical details:
 
-  - You must properly install `drake` using `install.packages()`,
-    `devtools::install_github()`, or similar. It is not enough to use
-    `devtools::load_all()`, particularly for the parallel computing
-    functionality, in which multiple R sessions initialize and then try
-    to `require(drake)`.
-  - For `make(parallelism = "Makefile")`, Windows users may need to
-    download and install
-    [`Rtools`](https://cran.r-project.org/bin/windows/Rtools/).
-  - To use `make(parallelism = "future")` or `make(parallelism =
-    "future_lapply")` to deploy your work to a computing cluster (see
-    the [high-performance computing
-    guide](https://ropenscilabs.github.io/drake-manual/hpc.html)), you
-    will need the
-    [`future.batchtools`](https://github.com/HenrikBengtsson/future.batchtools)
-    package.
+-   You must properly install `drake` using `install.packages()`, `devtools::install_github()`, or similar. It is not enough to use `devtools::load_all()`, particularly for the parallel computing functionality, in which multiple R sessions initialize and then try to `require(drake)`.
+-   For `make(parallelism = "Makefile")`, Windows users may need to download and install [`Rtools`](https://cran.r-project.org/bin/windows/Rtools/).
+-   To use `make(parallelism = "future")` or `make(parallelism = "future_lapply")` to deploy your work to a computing cluster (see the [high-performance computing guide](https://ropenscilabs.github.io/drake-manual/hpc.html)), you will need the [`future.batchtools`](https://github.com/HenrikBengtsson/future.batchtools) package.
 
-# Documentation
+Documentation
+=============
 
 The main resources to learn `drake` are
 
-1.  The [user manual](https://ropenscilabs.github.io/drake-manual/),
-    which contains a friendly introduction and several long-form
-    tutorials.
-2.  The [documentation website](https://ropensci.github.io/drake/),
-    which serves as a quicker reference.
-3.  [Kirill Müller](https://github.com/krlmlr)’s [`drake` workshop from
-    March 5, 2018](https://github.com/krlmlr/drake-sib-zurich).
+1.  The [user manual](https://ropenscilabs.github.io/drake-manual/), which contains a friendly introduction and several long-form tutorials.
+2.  The [documentation website](https://ropensci.github.io/drake/), which serves as a quicker reference.
+3.  [Kirill Müller](https://github.com/krlmlr)'s [`drake` workshop from March 5, 2018](https://github.com/krlmlr/drake-sib-zurich).
 
-## Cheat sheet
+Cheat sheet
+-----------
 
-Thanks to [Kirill](https://github.com/krlmlr) for preparing a [`drake`
-cheat
-sheet](https://github.com/krlmlr/drake-sib-zurich/blob/master/cheat-sheet.pdf)
-for the [workshop](https://github.com/krlmlr/drake-sib-zurich).
+Thanks to [Kirill](https://github.com/krlmlr) for preparing a [`drake` cheat sheet](https://github.com/krlmlr/drake-sib-zurich/blob/master/cheat-sheet.pdf) for the [workshop](https://github.com/krlmlr/drake-sib-zurich).
 
-## Frequently asked questions
+Frequently asked questions
+--------------------------
 
-The [FAQ page](https://ropenscilabs.github.io/drake-manual/faq.html) is
-an index of links to [appropriately-labeled issues on
-GitHub](https://github.com/ropensci/drake/issues?q=is%3Aissue+is%3Aopen+label%3A%22frequently+asked+question%22).
-To contribute, please [submit a new
-issue](https://github.com/ropensci/drake/issues/new) and ask that it be
-labeled as a frequently asked question.
+The [FAQ page](https://ropenscilabs.github.io/drake-manual/faq.html) is an index of links to [appropriately-labeled issues on GitHub](https://github.com/ropensci/drake/issues?q=is%3Aissue+is%3Aopen+label%3A%22frequently+asked+question%22). To contribute, please [submit a new issue](https://github.com/ropensci/drake/issues/new) and ask that it be labeled as a frequently asked question.
 
-## Function reference
+Function reference
+------------------
 
-The [reference
-section](https://ropensci.github.io/drake/reference/index.html) lists
-all the available functions. Here are the most important ones.
+The [reference section](https://ropensci.github.io/drake/reference/index.html) lists all the available functions. Here are the most important ones.
 
-  - `drake_plan()`: create a workflow data frame (like `my_plan`).
-  - `make()`: build your project.
-  - `loadd()`: load one or more built targets into your R session.
-  - `readd()`: read and return a built target.
-  - `drake_config()`: create a master configuration list for other
-    user-side functions.
-  - `vis_drake_graph()`: show an interactive visual network
-    representation of your workflow.
-  - `outdated()`: see which targets will be built in the next `make()`.
-  - `deps()`: check the dependencies of a command or function.
-  - `failed()`: list the targets that failed to build in the last
-    `make()`.
-  - `diagnose()`: return the full context of a build, including errors,
-    warnings, and messages.
+-   `drake_plan()`: create a workflow data frame (like `my_plan`).
+-   `make()`: build your project.
+-   `loadd()`: load one or more built targets into your R session.
+-   `readd()`: read and return a built target.
+-   `drake_config()`: create a master configuration list for other user-side functions.
+-   `vis_drake_graph()`: show an interactive visual network representation of your workflow.
+-   `outdated()`: see which targets will be built in the next `make()`.
+-   `deps()`: check the dependencies of a command or function.
+-   `failed()`: list the targets that failed to build in the last `make()`.
+-   `diagnose()`: return the full context of a build, including errors, warnings, and messages.
 
-## Tutorials
+Tutorials
+---------
 
-Thanks to [Kirill](https://github.com/krlmlr) for constructing two
-interactive [`learnr`](https://rstudio.github.io/learnr/) tutorials:
-[one supporting `drake`
-itself](https://krlmlr.shinyapps.io/cooking-drake-tutorial/), and a
-[prerequisite
-walkthrough](https://krlmlr.shinyapps.io/cooking-tutorial/) of the
-[`cooking` package](https://github.com/krlmlr/cooking).
+Thanks to [Kirill](https://github.com/krlmlr) for constructing two interactive [`learnr`](https://rstudio.github.io/learnr/) tutorials: [one supporting `drake` itself](https://krlmlr.shinyapps.io/cooking-drake-tutorial/), and a [prerequisite walkthrough](https://krlmlr.shinyapps.io/cooking-tutorial/) of the [`cooking` package](https://github.com/krlmlr/cooking).
 
-## Examples
+Examples
+--------
 
-There are multiple `drake`-powered example projects [available
-here](https://github.com/wlandau/drake-examples), ranging from
-beginner-friendly stubs to demonstrations of high-performance computing.
-You can generate the files for a project with `drake_example()` (e.g.
-`drake_example("gsp")`), and you can list the available projects with
-`drake_examples()`. You can contribute your own example project with a
-[fork and pull
-request](https://github.com/wlandau/drake-examples/pulls).
+There are multiple `drake`-powered example projects [available here](https://github.com/wlandau/drake-examples), ranging from beginner-friendly stubs to demonstrations of high-performance computing. You can generate the files for a project with `drake_example()` (e.g. `drake_example("gsp")`), and you can list the available projects with `drake_examples()`. You can contribute your own example project with a [fork and pull request](https://github.com/wlandau/drake-examples/pulls).
 
-## Presentations
+Presentations
+-------------
 
-  - [Kirill’s `drake` pitch](https://krlmlr.github.io/drake-pitch)
-  - [`drake` + cooking with
-    Kirill](https://krlmlr.github.io/slides/drake-sib-zurich).
-  - [`drake` + cooking
-    exercises](https://krlmlr.github.io/slides/drake-sib-zurich/cooking.html).
-  - [Christine Stawitz](https://github.com/cstawitz)’s [R-Ladies Seattle
-    talk on
-    June 25, 2018](https://github.com/cstawitz/RLadies_Sea_drake).
-  - [Sina Rüeger](https://github.com/sinarueeger)’s [Geneva R Users
-    Group presentation on
-    October 4, 2018](https://sinarueeger.github.io/20181004-geneve-rug)
-    ([example code](https://github.com/sinarueeger/workflow-example)).
-    The talk broadly focused on tidy workflows and diversity in the R
-    community.
+-   [Kirill's `drake` pitch](https://krlmlr.github.io/drake-pitch)
+-   [`drake` + cooking with Kirill](https://krlmlr.github.io/slides/drake-sib-zurich).
+-   [`drake` + cooking exercises](https://krlmlr.github.io/slides/drake-sib-zurich/cooking.html).
+-   [Christine Stawitz](https://github.com/cstawitz)'s [R-Ladies Seattle talk on June 25, 2018](https://github.com/cstawitz/RLadies_Sea_drake).
+-   [Sina Rüeger](https://github.com/sinarueeger)'s [Geneva R Users Group presentation on October 4, 2018](https://sinarueeger.github.io/20181004-geneve-rug) ([example code](https://github.com/sinarueeger/workflow-example)). The talk broadly focused on tidy workflows and diversity in the R community.
 
-## Real example projects
+Real example projects
+---------------------
 
-Here are some real-world applications of `drake` in the
-    wild.
+Here are some real-world applications of `drake` in the wild.
 
-  - [efcaguab/demografia-del-voto](https://github.com/efcaguab/demografia-del-voto)
-  - [efcaguab/great-white-shark-nsw](https://github.com/efcaguab/great-white-shark-nsw)
-  - [IndianaCHE/Detailed-SSP-Reports](https://github.com/IndianaCHE/Detailed-SSP-Reports)
-  - [tiernanmartin/home-and-hope](https://github.com/tiernanmartin/home-and-hope)
+-   [efcaguab/demografia-del-voto](https://github.com/efcaguab/demografia-del-voto)
+-   [efcaguab/great-white-shark-nsw](https://github.com/efcaguab/great-white-shark-nsw)
+-   [IndianaCHE/Detailed-SSP-Reports](https://github.com/IndianaCHE/Detailed-SSP-Reports)
+-   [tiernanmartin/home-and-hope](https://github.com/tiernanmartin/home-and-hope)
 
-If you have a project of your own, we would love to add it. [Click here
-to edit the `README.Rmd`
-file](https://github.com/ropensci/drake/edit/master/README.Rmd).
+If you have a project of your own, we would love to add it. [Click here to edit the `README.Rmd` file](https://github.com/ropensci/drake/edit/master/README.Rmd).
 
-## Context and history
+Context and history
+-------------------
 
-For context and history, check out [this post on the rOpenSci
-blog](https://ropensci.org/blog/2018/02/06/drake/) and [episode 22 of
-the R
-Podcast](https://www.r-podcast.org/episode/022-diving-in-to-drake-with-will-landau/).
+For context and history, check out [this post on the rOpenSci blog](https://ropensci.org/blog/2018/02/06/drake/) and [episode 22 of the R Podcast](https://www.r-podcast.org/episode/022-diving-in-to-drake-with-will-landau/).
 
-# Help and troubleshooting
+Help and troubleshooting
+========================
 
 The following resources document many known issues and challenges.
 
-  - [Frequently-asked
-    questions](https://github.com/ropensci/drake/issues?q=is%3Aissue+is%3Aopen+label%3A%22Frequently+Asked+Question%22).
-  - [Cautionary notes and edge
-    cases](https://ropenscilabs.github.io/drake-manual/caution.html)
-  - [Debugging and testing drake
-    projects](https://ropenscilabs.github.io/drake-manual/debug.html)
-  - [Other known issues](https://github.com/ropensci/drake/issues)
-    (please search both open and closed ones).
+-   [Frequently-asked questions](https://github.com/ropensci/drake/issues?q=is%3Aissue+is%3Aopen+label%3A%22Frequently+Asked+Question%22).
+-   [Cautionary notes and edge cases](https://ropenscilabs.github.io/drake-manual/caution.html)
+-   [Debugging and testing drake projects](https://ropenscilabs.github.io/drake-manual/debug.html)
+-   [Other known issues](https://github.com/ropensci/drake/issues) (please search both open and closed ones).
 
-If you are still having trouble, please submit a [new
-issue](https://github.com/ropensci/drake/issues/new) with a bug report
-or feature request, along with a minimal reproducible example where
-appropriate.
+If you are still having trouble, please submit a [new issue](https://github.com/ropensci/drake/issues/new) with a bug report or feature request, along with a minimal reproducible example where appropriate.
 
-The GitHub issue tracker is mainly intended for bug reports and feature
-requests. While questions about usage etc. are also highly encouraged,
-you may alternatively wish to post to [Stack
-Overflow](https://stackoverflow.com) and use the [`drake-r-package`
-tag](https://stackoverflow.com/tags/drake-r-package).
+The GitHub issue tracker is mainly intended for bug reports and feature requests. While questions about usage etc. are also highly encouraged, you may alternatively wish to post to [Stack Overflow](https://stackoverflow.com) and use the [`drake-r-package` tag](https://stackoverflow.com/tags/drake-r-package).
 
-# Contributing
+Contributing
+============
 
 Development is a community effort, and we encourage participation.
 
-## Code of Conduct
+Code of Conduct
+---------------
 
-The environment for collaboration should be friendly, inclusive,
-respectful, and safe for everyone, so all participants must obey [this
-repository’s code of
-conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md).
+The environment for collaboration should be friendly, inclusive, respectful, and safe for everyone, so all participants must obey [this repository's code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md).
 
-## Issues
+Issues
+------
 
-`drake` thrives on the suggestions, questions, and bug reports you
-submit to the [issue tracker](https://github.com/ropensci/drake/issues).
-Before posting, please search both the open and closed issues to help us
-avoid duplication. Usage questions are welcome, but you may also wish to
-post to [Stack Overflow](https://stackoverflow.com) with the
-[`drake-r-package` tag](https://stackoverflow.com/tags/drake-r-package).
+`drake` thrives on the suggestions, questions, and bug reports you submit to the [issue tracker](https://github.com/ropensci/drake/issues). Before posting, please search both the open and closed issues to help us avoid duplication. Usage questions are welcome, but you may also wish to post to [Stack Overflow](https://stackoverflow.com) with the [`drake-r-package` tag](https://stackoverflow.com/tags/drake-r-package).
 
-## Development
+Development
+-----------
 
-If you would like to work on the code or documentation, please [fork
-this repository](https://help.github.com/articles/fork-a-repo/), make
-the changes in your fork, and then submit a [pull
-request](https://github.com/ropensci/drake/pulls). We will discuss your
-work and then hopefully merge it into the project.
+If you would like to work on the code or documentation, please [fork this repository](https://help.github.com/articles/fork-a-repo/), make the changes in your fork, and then submit a [pull request](https://github.com/ropensci/drake/pulls). We will discuss your work and then hopefully merge it into the project.
 
-# Similar work
+Similar work
+============
 
-## GNU Make
+GNU Make
+--------
 
-The original idea of a time-saving reproducible build system extends
-back at least as far as [GNU Make](https://www.gnu.org/software/make/),
-which still aids the work of [data
-scientists](http://blog.kaggle.com/2012/10/15/make-for-data-scientists/)
-as well as the original user base of complied language programmers. In
-fact, the name “drake” stands for “Data Frames in R for Make”.
-[Make](http://kbroman.org/minimal_make/) is used widely in reproducible
-research. Below are some examples from [Karl Broman’s
-website](http://kbroman.org/minimal_make/).
+The original idea of a time-saving reproducible build system extends back at least as far as [GNU Make](https://www.gnu.org/software/make/), which still aids the work of [data scientists](http://blog.kaggle.com/2012/10/15/make-for-data-scientists/) as well as the original user base of complied language programmers. In fact, the name "drake" stands for "Data Frames in R for Make". [Make](http://kbroman.org/minimal_make/) is used widely in reproducible research. Below are some examples from [Karl Broman's website](http://kbroman.org/minimal_make/).
 
-  - Bostock, Mike (2013). “A map of flowlines from NHDPlus.”
-    <https://github.com/mbostock/us-rivers>. Powered by the Makefile at
-    <https://github.com/mbostock/us-rivers/blob/master/Makefile>.
-  - Broman, Karl W (2012). “Halotype Probabilities in Advanced
-    Intercross Populations.” *G3* 2(2), 199-202.Powered by the
-    `Makefile` at
-    <https://github.com/kbroman/ailProbPaper/blob/master/Makefile>.
-  - Broman, Karl W (2012). “Genotype Probabilities at Intermediate
-    Generations in the Construction of Recombinant Inbred Lines.”
-    \*Genetics 190(2), 403-412. Powered by the Makefile at
-    <https://github.com/kbroman/preCCProbPaper/blob/master/Makefile>.
-  - Broman, Karl W and Kim, Sungjin and Sen, Saunak and Ane, Cecile and
-    Payseur, Bret A (2012). “Mapping Quantitative Trait Loci onto a
-    Phylogenetic Tree.” *Genetics* 192(2), 267-279. Powered by the
-    `Makefile` at
-    <https://github.com/kbroman/phyloQTLpaper/blob/master/Makefile>.
+-   Bostock, Mike (2013). "A map of flowlines from NHDPlus." <https://github.com/mbostock/us-rivers>. Powered by the Makefile at <https://github.com/mbostock/us-rivers/blob/master/Makefile>.
+-   Broman, Karl W (2012). "Halotype Probabilities in Advanced Intercross Populations." *G3* 2(2), 199-202.Powered by the `Makefile` at <https://github.com/kbroman/ailProbPaper/blob/master/Makefile>.
+-   Broman, Karl W (2012). "Genotype Probabilities at Intermediate Generations in the Construction of Recombinant Inbred Lines." \*Genetics 190(2), 403-412. Powered by the Makefile at <https://github.com/kbroman/preCCProbPaper/blob/master/Makefile>.
+-   Broman, Karl W and Kim, Sungjin and Sen, Saunak and Ane, Cecile and Payseur, Bret A (2012). "Mapping Quantitative Trait Loci onto a Phylogenetic Tree." *Genetics* 192(2), 267-279. Powered by the `Makefile` at <https://github.com/kbroman/phyloQTLpaper/blob/master/Makefile>.
 
 There are several reasons for R users to prefer `drake` instead.
 
-  - `drake` already has a
-    [Make](http://kbroman.org/minimal_make/)-powered parallel backend.
-    Just run `make(..., parallelism = "Makefile", jobs = 2)` to enjoy
-    most of the original benefits of
-    [Make](http://kbroman.org/minimal_make/) itself.
-  - Improved scalability. With [Make](http://kbroman.org/minimal_make/),
-    you must write a potentially large and cumbersome
-    [Makefile](https://github.com/kbroman/preCCProbPaper/blob/master/Makefile)
-    by hand. But with `drake`, you can use [wildcard
-    templating](https://ropenscilabs.github.io/drake-manual/mtcars.html#generate-the-workflow-plan)
-    to automatically generate massive collections of targets with
-    minimal code.
-  - Lower overhead for light-weight tasks. For each
-    [Make](http://kbroman.org/minimal_make/) target that uses R, a brand
-    new R session must spawn. For projects with thousands of small
-    targets, that means more time may be spent loading R sessions than
-    doing the actual work. With `make(..., parallelism = "mclapply, jobs
-    = 4")`, `drake` launches 4 persistent workers up front and
-    efficiently processes the targets in R.
-  - Convenient organization of output. With
-    [Make](http://kbroman.org/minimal_make/), the user must save each
-    target as a file. `drake` saves all the results for you
-    automatically in a [storr cache](https://github.com/richfitz/storr)
-    so you do not have to micromanage the results.
+-   `drake` already has a [Make](http://kbroman.org/minimal_make/)-powered parallel backend. Just run `make(..., parallelism = "Makefile", jobs = 2)` to enjoy most of the original benefits of [Make](http://kbroman.org/minimal_make/) itself.
+-   Improved scalability. With [Make](http://kbroman.org/minimal_make/), you must write a potentially large and cumbersome [Makefile](https://github.com/kbroman/preCCProbPaper/blob/master/Makefile) by hand. But with `drake`, you can use [wildcard templating](https://ropenscilabs.github.io/drake-manual/mtcars.html#generate-the-workflow-plan) to automatically generate massive collections of targets with minimal code.
+-   Lower overhead for light-weight tasks. For each [Make](http://kbroman.org/minimal_make/) target that uses R, a brand new R session must spawn. For projects with thousands of small targets, that means more time may be spent loading R sessions than doing the actual work. With `make(..., parallelism = "mclapply, jobs = 4")`, `drake` launches 4 persistent workers up front and efficiently processes the targets in R.
+-   Convenient organization of output. With [Make](http://kbroman.org/minimal_make/), the user must save each target as a file. `drake` saves all the results for you automatically in a [storr cache](https://github.com/richfitz/storr) so you do not have to micromanage the results.
 
-## Remake
+Remake
+------
 
-[drake](https://github.com/ropensci/drake) overlaps with its direct
-predecessor, [remake](https://github.com/richfitz/remake). In fact,
-[drake](https://github.com/ropensci/drake) owes its core ideas to
-[remake](https://github.com/richfitz/remake) and [Rich
-FitzJohn](https://github.com/richfitz/remake).
-[Remake](https://github.com/richfitz/remake)’s development repository
-lists several [real-world
-applications](https://github.com/richfitz/remake/blob/master/README.md#real-world-examples).
-[drake](https://github.com/ropensci/drake) surpasses
-[remake](https://github.com/richfitz/remake) in several important ways,
-including but not limited to the following.
+[drake](https://github.com/ropensci/drake) overlaps with its direct predecessor, [remake](https://github.com/richfitz/remake). In fact, [drake](https://github.com/ropensci/drake) owes its core ideas to [remake](https://github.com/richfitz/remake) and [Rich FitzJohn](https://github.com/richfitz/remake). [Remake](https://github.com/richfitz/remake)'s development repository lists several [real-world applications](https://github.com/richfitz/remake/blob/master/README.md#real-world-examples). [drake](https://github.com/ropensci/drake) surpasses [remake](https://github.com/richfitz/remake) in several important ways, including but not limited to the following.
 
-1.  High-performance computing.
-    [Remake](https://github.com/richfitz/remake) has no native parallel
-    computing support. [drake](https://github.com/ropensci/drake), on
-    the other hand, has a thorough selection of parallel computing
-    technologies and scheduling algorithms. Thanks to
-    [future](github.com/HenrikBengtsson/future),
-    [future.batchtools](github.com/HenrikBengtsson/future.batchtools),
-    and [batchtools](github.com/mllg/batchtools), it is straightforward
-    to configure a [drake](https://github.com/ropensci/drake) project
-    for most popular job schedulers, such as
-    [SLURM](https://slurm.schedmd.com/),
-    [TORQUE](http://www.adaptivecomputing.com/products/torque/), and the
-    [Grid
-    Engine](https://www.oracle.com/technetwork/oem/grid-engine-166852.html),
-    as well as systems contained in [Docker
-    images](https://www.docker.com/).
-2.  A friendly interface. In
-    [remake](https://github.com/richfitz/remake), the user must manually
-    write a
-    [YAML](https://github.com/richfitz/remake/blob/master/doc/remake.yml)
-    configuration file to arrange the steps of a workflow, which leads
-    to some of the same scalability problems as
-    [Make](https://www.gnu.org/software/make/).
-    [drake](https://github.com/ropensci/drake)’s data-frame-based
-    interface and [wildcard templating
-    functionality](https://ropenscilabs.github.io/drake-manual/mtcars.html#generate-the-workflow-plan)
-    easily generate workflows at scale.
-3.  Thorough documentation. [drake](https://github.com/ropensci/drake)
-    contains [thorough user
-    manual](https://ropenscilabs.github.io/drake-manual/), a [reference
-    website](https://ropensci.github.io/drake/), a [comprehensive
-    README](https://github.com/ropensci/drake/blob/master/README.md),
-    examples in the help files of user-side functions, and [accessible
-    example code](https://github.com/wlandau/drake-examples) that users
-    can write with `drake::example_drake()`.
-4.  Active maintenance. [drake](https://github.com/ropensci/drake) is
-    actively developed and maintained, and
-    [issues](https://github.com/ropensci/drake/issues) are usually
-    addressed promptly.
-5.  Presence on CRAN. At the time of writing,
-    [drake](https://github.com/ropensci/drake) is [available on
-    CRAN](https://cran.r-project.org/package=drake), but
-    [remake](https://github.com/richfitz/remake) is not.
+1.  High-performance computing. [Remake](https://github.com/richfitz/remake) has no native parallel computing support. [drake](https://github.com/ropensci/drake), on the other hand, has a thorough selection of parallel computing technologies and scheduling algorithms. Thanks to [future](github.com/HenrikBengtsson/future), [future.batchtools](github.com/HenrikBengtsson/future.batchtools), and [batchtools](github.com/mllg/batchtools), it is straightforward to configure a [drake](https://github.com/ropensci/drake) project for most popular job schedulers, such as [SLURM](https://slurm.schedmd.com/), [TORQUE](http://www.adaptivecomputing.com/products/torque/), and the [Grid Engine](https://www.oracle.com/technetwork/oem/grid-engine-166852.html), as well as systems contained in [Docker images](https://www.docker.com/).
+2.  A friendly interface. In [remake](https://github.com/richfitz/remake), the user must manually write a [YAML](https://github.com/richfitz/remake/blob/master/doc/remake.yml) configuration file to arrange the steps of a workflow, which leads to some of the same scalability problems as [Make](https://www.gnu.org/software/make/). [drake](https://github.com/ropensci/drake)'s data-frame-based interface and [wildcard templating functionality](https://ropenscilabs.github.io/drake-manual/mtcars.html#generate-the-workflow-plan) easily generate workflows at scale.
+3.  Thorough documentation. [drake](https://github.com/ropensci/drake) contains [thorough user manual](https://ropenscilabs.github.io/drake-manual/), a [reference website](https://ropensci.github.io/drake/), a [comprehensive README](https://github.com/ropensci/drake/blob/master/README.md), examples in the help files of user-side functions, and [accessible example code](https://github.com/wlandau/drake-examples) that users can write with `drake::example_drake()`.
+4.  Active maintenance. [drake](https://github.com/ropensci/drake) is actively developed and maintained, and [issues](https://github.com/ropensci/drake/issues) are usually addressed promptly.
+5.  Presence on CRAN. At the time of writing, [drake](https://github.com/ropensci/drake) is [available on CRAN](https://cran.r-project.org/package=drake), but [remake](https://github.com/richfitz/remake) is not.
 
-## Memoise
+Memoise
+-------
 
-Memoization is the strategic caching of the return values of functions.
-Every time a memoized function is called with a new set of arguments,
-the return value is saved for future use. Later, whenever the same
-function is called with the same arguments, the previous return value is
-salvaged, and the function call is skipped to save time. The [memoise
-package](https://github.com/r-lib/memoise) is an excellent
-implementation of memoization in R.
+Memoization is the strategic caching of the return values of functions. Every time a memoized function is called with a new set of arguments, the return value is saved for future use. Later, whenever the same function is called with the same arguments, the previous return value is salvaged, and the function call is skipped to save time. The [memoise package](https://github.com/r-lib/memoise) is an excellent implementation of memoization in R.
 
-However, memoization does not go far enough. In reality, the return
-value of a function depends not only on the function body and the
-arguments, but also on any nested functions and global variables, the
-dependencies of those dependencies, and so on upstream. `drake`
-surpasses [memoise](https://github.com/r-lib/memoise) because it uses
-the *entire dependency network graph* of a project to decide which
-pieces need to be rebuilt and which ones can be skipped.
+However, memoization does not go far enough. In reality, the return value of a function depends not only on the function body and the arguments, but also on any nested functions and global variables, the dependencies of those dependencies, and so on upstream. `drake` surpasses [memoise](https://github.com/r-lib/memoise) because it uses the *entire dependency network graph* of a project to decide which pieces need to be rebuilt and which ones can be skipped.
 
-## Knitr
+Knitr
+-----
 
-Much of the R community uses [knitr](https://yihui.name/knitr/) for
-reproducible research. The idea is to intersperse code chunks in an [R
-Markdown](http://rmarkdown.rstudio.com/) or `*.Rnw` file and then
-generate a dynamic report that weaves together code, output, and prose.
-[Knitr](https://yihui.name/knitr/) is not designed to be a serious
-[pipeline toolkit](https://github.com/pditommaso/awesome-pipeline), and
-it should not be the primary computational engine for medium to large
-data analysis projects.
+Much of the R community uses [knitr](https://yihui.name/knitr/) for reproducible research. The idea is to intersperse code chunks in an [R Markdown](http://rmarkdown.rstudio.com/) or `*.Rnw` file and then generate a dynamic report that weaves together code, output, and prose. [Knitr](https://yihui.name/knitr/) is not designed to be a serious [pipeline toolkit](https://github.com/pditommaso/awesome-pipeline), and it should not be the primary computational engine for medium to large data analysis projects.
 
-1.  [Knitr](https://yihui.name/knitr/) scales far worse than
-    [Make](https://www.gnu.org/software/make/) or
-    [remake](https://github.com/richfitz/remake). The whole point is to
-    consolidate output and prose, so it deliberately lacks the essential
-    modularity.
+1.  [Knitr](https://yihui.name/knitr/) scales far worse than [Make](https://www.gnu.org/software/make/) or [remake](https://github.com/richfitz/remake). The whole point is to consolidate output and prose, so it deliberately lacks the essential modularity.
 2.  There is no obvious high-performance computing support.
-3.  While there is a way to skip chunks that are already up to date
-    (with code chunk options `cache` and `autodep`), this functionality
-    is not the focus of [knitr](https://yihui.name/knitr/). It is
-    deactivated by default, and
-    [remake](https://github.com/richfitz/remake) and `drake` are more
-    dependable ways to skip work that is already up to date.
+3.  While there is a way to skip chunks that are already up to date (with code chunk options `cache` and `autodep`), this functionality is not the focus of [knitr](https://yihui.name/knitr/). It is deactivated by default, and [remake](https://github.com/richfitz/remake) and `drake` are more dependable ways to skip work that is already up to date.
 
-`drake` was designed to manage the entire workflow with
-[knitr](https://yihui.name/knitr/) reports as targets. The strategy is
-analogous for [knitr](https://yihui.name/knitr/) reports within
-[remake](https://github.com/richfitz/remake) projects.
+`drake` was designed to manage the entire workflow with [knitr](https://yihui.name/knitr/) reports as targets. The strategy is analogous for [knitr](https://yihui.name/knitr/) reports within [remake](https://github.com/richfitz/remake) projects.
 
-## Factual’s Drake
+Factual's Drake
+---------------
 
-[Factual’s Drake](https://github.com/Factual/drake) is similar in
-concept, but the development effort is completely unrelated to the
-[drake R package](https://github.com/ropensci/drake).
+[Factual's Drake](https://github.com/Factual/drake) is similar in concept, but the development effort is completely unrelated to the [drake R package](https://github.com/ropensci/drake).
 
-## Other pipeline toolkits
+Other pipeline toolkits
+-----------------------
 
-There are [countless other successful pipeline
-toolkits](https://github.com/pditommaso/awesome-pipeline). The `drake`
-package distinguishes itself with its R-focused approach,
-Tidyverse-friendly interface, and a [thorough selection of parallel
-computing technologies and scheduling
-algorithms](https://ropenscilabs.github.io/drake-manual/hpc.html).
+There are [countless other successful pipeline toolkits](https://github.com/pditommaso/awesome-pipeline). The `drake` package distinguishes itself with its R-focused approach, Tidyverse-friendly interface, and a [thorough selection of parallel computing technologies and scheduling algorithms](https://ropenscilabs.github.io/drake-manual/hpc.html).
 
-# Acknowledgements
+Acknowledgements
+================
 
-Special thanks to [Jarad Niemi](http://www.jarad.me/), my advisor from
-[graduate school](http://stat.iastate.edu/), for first introducing me to
-the idea of [Makefiles](https://www.gnu.org/software/make/) for
-research. He originally set me down the path that led to `drake`.
+Special thanks to [Jarad Niemi](http://www.jarad.me/), my advisor from [graduate school](http://stat.iastate.edu/), for first introducing me to the idea of [Makefiles](https://www.gnu.org/software/make/) for research. He originally set me down the path that led to `drake`.
 
-Many thanks to [Julia Lowndes](https://github.com/jules32), [Ben
-Marwick](https://github.com/benmarwick), and [Peter
-Slaughter](https://github.com/gothub) for [reviewing drake for
-rOpenSci](https://github.com/ropensci/onboarding/issues/156), and to
-[Maëlle Salmon](https://github.com/maelle) for such active involvement
-as the editor. Thanks also to the following people for contributing
-early in development.
+Many thanks to [Julia Lowndes](https://github.com/jules32), [Ben Marwick](https://github.com/benmarwick), and [Peter Slaughter](https://github.com/gothub) for [reviewing drake for rOpenSci](https://github.com/ropensci/onboarding/issues/156), and to [Maëlle Salmon](https://github.com/maelle) for such active involvement as the editor. Thanks also to the following people for contributing early in development.
 
-  - [Alex Axthelm](https://github.com/AlexAxthelm)
-  - [Chan-Yub Park](https://github.com/mrchypark)
-  - [Daniel Falster](https://github.com/dfalster)
-  - [Eric Nantz](https://github.com/thercast)
-  - [Henrik Bengtsson](https://github.com/HenrikBengtsson)
-  - [Ian Watson](https://github.com/IanAWatson)
-  - [Jasper Clarkberg](https://github.com/dapperjapper)
-  - [Kendon Bell](https://github.com/kendonB)
-  - [Kirill Müller](https://github.com/krlmlr)
-  - [Michael Schubert](http://github.com/mschubert)
+-   [Alex Axthelm](https://github.com/AlexAxthelm)
+-   [Chan-Yub Park](https://github.com/mrchypark)
+-   [Daniel Falster](https://github.com/dfalster)
+-   [Eric Nantz](https://github.com/thercast)
+-   [Henrik Bengtsson](https://github.com/HenrikBengtsson)
+-   [Ian Watson](https://github.com/IanAWatson)
+-   [Jasper Clarkberg](https://github.com/dapperjapper)
+-   [Kendon Bell](https://github.com/kendonB)
+-   [Kirill Müller](https://github.com/krlmlr)
+-   [Michael Schubert](http://github.com/mschubert)
 
-Credit for images is [attributed
-here](https://github.com/ropensci/drake/blob/master/images/image-credit.md).
+Credit for images is [attributed here](https://github.com/ropensci/drake/blob/master/images/image-credit.md).
 
 [![ropensci\_footer](http://ropensci.org/public_images/github_footer.png)](https://ropensci.org)

--- a/tests/testthat/test-hash-table.R
+++ b/tests/testthat/test-hash-table.R
@@ -25,4 +25,6 @@ test_with_dir("hash tables work", {
   ht_merge(x, y)
   expect_equal(sort(ht_list(x)), sort(c("a", "b", "c", "d")))
   expect_equal(sort(ht_list(y)), sort(c("b", "c", "d")))
+  ht_clear(y)
+  expect_equal(ht_list(y), character(0))
 })


### PR DESCRIPTION
# Summary

For each target, `drake` reads the stored hashes of all the dependencies to help decide whether the target is up to date. Some targets share dependencies, so until now, `drake` has been reading the same hash from the cache over and over again. To avoid redundancy, this PR records each up-to-date hash in memory so that future targets can make use of it without having to access the file system all the time. For the times when we actually *do* need to read hashes from storage, hopefully https://github.com/richfitz/storr/issues/96 and https://github.com/richfitz/storr/pull/98 will help.

# Benchmarks

I ran benchmarks on [this test case](https://github.com/wlandau/drake-examples/tree/master/overhead), a mock workflow with 4096 targets and 64 dependencies per target for most of them. There is a noticeable improvement in the speed of `dependency_hash()`.

Before:

![slow](https://user-images.githubusercontent.com/1580860/50874157-ea61b100-1390-11e9-86d5-563c24196a0f.png)

After:

![fast](https://user-images.githubusercontent.com/1580860/50874168-f5b4dc80-1390-11e9-8769-16d4045b4d67.png)


# Related GitHub issues and pull requests

- Ref: #655 

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
