### PR TITLE
Replace `group` with tags

### DIFF
--- a/R/api-plan.R
+++ b/R/api-plan.R
@@ -72,10 +72,13 @@
 #' # This feature is experimental, so please
 #' # check your workflow with `vis_drake_graph()`
 #' # before running `make()`.
+#' # Read more at
+#' # <https://ropenscilabs.github.io/drake-manual/plans.html#create-large-plans-the-easy-way>. # nolint
 #' drake_plan(
 #'   data = target(
 #'     simulate(nrows),
-#'     transform = map(nrows = c(48, 64))
+#'     transform = map(nrows = c(48, 64)),
+#'     custom_column = 123
 #'   ),
 #'   reg = target(
 #'     reg_fun(data),
@@ -88,40 +91,19 @@
 #'   winners = target(
 #'     min(summ),
 #'     transform = reduce(data, sum_fun)
-#'   ),
-#'   trace = TRUE
-#' )
-#'
-#' # Optionally define custom groupings with the `group` field.
-#' # Again, this is still experimental.
-#' drake_plan(
-#'   small = simulate(48),
-#'   large = simulate(64),
-#'   reg1 = target(
-#'     reg_fun(data),
-#'     transform = map(data = c(small, large)),
-#'     group = reg
-#'   ),
-#'   reg2 = target(
-#'     reg_fun(data),
-#'     transform = cross(data = c(small, large)),
-#'     group = reg
-#'   ),
-#'   winners = target(
-#'     min(reg),
-#'     transform = reduce(data),
-#'     a = 1
 #'   )
 #' )
 #'
-#' # Set `trace` to `TRUE` to retain information about the
-#' # transformation process.
+#' # Set trace = TRUE to show what happened during the transformation process.
 #' drake_plan(
-#'   small = simulate(48),
-#'   large = simulate(64),
+#'   data = target(
+#'     simulate(nrows),
+#'     transform = map(nrows = c(48, 64)),
+#'     custom_column = 123
+#'   ),
 #'   reg = target(
 #'     reg_fun(data),
-#'    transform = cross(reg_fun = c(reg1, reg2), data = c(small, large))
+#'    transform = cross(reg_fun = c(reg1, reg2), data)
 #'   ),
 #'   summ = target(
 #'     sum_fun(data, reg),

--- a/R/api-plan.R
+++ b/R/api-plan.R
@@ -88,7 +88,8 @@
 #'   winners = target(
 #'     min(summ),
 #'     transform = reduce(data, sum_fun)
-#'   )
+#'   ),
+#'   trace = TRUE
 #' )
 #'
 #' # Optionally define custom groupings with the `group` field.

--- a/R/utils-utils.R
+++ b/R/utils-utils.R
@@ -311,9 +311,9 @@ wide_deparse <- function(x) {
   paste(deparse(x), collapse = "\n")
 }
 
-named <- function(x) {
+named <- function(x, exclude = character(0)) {
   if (is.null(names(x))) return(NULL)
-  x[names(x) != ""]
+  x[!(names(x) %in% c("", exclude))]
 }
 
 unnamed <- function(x) {

--- a/man/drake_plan.Rd
+++ b/man/drake_plan.Rd
@@ -93,10 +93,13 @@ deps_code("report.Rmd")
 # This feature is experimental, so please
 # check your workflow with `vis_drake_graph()`
 # before running `make()`.
+# Read more at
+# <https://ropenscilabs.github.io/drake-manual/plans.html#create-large-plans-the-easy-way>. # nolint
 drake_plan(
   data = target(
     simulate(nrows),
-    transform = map(nrows = c(48, 64))
+    transform = map(nrows = c(48, 64)),
+    custom_column = 123
   ),
   reg = target(
     reg_fun(data),
@@ -112,36 +115,16 @@ drake_plan(
   )
 )
 
-# Optionally define custom groupings with the `group` field.
-# Again, this is still experimental.
+# Set trace = TRUE to show what happened during the transformation process.
 drake_plan(
-  small = simulate(48),
-  large = simulate(64),
-  reg1 = target(
-    reg_fun(data),
-    transform = map(data = c(small, large)),
-    group = reg
+  data = target(
+    simulate(nrows),
+    transform = map(nrows = c(48, 64)),
+    custom_column = 123
   ),
-  reg2 = target(
-    reg_fun(data),
-    transform = cross(data = c(small, large)),
-    group = reg
-  ),
-  winners = target(
-    min(reg),
-    transform = reduce(data),
-    a = 1
-  )
-)
-
-# Set `trace` to `TRUE` to retain information about the
-# transformation process.
-drake_plan(
-  small = simulate(48),
-  large = simulate(64),
   reg = target(
     reg_fun(data),
-   transform = cross(reg_fun = c(reg1, reg2), data = c(small, large))
+   transform = cross(reg_fun = c(reg1, reg2), data)
   ),
   summ = target(
     sum_fun(data, reg),

--- a/tests/testthat/test-dsl.R
+++ b/tests/testthat/test-dsl.R
@@ -633,20 +633,60 @@ test_with_dir("dsl .tag_out groupings", {
   equivalent_plans(out, exp)
 })
 
-test_with_dir("reduce on tag_in", {
+test_with_dir("reduce() and tags", {
   i <- 1:2
   out <- drake_plan(
     x = target(1, transform = map(f = !!i, .tag_in = grp, .tag_out = targs)),
     y = target(1, transform = map(g = !!i, .tag_in = grp, .tag_out = targs)),
-    z = target(min(targs), transform = reduce(grp))
+    z = target(
+      min(targs),
+      transform = reduce(grp, .tag_in = im, .tag_out = here)
+    ),
+    trace = TRUE
   )
   exp <- drake_plan(
-    x_1 = 1,
-    x_2 = 1,
-    y_1 = 1,
-    y_2 = 1,
-    z_x = min(list(x_1 = x_1, x_2 = x_2)),
-    z_y = min(list(y_1 = y_1, y_2 = y_2))
+    x_1 = target(
+      command = 1,
+      f = "1",
+      x = "x_1",
+      grp = "x",
+      targs = "x_1"
+    ),
+    x_2 = target(
+      command = 1,
+      f = "2",
+      x = "x_2",
+      grp = "x",
+      targs = "x_2"
+    ),
+    y_1 = target(
+      command = 1,
+      grp = "y",
+      targs = "y_1",
+      g = "1",
+      y = "y_1"
+    ),
+    y_2 = target(
+      command = 1,
+      grp = "y",
+      targs = "y_2",
+      g = "2",
+      y = "y_2"
+    ),
+    z_x = target(
+      command = min(list(x_1 = x_1, x_2 = x_2)),
+      grp = "x",
+      z = "z_x",
+      im = "z",
+      here = "z_x"
+    ),
+    z_y = target(
+      command = min(list(y_1 = y_1, y_2 = y_2)),
+      grp = "y",
+      z = "z_y",
+      im = "z",
+      here = "z_y"
+    )
   )
   equivalent_plans(out, exp)
 })

--- a/tests/testthat/test-dsl.R
+++ b/tests/testthat/test-dsl.R
@@ -634,7 +634,7 @@ test_with_dir("dsl .tag_out groupings", {
 })
 
 test_with_dir("reduce() and tags", {
-  i <- 1:2
+  i <- as.numeric(1:3)
   out <- drake_plan(
     x = target(1, transform = map(f = !!i, .tag_in = grp, .tag_out = targs)),
     y = target(1, transform = map(g = !!i, .tag_in = grp, .tag_out = targs)),
@@ -659,6 +659,13 @@ test_with_dir("reduce() and tags", {
       grp = "x",
       targs = "x_2"
     ),
+    x_3 = target(
+      command = 1,
+      f = "3",
+      x = "x_3",
+      grp = "x",
+      targs = "x_3"
+    ),
     y_1 = target(
       command = 1,
       grp = "y",
@@ -673,15 +680,22 @@ test_with_dir("reduce() and tags", {
       g = "2",
       y = "y_2"
     ),
+    y_3 = target(
+      command = 1,
+      grp = "y",
+      targs = "y_3",
+      g = "3",
+      y = "y_3"
+    ),
     z_x = target(
-      command = min(list(x_1 = x_1, x_2 = x_2)),
+      command = min(list(x_1 = x_1, x_2 = x_2, x_3 = x_3)),
       grp = "x",
       z = "z_x",
       im = "z",
       here = "z_x"
     ),
     z_y = target(
-      command = min(list(y_1 = y_1, y_2 = y_2)),
+      command = min(list(y_1 = y_1, y_2 = y_2, y_3 = y_3)),
       grp = "y",
       z = "z_y",
       im = "z",

--- a/tests/testthat/test-dsl.R
+++ b/tests/testthat/test-dsl.R
@@ -17,6 +17,117 @@ test_with_dir("simple expansion", {
   expect_equal(plan$command, rep("1 + 1", 2))
 })
 
+test_with_dir("single tag_in", {
+  out <- drake_plan(
+    x = target(
+      y,
+      transform = cross(
+        x = c(1, 2),
+        .tag_in = single
+      )
+    ),
+    trace = T
+  )
+  exp <- drake_plan(
+    x_1 = target(
+      command = y,
+      x = "x_1",
+      single = "x"
+    ),
+    x_2 = target(
+      command = y,
+      x = "x_2",
+      single = "x"
+    )
+  )
+  equivalent_plans(out, exp)
+})
+
+test_with_dir("multiple tag_in", {
+  out <- drake_plan(
+    x = target(
+      y,
+      transform = cross(
+        x = c(1, 2),
+        .tag_in = c(one, second)
+      )
+    ),
+    trace = T
+  )
+  exp <- drake_plan(
+    x_1 = target(
+      command = y,
+      x = "x_1",
+      one = "x",
+      second = "x"
+    ),
+    x_2 = target(
+      command = y,
+      x = "x_2",
+      one = "x",
+      second = "x"
+    )
+  )
+  equivalent_plans(out, exp)
+})
+
+test_with_dir("single tag_out", {
+  out <- drake_plan(
+    x = target(
+      y,
+      transform = cross(
+        x = c(1, 2),
+        .tag_out = single
+      )
+    ),
+    trace = T
+  )
+  exp <- drake_plan(
+    x_1 = target(
+      command = y,
+      x = "x_1",
+      single = "x_1"
+    ),
+    x_2 = target(
+      command = y,
+      x = "x_2",
+      single = "x_2"
+    )
+  )
+  equivalent_plans(out, exp)
+})
+
+test_with_dir("multiple tag_out", {
+  out <- drake_plan(
+    x = target(
+      y,
+      transform = cross(
+        x = c(1, 2),
+        .tag_out = c(one, second)
+      )
+    ),
+    trace = T
+  )
+  exp <- drake_plan(
+    x_1 = target(
+      command = y,
+      x = "x_1",
+      one = "x_1",
+      second = "x_1"
+    ),
+    x_2 = target(
+      command = y,
+      x = "x_2",
+      one = "x_2",
+      second = "x_2"
+    )
+  )
+  equivalent_plans(out, exp)
+})
+
+
+
+
 test_with_dir("simple map", {
   plan <- drake_plan(a = target(1 + 1, transform = map(x = c(1, 2))))
   expect_equal(sort(plan$target), sort(c("a_1", "a_2")))

--- a/tests/testthat/test-dsl.R
+++ b/tests/testthat/test-dsl.R
@@ -125,9 +125,6 @@ test_with_dir("multiple tag_out", {
   equivalent_plans(out, exp)
 })
 
-
-
-
 test_with_dir("simple map", {
   plan <- drake_plan(a = target(1 + 1, transform = map(x = c(1, 2))))
   expect_equal(sort(plan$target), sort(c("a_1", "a_2")))
@@ -584,13 +581,11 @@ test_with_dir("dsl post-hoc groupings", {
     large = simulate(64),
     reg1 = target(
       rgfun(data),
-      transform = cross(data = c(small, large)),
-      group = c(reg, othergroup)
+      transform = cross(data = c(small, large), .tag_out = c(reg, othergroup)),
     ),
     reg2 = target(
       rgfun(data),
-      transform = cross(data = c(small, large)),
-      group = reg
+      transform = cross(data = c(small, large), .tag_out = reg),
     ),
     winners = target(min(reg), transform = reduce(), a = 1),
     trace = TRUE
@@ -741,13 +736,11 @@ test_with_dir("dsl: exact same plan as mtcars", {
     large = simulate(64),
     regression1 = target(
       reg1(data),
-      transform = map(data = c(small, large)),
-      group = reg
+      transform = map(data = c(small, large), .tag_out = reg),
     ),
     regression2 = target(
       reg2(data),
-      transform = map(data),
-      group = reg
+      transform = map(data, .tag_out = reg),
     ),
     summ = target(
       suppressWarnings(summary(reg$residuals)),
@@ -766,18 +759,15 @@ test_with_dir("dsl: no NA levels in reduce()", {
   out <- drake_plan(
     data_sim = target(
       sim_data(mean = x, sd = y),
-      transform = cross(x = c(1, 2), y = c(3, 4)),
-      group = c(data, local)
+      transform = cross(x = c(1, 2), y = c(3, 4), .tag_out = c(data, local)),
     ),
     data_download = target(
       download_data(url = x),
-      transform = map(x = c("http://url_1", "http://url_2")),
-      group = c(real, data)
+      transform = map(x = c("http://url_1", "http://url_2"), c(real, data))
     ),
     data_pkg = target(
       load_data_from_package(pkg = x),
-      transform = map(x = c("gapminder", "Ecdat")),
-      group = c(local, real, data)
+      transform = map(x = c("gapminder", "Ecdat"), c(local, real, data))
     ),
     summaries = target(
       compare_ds(data_sim),

--- a/tests/testthat/test-dsl.R
+++ b/tests/testthat/test-dsl.R
@@ -575,7 +575,7 @@ test_with_dir("running a dsl-generated mtcars plan", {
   expect_equal(justbuilt(config), character(0))
 })
 
-test_with_dir("dsl post-hoc groupings", {
+test_with_dir("dsl .tag_out groupings", {
   out <- drake_plan(
     small = simulate(48),
     large = simulate(64),
@@ -629,6 +629,24 @@ test_with_dir("dsl post-hoc groupings", {
       a = 1,
       winners = "winners"
     )
+  )
+  equivalent_plans(out, exp)
+})
+
+test_with_dir("reduce on tag_in", {
+  i <- 1:2
+  out <- drake_plan(
+    x = target(1, transform = map(f = !!i, .tag_in = grp, .tag_out = targs)),
+    y = target(1, transform = map(g = !!i, .tag_in = grp, .tag_out = targs)),
+    z = target(min(targs), transform = reduce(grp))
+  )
+  exp <- drake_plan(
+    x_1 = 1,
+    x_2 = 1,
+    y_1 = 1,
+    y_2 = 1,
+    z_x = min(list(x_1 = x_1, x_2 = x_2)),
+    z_y = min(list(y_1 = y_1, y_2 = y_2))
   )
   equivalent_plans(out, exp)
 })


### PR DESCRIPTION
# Summary

Before, we had

```r
drake_plan(
  x = target(
    command,
    transform = map(y = c(1, 2)),
    group = my_group
  )
)
```

The whole separate "group" slot was confusing. It conflicted with the term "grouping variable", which describes `y` above, and it's a dangling slot of `target()`.

This PR cleans up and completes the idea. Now, we have tags, which are grouping variables added post-hoc.

- In-tags: columns with the target names we start with.
- Out-tags: columns with the new target names that the transformation generates. 

``` r
library(drake)
drake_plan(
  x = target(
    command,
    transform = map(y = c(1, 2), .tag_in = from, .tag_out = c(to, out))
  ),
  trace = TRUE
)
#> # A tibble: 2 x 7
#>   target command y     x     from  to    out  
#>   <chr>  <chr>   <chr> <chr> <chr> <chr> <chr>
#> 1 x_1    command 1     x_1   x     x_1   x_1  
#> 2 x_2    command 2     x_2   x     x_2   x_2
```

<sup>Created on 2019-01-20 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

Above,

- `x` and `y` are implicit out-tags.
- `from` is an explicit in-tag.
- `to` and `out` are explicit out-tags.

The whole concept is intuitive and symmetric. Users can chain tags together to create much more complicated dependency graphs from individual calls to `drake_plan()`.

# Related

#233 

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
