### PR TITLE
691

### DIFF
--- a/R/api-dsl.R
+++ b/R/api-dsl.R
@@ -67,7 +67,12 @@ transform_row <- function(plan, row) {
 }
 
 index_can_transform <- function(plan) {
-  vapply(plan[["transform"]], can_transform, FUN.VALUE = logical(1), plan = plan)
+  vapply(
+    plan[["transform"]],
+    can_transform,
+    FUN.VALUE = logical(1),
+    plan = plan
+  )
 }
 
 can_transform <- function(transform, plan) {

--- a/R/api-dsl.R
+++ b/R/api-dsl.R
@@ -148,6 +148,7 @@ dsl_transform <- function(...) {
 dsl_transform.cross <- dsl_transform.map <- map_to_grid
 
 dsl_transform.combine <- function(transform, target, command, plan) {
+  cols_keep <- union(dsl_by(transform), dsl_combine(transform))
   rows_keep <- complete_cases(plan[, dsl_by(transform), drop = FALSE])
   if (!length(rows_keep) || !any(rows_keep)) {
     return(dsl_default_df(target, command))
@@ -286,10 +287,10 @@ dsl_by <- function(...) UseMethod("dsl_by")
 
 dsl_by.combine <- function(transform) {
   attr(transform, "by") %|||%
-    all.vars(transform[[1]][".by"], functions = FALSE)
+    all.vars(lang(transform)[[".by"]], functions = FALSE)
 }
 
-dsl_combine <- function(...) UseMethod("dsl_by")
+dsl_combine <- function(...) UseMethod("dsl_combine")
 
 dsl_combine.combine <- function(transform) {
   attr(transform, "combine") %|||%

--- a/R/api-dsl.R
+++ b/R/api-dsl.R
@@ -31,8 +31,10 @@ transform_plan <- function(plan, trace = FALSE) {
   while (any(index <- index_can_transform(plan))) {
     rows <- lapply(which(index), transform_row, plan = plan)
     plan <- sub_in_plan(plan, rows, at = which(index))
+    old_cols(plan) <- old_cols
   }
   if (!trace) {
+    keep <- as.character(intersect(colnames(plan), old_cols(plan)))
     plan <- plan[, intersect(colnames(plan), old_cols(plan)), drop = FALSE]
   }
   old_cols(plan) <- plan$transform <- plan$group <- NULL

--- a/R/api-dsl.R
+++ b/R/api-dsl.R
@@ -149,7 +149,7 @@ dsl_transform.cross <- dsl_transform.map <- map_to_grid
 
 dsl_transform.combine <- function(transform, target, command, plan) {
   cols_keep <- union(dsl_by(transform), dsl_combine(transform))
-  rows_keep <- complete_cases(plan[, dsl_by(transform), drop = FALSE])
+  rows_keep <- complete_cases(plan[, cols_keep, drop = FALSE])
   if (!length(rows_keep) || !any(rows_keep)) {
     return(dsl_default_df(target, command))
   }

--- a/R/api-dsl.R
+++ b/R/api-dsl.R
@@ -165,7 +165,7 @@ dsl_transform.combine <- function(transform, target, command, plan) {
 
 combine_step <- function(plan, command, transform) {
   aggregates <- lapply(
-    X = plan[, names(old_groupings(transform))],
+    X = plan[, dsl_combine(transform)],
     FUN = function(x) {
       unname(rlang::syms(as.character(na_omit(unique(x)))))
     }

--- a/R/api-dsl.R
+++ b/R/api-dsl.R
@@ -280,10 +280,6 @@ dsl_deps.combine <- function(transform) {
   )
 }
 
-dsl_deps.default <- function(...) {
-  character(0)
-}
-
 dsl_by <- function(...) UseMethod("dsl_by")
 
 dsl_by.combine <- function(transform) {
@@ -310,8 +306,6 @@ new_groupings.map <- function(transform) {
 
 new_groupings.cross <- new_groupings.map
 
-new_groupings.combined <- function(...) character(0)
-
 find_new_groupings <- function(code, exclude = character(0)) {
   list <- named(as.list(code), exclude)
   lapply(list, function(x) {
@@ -328,8 +322,6 @@ old_groupings.map <- old_groupings.cross <- function(transform, plan = NULL) {
   attr(transform, "old_groupings") %|||%
     find_old_groupings(transform, plan)
 }
-
-old_groupings.combined <- function(...) character(0)
 
 find_old_groupings <- function(transform, plan) {
   group_names <- as.character(unnamed(lang(transform))[-1])
@@ -408,9 +400,7 @@ dsl_left_outer_join <- function(x, y) {
   rows_keep <- complete_cases(y[, by])
   y <- y[rows_keep, ]
   dups <- duplicated(y[, by])
-  if (any(dups)) {
-    y <- y[!dups, ]
-  }
+  if (any(dups)) y <- y[!dups, ]
   # Is merge() a performance bottleneck?
   # Need to profile.
   out <- merge(x = x, y = y, by = by, all.x = TRUE)

--- a/R/api-dsl.R
+++ b/R/api-dsl.R
@@ -399,8 +399,8 @@ dsl_left_outer_join <- function(x, y) {
   # The output must have the same number of rows as x.
   rows_keep <- complete_cases(y[, by])
   y <- y[rows_keep, ]
-  dups <- duplicated(y[, by])
-  if (any(dups)) y <- y[!dups, ]
+  # Just a precaution. We should actually be okay by now.
+  y <- y[!duplicated(y[, by]), ]
   # Is merge() a performance bottleneck?
   # Need to profile.
   out <- merge(x = x, y = y, by = by, all.x = TRUE)

--- a/R/api-dsl.R
+++ b/R/api-dsl.R
@@ -49,7 +49,7 @@ can_transform <- function(transform, plan) {
   if (safe_is_na(transform)) {
     return(FALSE)
   }
-  missing_groups <- setdiff(unnamed_args(transform), names(plan))
+  missing_groups <- setdiff(dsl_deps(transform), names(plan))
   length(missing_groups) < 1L
 }
 
@@ -227,7 +227,7 @@ parse_transform.default <- function(transform) {
   assert_good_transform(out)
   structure(
     out,
-    unnamed_args = unnamed_args(out),
+    dsl_deps = dsl_deps(out),
     new_groupings = new_groupings(out),
     tag_in = tag_in(out),
     tag_out = tag_out(out)
@@ -248,14 +248,18 @@ assert_good_transform.default <- function(transform, target) {
   )
 }
 
-unnamed_args <- function(transform) UseMethod("unnamed_args")
+dsl_deps <- function(transform) UseMethod("dsl_deps")
 
-unnamed_args.transform <- function(transform) {
-  attr(transform, "unnamed_args") %|||%
+dsl_deps.map <- dsl_deps.cross <- function(transform) {
+  attr(transform, "dsl_deps") %|||%
     as.character(unnamed(as.list(transform[[1]][-1])))
 }
 
-unnamed_args.default <- function(...) {
+dsl_deps.combine <- function(transform) {
+  browser()
+}
+
+dsl_deps.default <- function(...) {
   character(0)
 }
 

--- a/R/api-plan.R
+++ b/R/api-plan.R
@@ -226,8 +226,9 @@ flatten_plan_list <- function(args, plan_env){
 }
 
 fill_cols <- function(x, cols) {
-  na_cols <- setdiff(cols, colnames(x))
-  x[, na_cols] <- NA
+  for (col in setdiff(cols, colnames(x))) {
+    x[[col]] <- rep(NA, nrow(x))
+  }
   x
 }
 

--- a/R/utils-utils.R
+++ b/R/utils-utils.R
@@ -7,6 +7,14 @@
   }
 }
 
+`%|||%` <- function(x, y) {
+  if (is.null(x)) {
+    y
+  } else {
+    x
+  }
+}
+
 `%||NA%` <- function(x, y) {
   if (is.null(x) || length(x) < 1 || anyNA(x)) {
     y
@@ -322,4 +330,16 @@ named <- function(x, exclude = character(0)) {
 unnamed <- function(x) {
   if (is.null(names(x))) return(x)
   x[!nzchar(names(x))]
+}
+
+sub_in_plan <- function(plan, rows, at) {
+  for (index in rev(seq_along(at))) {
+    row <- at[index]
+    plan <- bind_plans(
+      plan[seq_len(row - 1), ],
+      rows[[index]],
+      plan[-seq_len(row), ]
+    )
+  }
+  plan
 }

--- a/tests/testthat/test-dsl.R
+++ b/tests/testthat/test-dsl.R
@@ -359,7 +359,7 @@ test_with_dir("more map", {
     ),
     winners = target(
       min(summ),
-      transform = combine(sum_fun, data),
+      transform = combine(summ, .by = c(sum_fun, data)),
       custom2 = 456L
     )
   )
@@ -407,7 +407,7 @@ test_with_dir("map on mtcars-like workflow", {
     ),
     winners = target(
       min(summ),
-      transform = combine(data, sum_fun)
+      transform = combine(summ, .by = c(data, sum_fun))
     )
   )
   exp <- drake_plan(
@@ -510,7 +510,7 @@ test_with_dir("dsl and custom columns", {
       ),
       winners = target(
         min(summ),
-        transform = combine(data, sum_fun),
+        transform = combine(summ, .by = c(data, sum_fun)),
         custom2 = 456L
       )
     )
@@ -627,7 +627,7 @@ test_with_dir("dsl .tag_out groupings", {
       rgfun(data),
       transform = cross(data = c(small, large), .tag_out = reg),
     ),
-    winners = target(min(reg), transform = combine(), a = 1),
+    winners = target(min(reg), transform = combine(reg), a = 1),
     trace = TRUE
   )
   exp <- drake_plan(
@@ -680,7 +680,7 @@ test_with_dir("combine() and tags", {
     y = target(1, transform = map(g = !!i, .tag_in = grp, .tag_out = targs)),
     z = target(
       min(targs),
-      transform = combine(grp, .tag_in = im, .tag_out = here)
+      transform = combine(targs, .by = grp, .tag_in = im, .tag_out = here)
     ),
     trace = TRUE
   )
@@ -783,7 +783,7 @@ test_with_dir("dsl with differently typed group levels", {
   plan2 <- drake_plan(
     reducks = target(
       combine_analyses(analysis),
-      transform = combine()
+      transform = combine(analysis)
     ),
     transform = FALSE
   )
@@ -885,7 +885,7 @@ test_with_dir("dsl: no NA levels in combine()", {
     ),
     summaries = target(
       compare_ds(data_sim),
-      transform = combine(local)
+      transform = combine(data_sim, .by = local)
     )
   )
   exp <- drake_plan(
@@ -905,7 +905,6 @@ test_with_dir("dsl: no NA levels in combine()", {
   equivalent_plans(out, exp)
 })
 
-
 test_with_dir("trace has correct provenance", {
   out <- drake_plan(
     trace = TRUE,
@@ -917,8 +916,8 @@ test_with_dir("trace has correct provenance", {
     f = target(c, transform = map(c)),
     g = target(b, transform = map(b)),
     h = target(a, transform = map(a)),
-    i = target(e, transform = combine()),
-    j = target(f, transform = combine())
+    i = target(e, transform = combine(e)),
+    j = target(f, transform = combine(f))
   )
   exp <- drake_plan(
     a_1_3 = target(
@@ -1116,7 +1115,7 @@ test_with_dir("row order does not matter", {
     ),
     trace = TRUE
   )
-  expect_equal(nrow(plan1, 15L))
+  expect_equal(nrow(plan1), 15L)
   equivalent_plans(plan1, plan2)
 })
 
@@ -1169,6 +1168,6 @@ test_with_dir("same test (row order) different plan", {
     ),
     large = simulate(64)
   )
-  expect_equal(nrow(plan1, 23L))
+  expect_equal(nrow(plan1), 23L)
   equivalent_plans(plan1, plan2)
 })

--- a/tests/testthat/test-dsl.R
+++ b/tests/testthat/test-dsl.R
@@ -239,6 +239,22 @@ test_with_dir("groups and command symbols are undefined", {
   equivalent_plans(out, exp)
 })
 
+test_with_dir("command symbols are for combine() but the plan has them", {
+  out <- drake_plan(
+    data = target(x, transform = map(x = c(1, 2))),
+    nope = target(x, transform = map(x = c(1, 2))),
+    winners = target(min(data, nope), transform = combine(data))
+  )
+  exp <- drake_plan(
+    data_1 = 1,
+    data_2 = 2,
+    nope_1 = 1,
+    nope_2 = 2,
+    winners = min(list(data_1, data_2), nope)
+  )
+  equivalent_plans(out, exp)
+})
+
 test_with_dir("dsl with different types", {
   plan <- drake_plan(
     a = target(1 + 1, transform = cross(x = c(1, 2))),

--- a/tests/testthat/test-dsl.R
+++ b/tests/testthat/test-dsl.R
@@ -264,11 +264,11 @@ test_with_dir("dsl with the mtcars plan", {
     ),
     winners = target(
       min(summ),
-      transform = combine(summ, by = c(sum_fun, data))
+      transform = combine(summ, .by = c(sum_fun, data))
     ),
     others = target(
       analyze(list(c(summ), c(data))),
-      transform = combine(summ, data, by = c(data, sum_fun))
+      transform = combine(summ, data, .by = c(data, sum_fun))
     ),
     final_winner = target(
       min(winners),

--- a/tests/testthat/test-dsl.R
+++ b/tests/testthat/test-dsl.R
@@ -854,7 +854,7 @@ test_with_dir("dsl: exact same plan as mtcars", {
     ),
     regression2 = target(
       reg2(data),
-      transform = map(data, .tag_out = reg),
+      transform = map(data = c(small, large), .tag_out = reg),
     ),
     summ = target(
       suppressWarnings(summary(reg$residuals)),
@@ -877,11 +877,17 @@ test_with_dir("dsl: no NA levels in combine()", {
     ),
     data_download = target(
       download_data(url = x),
-      transform = map(x = c("http://url_1", "http://url_2"), c(real, data))
+      transform = map(
+        x = c("http://url_1", "http://url_2"),
+        .tag_out = c(real, data)
+      )
     ),
     data_pkg = target(
       load_data_from_package(pkg = x),
-      transform = map(x = c("gapminder", "Ecdat"), c(local, real, data))
+      transform = map(
+        x = c("gapminder", "Ecdat"),
+        .tag_out = c(local, real, data)
+      )
     ),
     summaries = target(
       compare_ds(data_sim),

--- a/tests/testthat/test-dsl.R
+++ b/tests/testthat/test-dsl.R
@@ -264,15 +264,15 @@ test_with_dir("dsl with the mtcars plan", {
     ),
     winners = target(
       min(summ),
-      transform = combine(data, sum_fun)
+      transform = combine(summ, by = c(sum_fun, data))
     ),
     others = target(
       analyze(list(c(summ), c(data))),
-      transform = combine(data, sum_fun)
+      transform = combine(summ, data, by = c(data, sum_fun))
     ),
     final_winner = target(
       min(winners),
-      transform = combine()
+      transform = combine(winners)
     )
   )
   exp <- drake_plan(

--- a/tests/testthat/test-dsl.R
+++ b/tests/testthat/test-dsl.R
@@ -264,7 +264,7 @@ test_with_dir("dsl with the mtcars plan", {
     ),
     winners = target(
       min(summ),
-      transform = combine(summ, .by = c(sum_fun, data))
+      transform = combine(summ, .by = c(data, sum_fun))
     ),
     others = target(
       analyze(list(c(summ), c(data))),

--- a/tests/testthat/test-dsl.R
+++ b/tests/testthat/test-dsl.R
@@ -1070,3 +1070,51 @@ test_with_dir("trace has correct provenance", {
   )
   equivalent_plans(out, exp)
 })
+
+test_with_dir("row order does not matter", {
+  plan1 <- drake_plan(
+    coef = target(
+      suppressWarnings(summary(reg))$coefficients,
+      transform = map(reg)
+    ),
+    summ = target(
+      suppressWarnings(summary(reg$residuals)),
+      transform = map(reg)
+    ),
+    report = knit(knitr_in("report.Rmd"), file_out("report.md"), quiet = TRUE),
+    regression1 = target(
+      reg1(data),
+      transform = map(data = c(small, large), .tag_out = reg),
+    ),
+    regression2 = target(
+      reg2(data),
+      transform = map(data = c(small, large), .tag_out = reg),
+    ),
+    small = simulate(48),
+    large = simulate(64),
+    trace = TRUE
+  )
+  plan2 <- drake_plan(
+    small = simulate(48),
+    large = simulate(64),
+    report = knit(knitr_in("report.Rmd"), file_out("report.md"), quiet = TRUE),
+    regression2 = target(
+      reg2(data),
+      transform = map(data = c(small, large), .tag_out = reg),
+    ),
+    regression1 = target(
+      reg1(data),
+      transform = map(data = c(small, large), .tag_out = reg),
+    ),
+    summ = target(
+      suppressWarnings(summary(reg$residuals)),
+      transform = map(reg)
+    ),
+    coef = target(
+      suppressWarnings(summary(reg))$coefficients,
+      transform = map(reg)
+    ),
+    trace = TRUE
+  )
+  equivalent_plans(plan1, plan2)
+})


### PR DESCRIPTION
# Summary

1. Row order in the plan no longer matters when it comes to transformations. `drake` is now aware of the dependencies of the `map()`, `cross()`, and `combine()`, and it goes through them in the correct order regardless of the order the user writes them.
2. For that to happen, `combine()` needed an update: `combine(A, B, .by = c(C, D))` now works on symbols `A` and `B` in the commands and groups by `C` and `D`. 

Below, plans 1 and 2 are equivalent even though their transformations are arranged differently.

``` r
library(drake)

plan1 <- drake_plan(
  small = get_small_data(),
  large = get_large_data(),
  analysis = target( # Analyze each dataset once with a different mean.
    analyze(data, mean),
    transform = map(data = c(small, large), mean = c(1, 2))
  ),
  # Calculate 2 different performance metrics on every model fit.
  metric = target(
    metric_fun(analysis),
    # mse = mean squared error, mae = mean absolute error.
    # Assume these are functions you write.
    transform = cross(metric_fun = c(mse, mae), analysis)
  ),
  # Summarize the performance metrics for each dataset.
  summ_data = target(
    summary(metric),
    transform = combine(metric, .by = data)
  ),
  # Same, but for each metric type.
  summ_metric = target(
    summary(metric),
    transform = combine(metric, .by = metric_fun)
  )
)

plan1
#> # A tibble: 12 x 2
#>    target                command                                           
#>    <chr>                 <chr>                                             
#>  1 small                 get_small_data()                                  
#>  2 large                 get_large_data()                                  
#>  3 analysis_small_1      analyze(small, 1)                                 
#>  4 analysis_large_2      analyze(large, 2)                                 
#>  5 metric_mse_analysis_… mse(analysis_large_2)                             
#>  6 metric_mae_analysis_… mae(analysis_large_2)                             
#>  7 metric_mse_analysis_… mse(analysis_small_1)                             
#>  8 metric_mae_analysis_… mae(analysis_small_1)                             
#>  9 summ_data_large       summary(list(metric_mse_analysis_large_2, metric_…
#> 10 summ_data_small       summary(list(metric_mse_analysis_small_1, metric_…
#> 11 summ_metric_mae       summary(list(metric_mae_analysis_large_2, metric_…
#> 12 summ_metric_mse       summary(list(metric_mse_analysis_large_2, metric_…

config1 <- drake_config(plan1)
vis_drake_graph(config1)
```

![](https://i.imgur.com/a8HbqTj.png)

``` r

plan2 <- drake_plan(
  # Calculate 2 different performance metrics on every model fit.
  summ_metric = target(
    summary(metric),
    transform = combine(metric, .by = metric_fun)
  ),
  metric = target(
    metric_fun(analysis),
    # mse = mean squared error, mae = mean absolute error.
    # Assume these are functions you write.
    transform = cross(metric_fun = c(mse, mae), analysis)
  ),
  small = get_small_data(),
  analysis = target( # Analyze each dataset once with a different mean.
    analyze(data, mean),
    transform = map(data = c(small, large), mean = c(1, 2))
  ),
  # Summarize the performance metrics for each dataset.
  summ_data = target(
    summary(metric),
    transform = combine(metric, .by = data)
  ),
  large = get_large_data()
  # Same, but for each metric type.
)

plan2
#> # A tibble: 12 x 2
#>    target                command                                           
#>    <chr>                 <chr>                                             
#>  1 summ_metric_mae       summary(list(metric_mae_analysis_large_2, metric_…
#>  2 summ_metric_mse       summary(list(metric_mse_analysis_large_2, metric_…
#>  3 metric_mse_analysis_… mse(analysis_large_2)                             
#>  4 metric_mae_analysis_… mae(analysis_large_2)                             
#>  5 metric_mse_analysis_… mse(analysis_small_1)                             
#>  6 metric_mae_analysis_… mae(analysis_small_1)                             
#>  7 small                 get_small_data()                                  
#>  8 analysis_small_1      analyze(small, 1)                                 
#>  9 analysis_large_2      analyze(large, 2)                                 
#> 10 summ_data_large       summary(list(metric_mse_analysis_large_2, metric_…
#> 11 summ_data_small       summary(list(metric_mse_analysis_small_1, metric_…
#> 12 large                 get_large_data()

config2 <- drake_config(plan2)
vis_drake_graph(config2)
```

![](https://i.imgur.com/QeABQWu.png)

<sup>Created on 2019-01-24 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

# Related GitHub issues and pull requests

- Ref: #691

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
