### PR TITLE
Custom grouping functions in the DSL

### DIFF
--- a/R/api-dsl.R
+++ b/R/api-dsl.R
@@ -137,7 +137,7 @@ dsl_transform.cross <- dsl_transform.map <- map_to_grid
 
 dsl_transform.combine <- function(transform, target, row, plan) {
   old_cols <- old_cols(plan)
-  cols_keep <- union(dsl_by(transform), dsl_combine(transform))
+  cols_keep <- union(dsl_by(transform), names(dsl_combine(transform)))
   rows_keep <- complete_cases(plan[, cols_keep, drop = FALSE])
   if (!length(rows_keep) || !any(rows_keep)) {
     row[["transform"]][[1]] <- NA
@@ -158,24 +158,33 @@ dsl_transform.combine <- function(transform, target, row, plan) {
 }
 
 combine_step <- function(plan, row, transform, old_cols) {
-  aggregates <- lapply(
-    X = plan[, dsl_combine(transform), drop = FALSE],
-    FUN = function(x) {
-      unname(lapply(as.character(na_omit(unique(x))), as.symbol))
-    }
-  )
+  env <- env_combine(plan, transform)
   out <- data.frame(command = NA, stringsAsFactors = FALSE)
   for (col in setdiff(old_cols, c("target", "transform"))) {
-    out[[col]] <- list(substitute_list(row[[col]][[1]], aggregates))
+    out[[col]] <- list(
+      eval(call("substitute", row[[col]][[1]], env), envir = baseenv())
+    )
   }
   out
 }
 
-substitute_list <- function(expr, env) {
-  env <- lapply(env, function(lst) {
-    as.call(c(quote(list), lst))
-  })
-  eval(call("substitute", expr, env), envir = baseenv())
+env_combine <- function(plan, transform) {
+  out <- lapply(
+    names(dsl_combine(transform)),
+    env_combine_entry,
+    plan = plan,
+    transform = transform
+  )
+  names(out) <- names(dsl_combine(transform))
+  out
+}
+
+env_combine_entry <- function(name, transform, plan) {
+  grouping_call <- dsl_combine(transform)[[name]]
+  levels <- unname(
+    lapply(as.character(na_omit(unique(plan[[name]]))), as.symbol)
+  )
+  as.call(c(grouping_call[[1]], levels, as.list(grouping_call[-1])))
 }
 
 lang <- function(...) UseMethod("lang")
@@ -257,7 +266,7 @@ dsl_deps.map <- dsl_deps.cross <- function(transform) {
 
 dsl_deps.combine <- function(transform) {
   attr(transform, "deps") %|||% c(
-    as.character(unnamed(transform[[1]][-1])),
+    names(dsl_combine(transform)),
     dsl_by(transform)
   )
 }
@@ -272,8 +281,28 @@ dsl_by.combine <- function(transform) {
 dsl_combine <- function(...) UseMethod("dsl_combine")
 
 dsl_combine.combine <- function(transform) {
-  attr(transform, "combine") %|||%
-    as.character(unnamed(lang(transform))[-1])
+  if (!is.null(attr(transform, "combine"))) {
+    return(attr(transform, "combine"))
+  }
+  expr <- lang(transform)
+  if (length(as.character(unnamed(expr)[-1]))) {
+    stop(
+      "please supply a grouping function to each grouping variable in ",
+      "combine(), e.g. combine(data = list()) instead of combine(data).",
+      call. = FALSE
+    )
+  }
+  named <- named(as.list(expr))
+  names <- names(named)
+  named <- named[setdiff(names(named), c(".by", dsl_all_special))]
+  named <- lapply(named, function(x) {
+    if (is.symbol(x)) {
+      x <- as.call(c(x))
+    }
+    x
+  })
+  names(named) <- names
+  named
 }
 
 new_groupings <- function(...) UseMethod("new_groupings")

--- a/R/api-dsl.R
+++ b/R/api-dsl.R
@@ -293,8 +293,8 @@ dsl_combine.combine <- function(transform) {
     )
   }
   named <- named(as.list(expr))
-  names <- names(named)
   named <- named[setdiff(names(named), c(".by", dsl_all_special))]
+  names <- names(named)
   named <- lapply(named, function(x) {
     if (is.symbol(x)) {
       x <- as.call(c(x))

--- a/R/api-plan.R
+++ b/R/api-plan.R
@@ -90,7 +90,7 @@
 #'   ), 
 #'   winners = target(
 #'     min(summ),
-#'     transform = combine(data, sum_fun)
+#'     transform = combine(data = list(), sum_fun = list())
 #'   )
 #' )
 #'
@@ -111,7 +111,7 @@
 #'   ), 
 #'   winners = target(
 #'     min(summ),
-#'     transform = combine(data, sum_fun)
+#'     transform = combine(data = list(), sum_fun = list())
 #'   ),
 #'   trace = TRUE
 #' )

--- a/man/drake_plan.Rd
+++ b/man/drake_plan.Rd
@@ -111,7 +111,7 @@ drake_plan(
   ), 
   winners = target(
     min(summ),
-    transform = combine(data, sum_fun)
+    transform = combine(data = list(), sum_fun = list())
   )
 )
 
@@ -132,7 +132,7 @@ drake_plan(
   ), 
   winners = target(
     min(summ),
-    transform = combine(data, sum_fun)
+    transform = combine(data = list(), sum_fun = list())
   ),
   trace = TRUE
 )

--- a/tests/testthat/test-dsl.R
+++ b/tests/testthat/test-dsl.R
@@ -266,7 +266,7 @@ test_with_dir("groups and command symbols are undefined", {
     large = simulate(64),
     lots = target(nobody(home), transform = cross(a, b)),
     mots = target(everyone(out), transform = map(c, d)),
-    winners = target(min(nobodyhome), transform = combine(data))
+    winners = target(min(nobodyhome), transform = combine(data = list()))
   )
   exp <- drake_plan(
     small = simulate(48),
@@ -282,7 +282,7 @@ test_with_dir("command symbols are for combine() but the plan has them", {
   out <- drake_plan(
     data = target(x, transform = map(x = c(1, 2))),
     nope = target(x, transform = map(x = c(1, 2))),
-    winners = target(min(data, nope), transform = combine(data))
+    winners = target(min(data, nope), transform = combine(data = list()))
   )
   exp <- drake_plan(
     data_1 = 1,
@@ -320,15 +320,19 @@ test_with_dir("dsl with the mtcars plan", {
     ),
     winners = target(
       min(summ),
-      transform = combine(summ, .by = c(data, sum_fun))
+      transform = combine(summ = list(), .by = c(data, sum_fun))
     ),
     others = target(
       analyze(list(c(summ), c(data))),
-      transform = combine(summ, data, .by = c(data, sum_fun))
+      transform = combine(
+        summ = list(),
+        data = list(),
+        .by = c(data, sum_fun)
+      )
     ),
     final_winner = target(
       min(winners),
-      transform = combine(winners)
+      transform = combine(winners = list())
     )
   )
   exp <- drake_plan(
@@ -415,7 +419,7 @@ test_with_dir("more map", {
     ),
     winners = target(
       min(summ),
-      transform = combine(summ, .by = c(sum_fun, data)),
+      transform = combine(summ = list(), .by = c(sum_fun, data)),
       custom2 = 456L
     )
   )
@@ -463,7 +467,7 @@ test_with_dir("map on mtcars-like workflow", {
     ),
     winners = target(
       min(summ),
-      transform = combine(summ, .by = c(data, sum_fun))
+      transform = combine(summ = list(), .by = c(data, sum_fun))
     )
   )
   exp <- drake_plan(
@@ -566,7 +570,7 @@ test_with_dir("dsl and custom columns", {
       ),
       winners = target(
         min(summ),
-        transform = combine(summ, .by = c(data, sum_fun)),
+        transform = combine(summ = list(), .by = c(data, sum_fun)),
         custom2 = 456L
       )
     )
@@ -618,7 +622,7 @@ test_with_dir("dsl trace", {
     ),
     winners = target(
       min(summ),
-      transform = combine(data, sum_fun)
+      transform = combine(data = list(), sum_fun = list())
     ),
     trace = FALSE
   )
@@ -637,7 +641,7 @@ test_with_dir("dsl trace", {
     ),
     winners = target(
       min(summ),
-      transform = combine(data, sum_fun)
+      transform = combine(data = list(), sum_fun = list())
     ),
     trace = TRUE
   )
@@ -689,7 +693,7 @@ test_with_dir("dsl .tag_out groupings", {
       rgfun(data),
       transform = cross(data = c(small, large), .tag_out = reg)
     ),
-    winners = target(min(reg), transform = combine(reg), a = 1),
+    winners = target(min(reg), transform = combine(reg = list()), a = 1),
     trace = TRUE
   )
   exp <- drake_plan(
@@ -742,7 +746,12 @@ test_with_dir("combine() and tags", {
     y = target(1, transform = map(g = !!i, .tag_in = grp, .tag_out = targs)),
     z = target(
       min(targs),
-      transform = combine(targs, .by = grp, .tag_in = im, .tag_out = here)
+      transform = combine(
+        targs = list(),
+        .by = grp,
+        .tag_in = im,
+        .tag_out = here
+      )
     ),
     trace = TRUE
   )
@@ -823,7 +832,7 @@ test_with_dir("can disable transformations in dsl", {
     ),
     winners = target(
       min(reg),
-      transform = combine(data),
+      transform = combine(data = list()),
       a = 1
     ),
     transform = FALSE
@@ -845,7 +854,7 @@ test_with_dir("dsl with differently typed group levels", {
   plan2 <- drake_plan(
     reducks = target(
       combine_analyses(analysis),
-      transform = combine(analysis)
+      transform = combine(analysis = list())
     ),
     transform = FALSE
   )
@@ -1120,7 +1129,7 @@ test_with_dir("dsl: no NA levels in combine()", {
   out <- drake_plan(
     data_sim = target(
       sim_data(mean = x, sd = y),
-      transform = cross(x = c(1, 2), y = c(3, 4), .tag_out = c(data, local)),
+      transform = cross(x = c(1, 2), y = c(3, 4), .tag_out = c(data, local))
     ),
     data_download = target(
       download_data(url = x),
@@ -1138,7 +1147,7 @@ test_with_dir("dsl: no NA levels in combine()", {
     ),
     summaries = target(
       compare_ds(data_sim),
-      transform = combine(data_sim, .by = local)
+      transform = combine(data_sim = list(), .by = local)
     )
   )
   exp <- drake_plan(
@@ -1169,8 +1178,8 @@ test_with_dir("trace has correct provenance", {
     f = target(c, transform = map(c)),
     g = target(b, transform = map(b)),
     h = target(a, transform = map(a)),
-    i = target(e, transform = combine(e)),
-    j = target(f, transform = combine(f))
+    i = target(e, transform = combine(e = list())),
+    j = target(f, transform = combine(f = list()))
   )
   exp <- drake_plan(
     a_1_3 = target(
@@ -1386,21 +1395,25 @@ test_with_dir("same test (row order) different plan", {
     ),
     winners = target(
       min(summ),
-      transform = combine(summ, .by = c(data, sum_fun))
+      transform = combine(summ = list(), .by = c(data, sum_fun))
     ),
     others = target(
       analyze(list(c(summ), c(data))),
-      transform = combine(summ, data, .by = c(data, sum_fun))
+      transform = combine(
+        summ = list(),
+        data = list(),
+        .by = c(data, sum_fun)
+      )
     ),
     final_winner = target(
       min(winners),
-      transform = combine(winners)
+      transform = combine(winners = list())
     )
   )
   plan2 <- drake_plan(
     final_winner = target(
       min(winners),
-      transform = combine(winners)
+      transform = combine(winners = list())
     ),
     reg = target(
       reg_fun(data),
@@ -1413,11 +1426,15 @@ test_with_dir("same test (row order) different plan", {
     ),
     others = target(
       analyze(list(c(summ), c(data))),
-      transform = combine(summ, data, .by = c(data, sum_fun))
+      transform = combine(
+        summ = list(),
+        data = list(),
+        .by = c(data, sum_fun)
+      )
     ),
     winners = target(
       min(summ),
-      transform = combine(summ, .by = c(data, sum_fun))
+      transform = combine(summ = list(), .by = c(data, sum_fun))
     ),
     large = simulate(64)
   )
@@ -1480,17 +1497,21 @@ test_with_dir("transformations in triggers", {
     winners = target(
       min(summ),
       trigger = trigger(change = min(summ)),
-      transform = combine(summ, .by = c(data, sum_fun))
+      transform = combine(summ = list(), .by = c(data, sum_fun))
     ),
     others = target(
       analyze(list(c(summ), c(data))),
       trigger = trigger(change = analyze(list(c(summ), c(data)))),
-      transform = combine(summ, data, .by = c(data, sum_fun))
+      transform = combine(
+        summ = list(),
+        data = list(),
+        .by = c(data, sum_fun)
+      )
     ),
     final_winner = target(
       min(winners),
       trigger = trigger(change = min(winners)),
-      transform = combine(winners)
+      transform = combine(winners = list())
     )
   )
   exp <- drake_plan(
@@ -1709,7 +1730,7 @@ test_with_dir(".id = FALSE", {
   out <- drake_plan(
     a = target(c(x, y), transform = cross(x = !!x_, y = !!y_, .id = FALSE)),
     b = target(c(a, z), transform = map(a, z = !!z_, .id = FALSE)),
-    d = target(b, transform = combine(b, .by = x, .id = FALSE))
+    d = target(b, transform = combine(b = list(), .by = x, .id = FALSE))
   )
   exp <- drake_plan(
     a = c("a", "c"),
@@ -1736,7 +1757,7 @@ test_with_dir("(1) .id = syms. (2) map() finds the correct cross() syms", {
       transform = cross(x = !!x_, y = !!y_, z = !!z_, .id = z)
     ),
     B = target(c(A, y, z), transform = map(A, y, z, .id = c(y, z))),
-    C = target(B, transform = combine(B, .by = c(x, y), .id = bad))
+    C = target(B, transform = combine(B = list(), .by = c(x, y), .id = bad))
   )
   # nolint start
   exp <- drake_plan(
@@ -1797,7 +1818,7 @@ test_with_dir("unequal trace vars are not duplicated in map()", {
       transform = map(a = !!inputs, type = !!types) ),
     prelim = target(
       preliminary(wide1),
-      transform = combine(wide1, .by = type) ),
+      transform = combine(wide1 = list(), .by = type) ),
     main = target(
       expensive_calc(prelim),
       transform = map(prelim)
@@ -1827,8 +1848,8 @@ test_with_dir("commands from combine() produce the correct values", {
   x_ <- letters[1:2]
   plan <- drake_plan(
     A = target(x, transform = map(x = !!x_)),
-    B = target(A, transform = combine(A)),
-    C = target(c(A), transform = combine(A)),
+    B = target(A, transform = combine(A = list())),
+    C = target(c(A), transform = combine(A = list())),
     trace = TRUE
   )
   cache <- storr::storr_environment()
@@ -1924,7 +1945,7 @@ test_with_dir("grid for GitHub issue 710", {
     ),
     serial = target(
       expensive_calc(wide),
-      transform = combine(wide, .by = type)
+      transform = combine(wide = list(), .by = type)
     ),
     dist = target(
       distribute_results(serial_, wide_),

--- a/tests/testthat/test-dsl.R
+++ b/tests/testthat/test-dsl.R
@@ -2012,3 +2012,20 @@ test_with_dir("combine() with complicated calls", {
   )
   equivalent_plans(out, exp)
 })
+
+test_with_dir("each grouping var in combine() needs a grouping fn", {
+  expect_error(
+    drake_plan(
+      data = target(
+        get_data(param),
+        transform = map(param = c(1, 2))
+      ),
+      results = target(
+        .data %>%
+          data,
+        transform = combine(data)
+      )
+    ),
+    regexp = "please supply a grouping function to each grouping variable"
+  )
+})

--- a/tests/testthat/test-dsl.R
+++ b/tests/testthat/test-dsl.R
@@ -1968,3 +1968,47 @@ test_with_dir("grid for GitHub issue 710", {
   )
   equivalent_plans(out, exp)
 })
+
+test_with_dir("combine() with symbols instead of calls", {
+  out <- drake_plan(
+    data = target(
+      get_data(param),
+      transform = map(param = c(1, 2))
+    ),
+    results = target(
+      .data %>%
+        data,
+      transform = combine(data = select)
+    )
+  )
+  exp <- drake_plan(
+    data_1 = get_data(1),
+    data_2 = get_data(2),
+    results = .data %>% select(data_1, data_2)
+  )
+  equivalent_plans(out, exp)
+})
+
+test_with_dir("combine() with complicated calls", {
+  out <- drake_plan(
+    data = target(
+      get_data(param),
+      transform = map(param = c(1, 2))
+    ),
+    results = target(
+      .data %>%
+        c(data, 2, data),
+      transform = combine(data = min(0, na.rm = FALSE))
+    )
+  )
+  exp <- drake_plan(
+    data_1 = get_data(1),
+    data_2 = get_data(2),
+    results = .data %>% c(
+      min(data_1, data_2, 0, na.rm = FALSE),
+      2,
+      min(data_1, data_2, 0, na.rm = FALSE)
+    )
+  )
+  equivalent_plans(out, exp)
+})

--- a/tests/testthat/test-dsl.R
+++ b/tests/testthat/test-dsl.R
@@ -22,7 +22,7 @@ test_with_dir("1 grouping level", {
   out <- drake_plan(
     a = target(x, transform = cross(x = 1)),
     b = target(a, transform = map(a)),
-    c = target(b, transform = combine(b))
+    c = target(b, transform = combine(b = list()))
   )
   exp <- drake_plan(
     a_1 = 1,


### PR DESCRIPTION
# Summary

In the current DSL, `combine(stuff)` always gathers targets into lists, which is too limiting. This PR allows users to supply custom grouping functions. 

``` r
library(drake)
drake_plan(
  data = target(
    get_data(param),
    transform = map(param = c(1, 2))
  ),
  results = target(
    .data %>%
      data,
    transform = combine(data = select)
  )
)
#> # A tibble: 3 x 2
#>   target  command                         
#>   <chr>   <expr>                          
#> 1 data_1  get_data(1)                     
#> 2 data_2  get_data(2)                     
#> 3 results .data %>% select(data_1, data_2)
```

<sup>Created on 2019-02-10 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

``` r
library(drake)
drake_plan(
  data = target(
    get_data(param),
    transform = map(param = c(1, 2))
  ),
  results = target(
    .data %>%
      data,
    transform = combine(data = min(0, na.rm = FALSE))
  )
)
#> # A tibble: 3 x 2
#>   target  command                                        
#>   <chr>   <expr>                                         
#> 1 data_1  get_data(1)                                    
#> 2 data_2  get_data(2)                                    
#> 3 results .data %>% min(data_1, data_2, 0, na.rm = FALSE)
```

<sup>Created on 2019-02-10 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

The following is equivalent to the current DSL.

``` r
library(drake)
drake_plan(
  data = target(
    get_data(param),
    transform = map(param = c(1, 2))
  ),
  results = target(
    .data %>%
      data,
    transform = combine(data = list())
  )
)
#> # A tibble: 3 x 2
#>   target  command                       
#>   <chr>   <expr>                        
#> 1 data_1  get_data(1)                   
#> 2 data_2  get_data(2)                   
#> 3 results .data %>% list(data_1, data_2)
```

<sup>Created on 2019-02-10 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

One new restriction: you must always supply a grouping call to every grouping variable.

``` r
library(drake)
drake_plan(
  data = target(
    get_data(param),
    transform = map(param = c(1, 2))
  ),
  results = target(
    .data %>%
      data,
    transform = combine(data)
  )
)
#> Error: please supply a grouping function to each grouping variable in combine(), e.g. combine(data = list()) instead of combine(data).
```

<sup>Created on 2019-02-10 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

This API is not as powerful or flexible as tidy evaluation's unquote-splice operator (`!!!`) but it is still very powerful and it fits `drake`'s DSL very nicely.

cc @tmastny 

# Related GitHub issues and pull requests

- Ref: #724

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
