### PR TITLE
Get rid of the "kernels" 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 - Set the default value of `lock_envir` to `TRUE` in `make()` and `drake_config()`. So `make()` will automatically quit in error if the act of building a target tries to change upstream dependencies.
 - `make()` no longer returns a value. Users will need to call `drake_config()` separately to get the old return value of `make()`.
 - Make `jobs` a scalar argument to `make()` and `drake_config()`. To parallelize the imports and other preprocessing tasks, use `jobs_preprocess`.
+- Get rid of the "kernels" `storr` namespace. As a result, `drake` is faster, but users will no longer be able to use imported functions loaded from `loadd()` or `readd()`.
 
 ## Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Breaking changes
 
-- This release will be version 7.0.0, a major update. Unfortunately, some enhancements that increase cache speed also invalidate targets in old projects. Workflows run with drake <= 6.2.1 will need to run from scratch again.
+- This release will be version 7.0.0, a major update. It contains tremendous speed improvements, more and better boosts than in any previous release. Unfortunately, some enhancements that increase cache speed also invalidate targets in old projects. Workflows run with drake <= 6.2.1 will need to run from scratch again.
 - Remove all parallel backends (`parallelism` argument of `make()`) except "clustermq", "future", and "hasty".
 - A large amount of deprecated functionality is removed, including several functions and the single-quoted file API.
 - Set the default value of `lock_envir` to `TRUE` in `make()` and `drake_config()`. So `make()` will automatically quit in error if the act of building a target tries to change upstream dependencies.

--- a/R/api-cache.R
+++ b/R/api-cache.R
@@ -482,7 +482,7 @@ drake_cache_log <- function(
 }
 
 single_cache_log <- function(key, cache) {
-  hash <- cache$get_hash(key = key, namespace = "kernels")
+  hash <- cache$get_hash(key = key)
   imported <- get_from_subspace(
     key = key,
     subspace = "imported",
@@ -541,11 +541,9 @@ safe_get_hash <- function(key, namespace, config) {
   out
 }
 
-kernel_exists <- function(target, config) {
-  config$cache$exists(key = target, namespace = "kernels")
+target_exists <- function(target, config) {
+  config$cache$exists(key = target)
 }
-
-target_exists <- kernel_exists
 
 memo_expr <- function(expr, cache, ...) {
   if (is.null(cache)) {

--- a/R/exec-meta.R
+++ b/R/exec-meta.R
@@ -114,7 +114,7 @@ dependency_hash <- function(target, config) {
 self_hash <- function(target, config) {
   # tryCatch is faster than checking if the key exists beforehand.
   tryCatch(
-    config$cache$get_hash(target, namespace = "kernels"),
+    config$cache$get_hash(target),
     error = error_na
   )
 }
@@ -235,10 +235,10 @@ file_hash <- function(
     new_mtime = new_mtime,
     old_mtime = old_mtime,
     size_cutoff = size_cutoff)
-  old_hash_exists <- config$cache$exists(key = target, namespace = "kernels")
+  old_hash_exists <- config$cache$exists(key = target)
   if (do_rehash || !old_hash_exists) {
     rehash_file(target = target, config = config)
   } else {
-    config$cache$get(key = target, namespace = "kernels")
+    config$cache$get(key = target)
   }
 }

--- a/R/exec-store.R
+++ b/R/exec-store.R
@@ -85,16 +85,7 @@ finalize_storage <- function(target, value, meta, config, verbose) {
 }
 
 store_object <- function(target, value, meta, config) {
-  config$cache$set(
-    key = target,
-    value = value
-  )
-  config$cache$duplicate(
-    key_src = target,
-    key_dest = target,
-    namespace_src = config$cache$default_namespace,
-    namespace_dest = "kernels"
-  )
+  config$cache$set(key = target, value = value)
 }
 
 store_file <- function(target, meta, config) {
@@ -121,26 +112,13 @@ store_output_files <- function(files, meta, config) {
 }
 
 store_function <- function(target, value, meta, config) {
-  config$cache$set(
-    key = target,
-    value = value,
-    namespace = config$cache$default_namespace
-  )
-  # For the kernel of an imported function,
-  # we ignore any code wrapped in ignore().
   if (meta$imported) {
     value <- ignore_ignore(value)
+    # Unfortunately, vectorization is removed, but this is for the best.
+    value <- deparse(unwrap_function(value))
+    value <- c(value, meta$dependency_hash)
   }
-  # Unfortunately, vectorization is removed, but this is for the best.
-  string <- deparse(unwrap_function(value))
-  if (meta$imported) {
-    string <- c(string, meta$dependency_hash)
-  }
-  config$cache$set(
-    key = target,
-    value = string,
-    namespace = "kernels"
-  )
+  store_object(target, value, meta, config)
 }
 
 store_failure <- function(target, meta, config) {

--- a/R/utils-cache.R
+++ b/R/utils-cache.R
@@ -38,11 +38,7 @@ cache_namespaces <- function(
 cleaned_namespaces <- function(
   default = storr::storr_environment()$default_namespace
 ) {
-  out <- c(
-    default,   # the target values themselves
-    "kernels", # reproducibly-tracked representation of targets. watched for changes # nolint
-    "meta"     # watched metadata such as hashes and time stamps
-  )
+  out <- c(default, "meta")
   sort(out)
 }
 

--- a/R/utils-checksums.R
+++ b/R/utils-checksums.R
@@ -5,7 +5,6 @@ mc_get_checksum <- function(target, config) {
       namespace = config$cache$default_namespace,
       config = config
     ),
-    safe_get_hash(key = target, namespace = "kernels", config = config),
     safe_get_hash(key = target, namespace = "meta", config = config),
     mc_get_outfile_checksum(target, config),
     sep = " "
@@ -46,7 +45,7 @@ mc_is_good_checksum <- function(target, checksum, config) {
   }
   all(
     vapply(
-      X = unlist(strsplit(local_checksum, " "))[1:3],
+      X = unlist(strsplit(local_checksum, " "))[1:2],
       config$cache$exists_object,
       FUN.VALUE = logical(1)
     )

--- a/R/utils-checksums.R
+++ b/R/utils-checksums.R
@@ -1,6 +1,10 @@
 mc_get_checksum <- function(target, config) {
   paste(
-    safe_get_hash(key = target, config = config),
+    safe_get_hash(
+      key = target,
+      namespace = config$cache$default_namespace,
+      config = config
+    ),
     safe_get_hash(key = target, namespace = "meta", config = config),
     mc_get_outfile_checksum(target, config),
     sep = " "

--- a/R/utils-checksums.R
+++ b/R/utils-checksums.R
@@ -1,10 +1,6 @@
 mc_get_checksum <- function(target, config) {
   paste(
-    safe_get_hash(
-      key = target,
-      namespace = config$cache$default_namespace,
-      config = config
-    ),
+    safe_get_hash(key = target, config = config),
     safe_get_hash(key = target, namespace = "meta", config = config),
     mc_get_outfile_checksum(target, config),
     sep = " "

--- a/R/utils-utils.R
+++ b/R/utils-utils.R
@@ -160,18 +160,6 @@ map_by <- function(.x, .by, .f, ...) {
   do.call(what = rbind, args = out)
 }
 
-merge_lists <- function(x, y) {
-  names <- base::union(names(x), names(y))
-  x <- lapply(
-    X = names,
-    function(name) {
-      base::union(x[[name]], y[[name]])
-    }
-  )
-  names(x) <- names
-  x
-}
-
 padded_scale <- function(x) {
   r <- range(x)
   pad <- 0.2 * (r[2] - r[1])

--- a/tests/scenarios/all.R
+++ b/tests/scenarios/all.R
@@ -1,5 +1,5 @@
 devtools::load_all()
-for (scenario in testing_scenario_names()){
+for (scenario in sort(testing_scenario_names())){
   cat(scenario, "\n")
   system2(
     command = "R",

--- a/tests/scenarios/exec.sh
+++ b/tests/scenarios/exec.sh
@@ -1,0 +1,1 @@
+nohup R CMD BATCH all.R &

--- a/tests/scenarios/watch.sh
+++ b/tests/scenarios/watch.sh
@@ -1,0 +1,1 @@
+watch -n .1 tail -n 30 *out

--- a/tests/scenarios/watch.sh
+++ b/tests/scenarios/watch.sh
@@ -1,1 +1,1 @@
-watch -n .1 tail -n 30 *out
+watch -n .1 tail -n 30 $1

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -367,7 +367,7 @@ test_with_dir("cache functions work from various working directories", {
   expect_true(is.numeric(readd(final, search = FALSE)))
   expect_error(loadd(yourinput, myinput, search = FALSE, imported_only = TRUE))
   loadd(h, i, j, c, jobs = 2, search = FALSE, envir = envir)
-  expect_true(is.numeric(h(1)))
+  expect_true(is.character(h))
   rm(h, i, j, c, envir = envir)
   expect_error(h(1))
 
@@ -454,9 +454,8 @@ test_with_dir("cache functions work from various working directories", {
   expect_error(h(1))
   expect_error(j(1))
   loadd(h, i, j, c, path = s, search = TRUE, envir = envir)
-  expect_true(is.numeric(h(1)))
+  expect_true(is.character(h))
   rm(h, i, j, c, envir = envir)
-  expect_error(h(1))
 
   # load dependencies
   e <- new.env()

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -194,7 +194,7 @@ test_with_dir("Vectorized nested functions work", {
   }
   expect_equal(readd(a), 8:17)
   k <- readd(f)
-  expect_equal(k(2:5), 9:12)
+  expect_true(is.character(k))
   expect_equal(character(0), outdated(config))
   config$envir$y <- 8
   expect_equal("a", outdated(config))
@@ -436,11 +436,10 @@ test_with_dir("ignore() in imported functions", {
   make(plan, cache = cache)
   config <- drake_config(plan, cache = cache)
   expect_equal(justbuilt(config), "x")
-  expect_equal(readd(f, cache = cache), f)
-  expect_equal(
-    readd(f, cache = cache, namespace = "kernels")[3],
-    "    (sqrt(ignore() + 123))"
-  )
+
+  str <- readd(f, cache = cache)
+  expect_false(any(grepl("sqrt(x)", str, fixed = TRUE)))
+  expect_equal(str[3], "    (sqrt(ignore() + 123))")
   f <- function(x) {
     (sqrt( ignore(sqrt(x) + 8) + 123)) # nolint
   }

--- a/tests/testthat/test-edge-cases.R
+++ b/tests/testthat/test-edge-cases.R
@@ -219,12 +219,7 @@ test_with_dir("true targets can be functions", {
   make(plan, verbose = FALSE, session_info = FALSE)
   config <- drake_config(plan, verbose = FALSE, session_info = FALSE)
   expect_equal(readd(output), 2)
-  expect_true(
-    is.character(
-      config$cache$get("myfunction",
-      namespace = "kernels")
-    )
-  )
+  expect_true(is.function(config$cache$get("myfunction")))
   myfunction <- readd(myfunction)
   expect_equal(myfunction(4), 5)
 })

--- a/tests/testthat/test-full-build.R
+++ b/tests/testthat/test-full-build.R
@@ -63,17 +63,12 @@ test_with_dir("scratch build with custom filesystem cache.", {
   # clean removes imported functions and cleans up 'functions'
   # namespace
   expect_true(cached(f, cache = cache))
-  for (n in c(cache$default_namespace, "kernels")) {
-    expect_true("f" %in% config$cache$list(namespace = n))
-  }
+  expect_true("f" %in% config$cache$list())
   clean(f, cache = cache)
-  for (n in c(cache$default_namespace, "kernels")) {
-    expect_false("f" %in% config$cache$list(namespace = n))
-  }
+  expect_false("f" %in% config$cache$list())
 
   clean(destroy = FALSE, cache = cache)
   expect_equal(config$cache$list(), character(0))
-  expect_equal(config$cache$list("kernels"), character(0))
   expect_false(file.exists("intermediatefile.rds"))
   expect_true(file.exists("input.rds"))
   expect_false(file.exists(default_cache_path()))

--- a/tests/testthat/test-namespaced.R
+++ b/tests/testthat/test-namespaced.R
@@ -76,9 +76,9 @@ test_with_dir("namespaced drake_plan works", {
     session_info = FALSE
   )
   fromcache <- readd("base::list", character_only = TRUE)
-  expect_equal(fromcache(1, "a"), list(1, "a"))
+  expect_true(is.character(fromcache))
   fromcache2 <- readd("base:::c", character_only = TRUE)
-  expect_equal(fromcache2(1, 2), c(1, 2))
+  expect_true(is.character(fromcache2))
   ns <- sort(c("base:::c", "base::list", "base::nchar"))
   expect_true(all(cached(list = ns)))
   expect_true(all(ns %in% imported()))

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -5,15 +5,6 @@ test_with_dir("file system", {
   expect_equal(file_extn("123"), "123")
 })
 
-test_with_dir("merge_lists()", {
-  x <- list(a = 1, b = 1:2, c = 1:3)
-  y <- list(b = 3:4, c = 4:5, d = 1:5)
-  z <- merge_lists(x, y)
-  z <- lapply(z, sort)
-  w <- list(a = 1, b = 1:4, c = 1:5, d = 1:5)
-  expect_equal(z, w)
-})
-
 test_with_dir("drake_pmap", {
   # Basic functionality: example from purrr::pmap
   x <- list(1, 10, 100)


### PR DESCRIPTION
# Summary

Speeds up `store_object()`. As a consequence, users will not be able to load imported functions with `loadd()` or `readd()`, but I do not think there was ever any need to do so.

# Related GitHub issues and pull requests

- Ref: #668

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
