### PR TITLE
Add map() to the DSL

### DIFF
--- a/R/api-dsl.R
+++ b/R/api-dsl.R
@@ -66,7 +66,7 @@ transform_row <- function(plan, row) {
   post_hoc_groups <- parse_group(plan[["group"]][[row]])
   transform <- parse_transform(plan$transform[[row]], plan)
   new_cols <- c(target, post_hoc_groups, group_names(transform))
-  check_groupings(new_cols, old_cols(plan))
+  check_group_names(new_cols, old_cols(plan))
   out <- dsl_transform(transform, target, command, plan)
   out[[target]] <- out$target
   old_cols <- setdiff(
@@ -109,6 +109,7 @@ dsl_grid.cross <- function(transform, groupings) {
 }
 
 dsl_grid.map <- function(transform, groupings) {
+  check_map_groupings(transform, groupings)
   as.data.frame(groupings)
 }
 
@@ -301,7 +302,18 @@ dsl_default_df <- function(target, command) {
   )
 }
 
-check_groupings <- function(groups, protect) {
+check_map_groupings <- function(transform, groupings) {
+  n <- unique(vapply(groupings, length, FUN.VALUE = integer(1)))
+  if (length(n) > 1) {
+    stop(
+      "uneven groupings in ", char(transform), ":\n",
+      multiline_message(groupings),
+      call. = FALSE
+    )
+  }
+}
+
+check_group_names <- function(groups, protect) {
   groups <- intersect(groups, protect)
   if (length(groups)) {
     stop(

--- a/R/api-dsl.R
+++ b/R/api-dsl.R
@@ -16,7 +16,8 @@
 #' @seealso [drake_plan()]
 #' @return A transformed workflow plan data frame
 #' @param plan Workflow plan data frame with a column for targets,
-#'   a column for commands, and a column for transformations.
+#'   a column for commands, a column for transformations,
+#'   and a column for optional grouping variables.
 #' @param trace Logical, whether to add columns to show
 #'   what happened during target transformations, e.g.
 #'   `drake_plan(x = target(..., transform = ...), transform = TRUE)`.
@@ -24,7 +25,7 @@
 #' plan1 <- drake_plan(
 #'   analysis = target(
 #'     analyze_data("source"),
-#'     transform = cross(source = c(source1, source2))
+#'     transform = map(source = c(source1, source2)) # cross() would work too
 #'   ),
 #'   transform = FALSE
 #' )

--- a/R/api-plan.R
+++ b/R/api-plan.R
@@ -95,11 +95,13 @@
 #' # check your workflow with `vis_drake_graph()`
 #' # before running `make()`.
 #' drake_plan(
-#'   small = simulate(48),
-#'   large = simulate(64),
+#'   data = target(
+#'     simulate(nrows),
+#'     transform = map(nrows = c(48, 64))
+#'   ),
 #'   reg = target(
 #'     reg_fun(data),
-#'    transform = cross(reg_fun = c(reg1, reg2), data = c(small, large))
+#'    transform = cross(reg_fun = c(reg1, reg2), data)
 #'   ),
 #'   summ = target(
 #'     sum_fun(data, reg),
@@ -118,7 +120,7 @@
 #'   large = simulate(64),
 #'   reg1 = target(
 #'     reg_fun(data),
-#'     transform = cross(data = c(small, large)),
+#'     transform = map(data = c(small, large)),
 #'     group = reg
 #'   ),
 #'   reg2 = target(

--- a/man/drake_plan.Rd
+++ b/man/drake_plan.Rd
@@ -119,11 +119,13 @@ deps_code("report.Rmd")
 # check your workflow with `vis_drake_graph()`
 # before running `make()`.
 drake_plan(
-  small = simulate(48),
-  large = simulate(64),
+  data = target(
+    simulate(nrows),
+    transform = map(nrows = c(48, 64))
+  ),
   reg = target(
     reg_fun(data),
-   transform = cross(reg_fun = c(reg1, reg2), data = c(small, large))
+   transform = cross(reg_fun = c(reg1, reg2), data)
   ),
   summ = target(
     sum_fun(data, reg),
@@ -142,7 +144,7 @@ drake_plan(
   large = simulate(64),
   reg1 = target(
     reg_fun(data),
-    transform = cross(data = c(small, large)),
+    transform = map(data = c(small, large)),
     group = reg
   ),
   reg2 = target(

--- a/man/transform_plan.Rd
+++ b/man/transform_plan.Rd
@@ -8,7 +8,8 @@ transform_plan(plan, trace = FALSE)
 }
 \arguments{
 \item{plan}{Workflow plan data frame with a column for targets,
-a column for commands, and a column for transformations.}
+a column for commands, a column for transformations,
+and a column for optional grouping variables.}
 
 \item{trace}{Logical, whether to add columns to show
 what happened during target transformations, e.g.
@@ -37,7 +38,7 @@ and and want to combine and transform them later.
 plan1 <- drake_plan(
   analysis = target(
     analyze_data("source"),
-    transform = cross(source = c(source1, source2))
+    transform = map(source = c(source1, source2)) # cross() would work too
   ),
   transform = FALSE
 )

--- a/tests/testthat/test-dsl.R
+++ b/tests/testthat/test-dsl.R
@@ -239,6 +239,7 @@ test_with_dir("more map", {
       custom2 = 456L
     )
   )
+  equivalent_plans(out, exp)
 })
 
 test_with_dir("map on mtcars-like workflow", {

--- a/tests/testthat/test-dsl.R
+++ b/tests/testthat/test-dsl.R
@@ -3,15 +3,30 @@ drake_context("dsl")
 test_with_dir("empty transformations", {
   out <- drake_plan(
     a = target(x, transform = cross()),
-    b = target(y, transform = reduce())
+    b = target(y, transform = reduce()),
+    c = target(z, transform = map())
   )
-  exp <- drake_plan(a = x, b = y)
+  exp <- drake_plan(a = x, b = y, c = z)
   equivalent_plans(out, exp)
 })
 
 test_with_dir("simple expansion", {
   plan <- drake_plan(a = target(1 + 1, transform = cross(x = c(1, 2))))
   expect_equal(sort(plan$target), sort(c("a_1", "a_2")))
+  expect_equal(plan$command, rep("1 + 1", 2))
+})
+
+test_with_dir("simple map", {
+  plan <- drake_plan(a = target(1 + 1, transform = map(x = c(1, 2))))
+  expect_equal(sort(plan$target), sort(c("a_1", "a_2")))
+  expect_equal(plan$command, rep("1 + 1", 2))
+})
+
+test_with_dir("simple map with 2 factors", {
+  plan <- drake_plan(
+    a = target(1 + 1, transform = map(x = c(1, 2), y = c(3, 4)))
+  )
+  expect_equal(sort(plan$target), sort(c("a_1_3", "a_2_4")))
   expect_equal(plan$command, rep("1 + 1", 2))
 })
 
@@ -29,17 +44,47 @@ test_with_dir("all new crossings", {
   equivalent_plans(out, exp)
 })
 
+test_with_dir("1 new map", {
+  out <- drake_plan(
+    analysis = target(
+      analyze_data(source),
+      transform = map(source = c(source1, source2))
+    )
+  )
+  exp <- drake_plan(
+    analysis_source1 = analyze_data(source1),
+    analysis_source2 = analyze_data(source2)
+  )
+  equivalent_plans(out, exp)
+})
+
+test_with_dir("2 new maps", {
+  out <- drake_plan(
+    analysis = target(
+      analyze_data(source, set),
+      transform = map(source = c(source1, source2), set = c(set1, set2))
+    )
+  )
+  exp <- drake_plan(
+    analysis_source1_set1 = analyze_data(source1, set1),
+    analysis_source2_set2 = analyze_data(source2, set2)
+  )
+  equivalent_plans(out, exp)
+})
+
 test_with_dir("groups and command symbols are undefined", {
   out <- drake_plan(
     small = simulate(48),
     large = simulate(64),
     lots = target(nobody(home), transform = cross(a, b)),
+    mots = target(everyone(out), transform = map(c, d)),
     winners = target(min(nobodyhome), transform = reduce(data))
   )
   exp <- drake_plan(
     small = simulate(48),
     large = simulate(64),
     lots = nobody(home),
+    mots = everyone(out),
     winners = min(nobodyhome)
   )
   equivalent_plans(out, exp)
@@ -148,6 +193,76 @@ test_with_dir("dsl with the mtcars plan", {
     ))
   )
   equivalent_plans(out, exp)
+})
+
+test_with_dir("more map", {
+  out <- drake_plan(
+    small = simulate(48),
+    large = simulate(64),
+    reg = target(
+      reg_fun(data),
+      transform = map(reg_fun = c(reg1, reg2), data = c(small, large))
+    ),
+    summ = target(
+      sum_fun(data, reg),
+      transform = map(sum_fun = c(coef, residuals), reg),
+      custom1 = 123L
+    ),
+    winners = target(
+      min(summ),
+      transform = reduce(sum_fun, data),
+      custom2 = 456L
+    )
+  )
+  exp <- drake_plan(
+    small = simulate(48),
+    large = simulate(64),
+    reg_reg1_small = reg1(small),
+    reg_reg2_large = reg2(large),
+    summ_coef_reg_reg1_small = target(
+      command = coef(small, reg_reg1_small),
+      custom1 = 123L
+    ),
+    summ_residuals_reg_reg2_large = target(
+      command = residuals(large, reg_reg2_large),
+      custom1 = 123L
+    ),
+    winners_residuals_large = target(
+      command = min(
+        list(summ_residuals_reg_reg2_large = summ_residuals_reg_reg2_large)),
+      custom2 = 456L
+    ),
+    winners_coef_small = target(
+      command = min(
+        list(summ_coef_reg_reg1_small = summ_coef_reg_reg1_small)
+      ),
+      custom2 = 456L
+    )
+  )
+})
+
+test_with_dir("map with unequal columns", {
+  expect_error(
+    drake_plan(
+      small = simulate(48),
+      large = simulate(64),
+      reg = target(
+        reg_fun(data),
+        transform = map(reg_fun = c(reg1, reg2), data = c(small, large, huge))
+      ),
+      summ = target(
+        sum_fun(data, reg),
+        transform = map(sum_fun = c(coef, residuals), reg),
+        custom1 = 123L
+      ),
+      winners = target(
+        min(summ),
+        transform = reduce(sum_fun, data),
+        custom2 = 456L
+      )
+    ),
+    regexp = "uneven groupings in map"
+  )
 })
 
 test_with_dir("dsl and custom columns", {

--- a/tests/testthat/test-dsl.R
+++ b/tests/testthat/test-dsl.R
@@ -254,8 +254,8 @@ test_with_dir("map on mtcars-like workflow", {
     ),
     summ = target(
       sum_fun(data, reg),
-     transform = cross(sum_fun = c(coef, residuals), reg)
-    ), 
+     transform = cross(sum_fun = c(coef, resid), reg)
+    ),
     winners = target(
       min(summ),
       transform = reduce(data, sum_fun)
@@ -269,13 +269,13 @@ test_with_dir("map on mtcars-like workflow", {
     reg_reg1_data_64 = reg1(data_64),
     reg_reg2_data_64 = reg2(data_64),
     summ_coef_reg_reg1_data_48 = coef(data_48, reg_reg1_data_48),
-    summ_residuals_reg_reg1_data_48 = residuals(data_48, reg_reg1_data_48),
+    summ_resid_reg_reg1_data_48 = resid(data_48, reg_reg1_data_48),
     summ_coef_reg_reg1_data_64 = coef(data_64, reg_reg1_data_64),
-    summ_residuals_reg_reg1_data_64 = residuals(data_64, reg_reg1_data_64),
+    summ_resid_reg_reg1_data_64 = resid(data_64, reg_reg1_data_64),
     summ_coef_reg_reg2_data_48 = coef(data_48, reg_reg2_data_48),
-    summ_residuals_reg_reg2_data_48 = residuals(data_48, reg_reg2_data_48),
+    summ_resid_reg_reg2_data_48 = resid(data_48, reg_reg2_data_48),
     summ_coef_reg_reg2_data_64 = coef(data_64, reg_reg2_data_64),
-    summ_residuals_reg_reg2_data_64 = residuals(data_64, reg_reg2_data_64),
+    summ_resid_reg_reg2_data_64 = resid(data_64, reg_reg2_data_64),
     winners_data_48_coef = min(list(
       summ_coef_reg_reg1_data_48 = summ_coef_reg_reg1_data_48,
       summ_coef_reg_reg2_data_48 = summ_coef_reg_reg2_data_48
@@ -284,13 +284,13 @@ test_with_dir("map on mtcars-like workflow", {
       summ_coef_reg_reg1_data_64 = summ_coef_reg_reg1_data_64,
       summ_coef_reg_reg2_data_64 = summ_coef_reg_reg2_data_64
     )),
-    winners_data_48_residuals = min(list(
-      summ_residuals_reg_reg1_data_48 = summ_residuals_reg_reg1_data_48,
-      summ_residuals_reg_reg2_data_48 = summ_residuals_reg_reg2_data_48
+    winners_data_48_resid = min(list(
+      summ_resid_reg_reg1_data_48 = summ_resid_reg_reg1_data_48,
+      summ_resid_reg_reg2_data_48 = summ_resid_reg_reg2_data_48
     )),
-    winners_data_64_residuals = min(list(
-      summ_residuals_reg_reg1_data_64 = summ_residuals_reg_reg1_data_64,
-      summ_residuals_reg_reg2_data_64 = summ_residuals_reg_reg2_data_64
+    winners_data_64_resid = min(list(
+      summ_resid_reg_reg1_data_64 = summ_resid_reg_reg1_data_64,
+      summ_resid_reg_reg2_data_64 = summ_resid_reg_reg2_data_64
     ))
   )
   equivalent_plans(out, exp)


### PR DESCRIPTION
# Summary

``` r
library(drake)
plan <- drake_plan(
  data = target(
    simulate(data, nrows),
    transform = map(data = c(mtcars, "iris"), nrows = c(48, 64))
  ),
  analysis = target(analyze(data), transform = reduce())
)
plan
#> # A tibble: 3 x 2
#>   target        command                                                    
#>   <chr>         <chr>                                                      
#> 1 data_mtcars_… simulate(mtcars, 48)                                       
#> 2 data_.iris._… "simulate(\"iris\", 64)"                                   
#> 3 analysis      analyze(list(data_mtcars_48 = data_mtcars_48, data_.iris._…

drake_plan_source(plan)
#> drake_plan(
#>   data_mtcars_48 = simulate(mtcars, 48),
#>   data_.iris._64 = simulate("iris", 64),
#>   analysis = analyze(list(data_mtcars_48 = data_mtcars_48, data_.iris._64 = data_.iris._64))
#> )
```

<sup>Created on 2019-01-19 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

cc @AlexAxthelm re https://github.com/ropensci/drake/issues/235#issue-294321106. Fixes #233.

This is a better solution than `map_plan()` because the DSL lets you work entirely in `drake_plan()`.

# Related GitHub issues and pull requests

- Ref: #233

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
