### PR TITLE
Make DSL target names less awkward

### DIFF
--- a/R/api-dsl.R
+++ b/R/api-dsl.R
@@ -178,11 +178,11 @@ new_targets <- function(target, grid, cols, id) {
   grid <- grid[, cols, drop = FALSE]
   if (identical(id, FALSE) || any(dim(grid) < 1L)) {
     out <- rep(target, nrow(grid))
-    return(make.names(out, unique = TRUE))
+    return(make_unique(make.names(out, unique = FALSE, allow_ = TRUE)))
   }
   suffixes <- apply(grid, 1, paste, collapse = "_")
   out <- paste0(target, "_", suffixes)
-  make.names(out, unique = TRUE)
+  make_unique(make.names(out, unique = FALSE, allow_ = TRUE))
 }
 
 dsl_transform <- function(...) {

--- a/R/api-wildcards.R
+++ b/R/api-wildcards.R
@@ -218,8 +218,8 @@ evaluate_single_wildcard <- function(
   if (!any(matches)) {
     return(plan)
   }
-  major <- make.names(tempfile())
-  minor <- make.names(tempfile())
+  major <- make.names(tempfile(), unique = FALSE, allow_ = TRUE)
+  minor <- make.names(tempfile(), unique = FALSE, allow_ = TRUE)
   plan[[major]] <- seq_len(nrow(plan))
   plan[[minor]] <- plan[[major]]
   matching <- plan[matches, ]

--- a/R/preprocess-sanitize.R
+++ b/R/preprocess-sanitize.R
@@ -50,7 +50,7 @@ sanitize_nodes <- function(nodes, choices) {
 }
 
 repair_target_names <- function(x) {
-  make.names(x, unique = FALSE)
+  make.names(x, unique = FALSE, allow_ = TRUE)
 }
 
 arrange_plan_cols <- function(plan) {

--- a/R/utils-knitr.R
+++ b/R/utils-knitr.R
@@ -57,7 +57,7 @@ safe_get_tangled_frags <- function(file) {
 # From https://github.com/duncantl/CodeDepends/blob/master/R/sweave.R#L15
 get_tangled_frags <- function(doc) {
   assert_pkg("knitr")
-  id <- make.names(tempfile())
+  id <- make.names(tempfile(), unique = FALSE, allow_ = TRUE)
   con <- textConnection(id, "w", local = TRUE)
   on.exit(close(con))
   with_options(

--- a/R/utils-utils.R
+++ b/R/utils-utils.R
@@ -434,3 +434,17 @@ targets_from_dots <- function(dots, list) {
   targets <- unique(c(names, list))
   standardize_key(targets)
 }
+
+make_unique <- function(x) {
+  if (!length(x)) {
+    return(character(0))
+  }
+  ord <- order(x)
+  y <- x[ord]
+  dup <- duplicated(y)
+  suffix <- as.integer(do.call(c, tapply(dup, y, FUN = cumsum)))
+  i <- suffix > 0L
+  suffix <- suffix + i
+  y[i] <- paste(y[i], suffix[i], sep = "_")
+  y[order(ord)]
+}

--- a/R/utils-utils.R
+++ b/R/utils-utils.R
@@ -442,7 +442,12 @@ make_unique <- function(x) {
   ord <- order(x)
   y <- x[ord]
   dup <- duplicated(y)
-  suffix <- as.integer(do.call(c, tapply(dup, y, FUN = cumsum)))
+  if (!any(dup)) {
+    return(x)
+  }
+  suffix <- as.integer(
+    do.call(c, tapply(dup, y, FUN = cumsum, simplify = FALSE))
+  )
   i <- suffix > 0L
   suffix <- suffix + i
   y[i] <- paste(y[i], suffix[i], sep = "_")

--- a/tests/testthat/test-dsl.R
+++ b/tests/testthat/test-dsl.R
@@ -90,10 +90,10 @@ test_with_dir("replicates", {
       x = "1",
       a = "a_1"
     ),
-    a_1.1 = target(
+    a_1_2 = target(
       command = 1,
       x = "1",
-      a = "a_1.1"
+      a = "a_1_2"
     ),
     b_a_1 = target(
       command = f(a_1),
@@ -101,11 +101,11 @@ test_with_dir("replicates", {
       a = "a_1",
       b = "b_a_1"
     ),
-    b_a_1.1 = target(
-      command = f(a_1.1),
+    b_a_1_2 = target(
+      command = f(a_1_2),
       x = "1",
-      a = "a_1.1",
-      b = "b_a_1.1"
+      a = "a_1_2",
+      b = "b_a_1_2"
     )
   )
   equivalent_plans(out, exp)
@@ -1266,11 +1266,11 @@ test_with_dir("trace has correct provenance", {
       y = "3",
       a = "a_1_3"
     ),
-    a_1_3.1 = target(
+    a_1_3_2 = target(
       command = 1,
       x = "1",
       y = "3",
-      a = "a_1_3.1"
+      a = "a_1_3_2"
     ),
     b_a_1_3 = target(
       command = a_1_3,
@@ -1279,12 +1279,12 @@ test_with_dir("trace has correct provenance", {
       a = "a_1_3",
       b = "b_a_1_3"
     ),
-    b_a_1_3.1 = target(
-      command = a_1_3.1,
+    b_a_1_3_2 = target(
+      command = a_1_3_2,
       x = "1",
       y = "3",
-      a = "a_1_3.1",
-      b = "b_a_1_3.1"
+      a = "a_1_3_2",
+      b = "b_a_1_3_2"
     ),
     c_b_a_1_3 = target(
       command = b_a_1_3,
@@ -1294,13 +1294,13 @@ test_with_dir("trace has correct provenance", {
       b = "b_a_1_3",
       c = "c_b_a_1_3"
     ),
-    c_b_a_1_3.1 = target(
-      command = b_a_1_3.1,
+    c_b_a_1_3_2 = target(
+      command = b_a_1_3_2,
       x = "1",
       y = "3",
-      a = "a_1_3.1",
-      b = "b_a_1_3.1",
-      c = "c_b_a_1_3.1"
+      a = "a_1_3_2",
+      b = "b_a_1_3_2",
+      c = "c_b_a_1_3_2"
     ),
     d_b_a_1_3_c_b_a_1_3 = target(
       command = b_a_1_3,
@@ -1311,26 +1311,26 @@ test_with_dir("trace has correct provenance", {
       c = "c_b_a_1_3",
       d = "d_b_a_1_3_c_b_a_1_3"
     ),
-    d_b_a_1_3_c_b_a_1_3.1 = target(
+    d_b_a_1_3_c_b_a_1_3_2 = target(
       command = b_a_1_3,
       b = "b_a_1_3",
-      c = "c_b_a_1_3.1",
-      d = "d_b_a_1_3_c_b_a_1_3.1"
+      c = "c_b_a_1_3_2",
+      d = "d_b_a_1_3_c_b_a_1_3_2"
     ),
-    d_b_a_1_3.1_c_b_a_1_3 = target(
-      command = b_a_1_3.1,
-      b = "b_a_1_3.1",
+    d_b_a_1_3_2_c_b_a_1_3 = target(
+      command = b_a_1_3_2,
+      b = "b_a_1_3_2",
       c = "c_b_a_1_3",
-      d = "d_b_a_1_3.1_c_b_a_1_3"
+      d = "d_b_a_1_3_2_c_b_a_1_3"
     ),
-    d_b_a_1_3.1_c_b_a_1_3.1 = target(
-      command = b_a_1_3.1,
+    d_b_a_1_3_2_c_b_a_1_3_2 = target(
+      command = b_a_1_3_2,
       x = "1",
       y = "3",
-      a = "a_1_3.1",
-      b = "b_a_1_3.1",
-      c = "c_b_a_1_3.1",
-      d = "d_b_a_1_3.1_c_b_a_1_3.1"
+      a = "a_1_3_2",
+      b = "b_a_1_3_2",
+      c = "c_b_a_1_3_2",
+      d = "d_b_a_1_3_2_c_b_a_1_3_2"
     ),
     e_c_b_a_1_3 = target(
       command = c_b_a_1_3,
@@ -1341,14 +1341,14 @@ test_with_dir("trace has correct provenance", {
       c = "c_b_a_1_3",
       e = "e_c_b_a_1_3"
     ),
-    e_c_b_a_1_3.1 = target(
-      command = c_b_a_1_3.1,
+    e_c_b_a_1_3_2 = target(
+      command = c_b_a_1_3_2,
       x = "1",
       y = "3",
-      a = "a_1_3.1",
-      b = "b_a_1_3.1",
-      c = "c_b_a_1_3.1",
-      e = "e_c_b_a_1_3.1"
+      a = "a_1_3_2",
+      b = "b_a_1_3_2",
+      c = "c_b_a_1_3_2",
+      e = "e_c_b_a_1_3_2"
     ),
     f_c_b_a_1_3 = target(
       command = c_b_a_1_3,
@@ -1359,14 +1359,14 @@ test_with_dir("trace has correct provenance", {
       c = "c_b_a_1_3",
       f = "f_c_b_a_1_3"
     ),
-    f_c_b_a_1_3.1 = target(
-      command = c_b_a_1_3.1,
+    f_c_b_a_1_3_2 = target(
+      command = c_b_a_1_3_2,
       x = "1",
       y = "3",
-      a = "a_1_3.1",
-      b = "b_a_1_3.1",
-      c = "c_b_a_1_3.1",
-      f = "f_c_b_a_1_3.1"
+      a = "a_1_3_2",
+      b = "b_a_1_3_2",
+      c = "c_b_a_1_3_2",
+      f = "f_c_b_a_1_3_2"
     ),
     g_b_a_1_3 = target(
       command = b_a_1_3,
@@ -1376,13 +1376,13 @@ test_with_dir("trace has correct provenance", {
       b = "b_a_1_3",
       g = "g_b_a_1_3"
     ),
-    g_b_a_1_3.1 = target(
-      command = b_a_1_3.1,
+    g_b_a_1_3_2 = target(
+      command = b_a_1_3_2,
       x = "1",
       y = "3",
-      a = "a_1_3.1",
-      b = "b_a_1_3.1",
-      g = "g_b_a_1_3.1"
+      a = "a_1_3_2",
+      b = "b_a_1_3_2",
+      g = "g_b_a_1_3_2"
     ),
     h_a_1_3 = target(
       command = a_1_3,
@@ -1391,19 +1391,19 @@ test_with_dir("trace has correct provenance", {
       a = "a_1_3",
       h = "h_a_1_3"
     ),
-    h_a_1_3.1 = target(
-      command = a_1_3.1,
+    h_a_1_3_2 = target(
+      command = a_1_3_2,
       x = "1",
       y = "3",
-      a = "a_1_3.1",
-      h = "h_a_1_3.1"
+      a = "a_1_3_2",
+      h = "h_a_1_3_2"
     ),
     i = target(
-      command = list(e_c_b_a_1_3, e_c_b_a_1_3.1),
+      command = list(e_c_b_a_1_3, e_c_b_a_1_3_2),
       i = "i"
     ),
     j = target(
-      command = list(f_c_b_a_1_3, f_c_b_a_1_3.1),
+      command = list(f_c_b_a_1_3, f_c_b_a_1_3_2),
       j = "j"
     )
   )
@@ -1796,15 +1796,15 @@ test_with_dir(".id = FALSE", {
   )
   exp <- drake_plan(
     a = c("a", "c"),
-    a.1 = c("b", "c"),
-    a.2 = c("a", "d"),
-    a.3 = c("b", "d"),
+    a_2 = c("b", "c"),
+    a_3 = c("a", "d"),
+    a_4 = c("b", "d"),
     b = c(a, "k"),
-    b.1 = c(a.1, "l"),
-    b.2 = c(a.2, "m"),
-    b.3 = c(a.3, "n"),
-    d = list(b, b.2),
-    d.1 = list(b.1, b.3)
+    b_2 = c(a_2, "l"),
+    b_3 = c(a_3, "m"),
+    b_4 = c(a_4, "n"),
+    d = list(b, b_3),
+    d_2 = list(b_2, b_4)
   )
   equivalent_plans(out, exp)
 })
@@ -1824,33 +1824,33 @@ test_with_dir("(1) .id = syms. (2) map() finds the correct cross() syms", {
   # nolint start
   exp <- drake_plan(
     A_.k. = c("a", "c", "k"),
-    A_.k..1 = c("b", "c", "k"),
-    A_.k..2 = c("a", "d", "k"),
-    A_.k..3 = c("b", "d", "k"),
+    A_.k._2 = c("b", "c", "k"),
+    A_.k._3 = c("a", "d", "k"),
+    A_.k._4 = c("b", "d", "k"),
     A_.l. = c("a", "c", "l"),
-    A_.l..1 = c("b", "c", "l"),
-    A_.l..2 = c("a", "d", "l"),
-    A_.l..3 = c("b", "d", "l"),
+    A_.l._2 = c("b", "c", "l"),
+    A_.l._3 = c("a", "d", "l"),
+    A_.l._4 = c("b", "d", "l"),
     B_.c._.k. = c(A_.k., "c", "k"),
-    B_.c._.k..1 = c(A_.k..1, "c", "k"),
-    B_.d._.k. = c(A_.k..2, "d", "k"),
-    B_.d._.k..1 = c(A_.k..3, "d", "k"),
+    B_.c._.k._2 = c(A_.k._2, "c", "k"),
+    B_.d._.k. = c(A_.k._3, "d", "k"),
+    B_.d._.k._2 = c(A_.k._4, "d", "k"),
     B_.c._.l. = c(A_.l., "c", "l"),
-    B_.c._.l..1 = c(A_.l..1, "c", "l"),
-    B_.d._.l. = c(A_.l..2, "d", "l"),
-    B_.d._.l..1 = c(A_.l..3, "d", "l"),
+    B_.c._.l._2 = c(A_.l._2, "c", "l"),
+    B_.d._.l. = c(A_.l._3, "d", "l"),
+    B_.d._.l._2 = c(A_.l._4, "d", "l"),
     C = list(B_.c._.k., B_.c._.l.),
-    C.1 = list(B_.c._.k..1, B_.c._.l..1),
-    C.2 = list(B_.d._.k., B_.d._.l.),
-    C.3 = list(B_.d._.k..1, B_.d._.l..1)
+    C_2 = list(B_.c._.k._2, B_.c._.l._2),
+    C_3 = list(B_.d._.k., B_.d._.l.),
+    C_4 = list(B_.d._.k._2, B_.d._.l._2)
   )
   # nolint end
   equivalent_plans(out, exp)
 })
 
 test_with_dir("upstream .id columns are available", {
-  factor_a_ <- c(0.4, 0.5, 0.6, 0.7, 0.8)
-  factor_b_ <- 0.1
+  factor_a_ <- as.character(c(4, 5, 6, 7, 8))
+  factor_b_ <- "2"
   out <- drake_plan(
     raw_data = get_data(),
     data = clean_data(raw_data),
@@ -1869,19 +1869,19 @@ test_with_dir("upstream .id columns are available", {
   exp <- drake_plan(
     raw_data = get_data(),
     data = clean_data(raw_data),
-    analysis_0.4_0.1 = data %>% filter(factor_a == 0.4 & factor_b == 0.1),
-    analysis_0.5_0.1 = data %>% filter(factor_a == 0.5 & factor_b == 0.1),
-    analysis_0.6_0.1 = data %>% filter(factor_a == 0.6 & factor_b == 0.1),
-    analysis_0.7_0.1 = data %>% filter(factor_a == 0.7 & factor_b == 0.1),
-    analysis_0.8_0.1 = data %>% filter(factor_a == 0.8 & factor_b == 0.1),
-    summary_0.4_0.1 = my_summarize(analysis_0.4_0.1),
-    summary_0.5_0.1 = my_summarize(analysis_0.5_0.1),
-    summary_0.6_0.1 = my_summarize(analysis_0.6_0.1),
-    summary_0.7_0.1 = my_summarize(analysis_0.7_0.1),
-    summary_0.8_0.1 = my_summarize(analysis_0.8_0.1),
+    analysis_.4._.2. = data %>% filter(factor_a == "4" & factor_b == "2"),
+    analysis_.5._.2. = data %>% filter(factor_a == "5" & factor_b == "2"),
+    analysis_.6._.2. = data %>% filter(factor_a == "6" & factor_b == "2"),
+    analysis_.7._.2. = data %>% filter(factor_a == "7" & factor_b == "2"),
+    analysis_.8._.2. = data %>% filter(factor_a == "8" & factor_b == "2"),
+    summary_.4._.2. = my_summarize(analysis_.4._.2.),
+    summary_.5._.2. = my_summarize(analysis_.5._.2.),
+    summary_.6._.2. = my_summarize(analysis_.6._.2.),
+    summary_.7._.2. = my_summarize(analysis_.7._.2.),
+    summary_.8._.2. = my_summarize(analysis_.8._.2.),
     results = bind_rows(
-      summary_0.4_0.1, summary_0.5_0.1, summary_0.6_0.1,
-      summary_0.7_0.1, summary_0.8_0.1
+      summary_.4._.2., summary_.5._.2., summary_.6._.2.,
+      summary_.7._.2., summary_.8._.2.
     )
   )
   # nolint end
@@ -1899,13 +1899,13 @@ test_with_dir("repeated maps do not duplicate targets", {
   )
   exp <- drake_plan(
     A = "a",
-    A.1 = "a",
+    A_2 = "a",
     B = c(A, "a"),
-    B.1 = c(A.1, "a"),
+    B_2 = c(A_2, "a"),
     C = "b",
-    C.1 = "b",
+    C_2 = "b",
     D = c(A, B, C, "a", "b"),
-    D.1 = c(A.1, B.1, C.1, "a", "b")
+    D_2 = c(A_2, B_2, C_2, "a", "b")
   )
   equivalent_plans(out, exp)
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -183,3 +183,26 @@ test_with_dir("splice_args()", {
   )
   expect_equal(deparse(out), "f(a = 1, b = sym, c = \"char\", 5)")
 })
+
+test_with_dir("make_unique()", {
+  skip_on_cran()
+  expect_equal(make_unique(character(0)), character(0))
+  x <- c("d", "c", "b", "b", "b", "d", "a", "a", "c", "d")
+  out <- make_unique(x)
+  exp <- c("d", "c", "b", "b_2", "b_3", "d_2", "a", "a_2", "c_2", "d_3")
+  expect_equal(out, exp)
+  set.seed(0)
+  x <- sample(letters[seq_len(4)], size = 1e3, replace = TRUE)
+  out <- make_unique(x)
+  out <- vapply(out, function(x) {
+    y <- strsplit(x, split = "_")[[1]]
+    if (length(y) == 1L) {
+      return(y)
+    }
+    suffix <- as.integer(y[2])
+    expect_true(suffix > 1L)
+    paste(y[1], suffix - 1L, sep = ".") 
+  }, FUN.VALUE = character(1), USE.NAMES = FALSE)
+  exp <- make.unique(x, sep = ".")
+  expect_equal(out, exp)
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -187,6 +187,7 @@ test_with_dir("splice_args()", {
 test_with_dir("make_unique()", {
   skip_on_cran()
   expect_equal(make_unique(character(0)), character(0))
+  expect_equal(make_unique(letters), letters)
   x <- c("d", "c", "b", "b", "b", "d", "a", "a", "c", "d")
   out <- make_unique(x)
   exp <- c("d", "c", "b", "b_2", "b_3", "d_2", "a", "a_2", "c_2", "d_3")

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -195,15 +195,20 @@ test_with_dir("make_unique()", {
   set.seed(0)
   x <- sample(letters[seq_len(4)], size = 1e3, replace = TRUE)
   out <- make_unique(x)
-  out <- vapply(out, function(x) {
-    y <- strsplit(x, split = "_")[[1]]
-    if (length(y) == 1L) {
-      return(y)
-    }
-    suffix <- as.integer(y[2])
-    expect_true(suffix > 1L)
-    paste(y[1], suffix - 1L, sep = ".") 
-  }, FUN.VALUE = character(1), USE.NAMES = FALSE)
+  out <- vapply(
+    out,
+    function(x) {
+      y <- strsplit(x, split = "_")[[1]]
+      if (length(y) == 1L) {
+        return(y)
+      }
+      suffix <- as.integer(y[2])
+      expect_true(suffix > 1L)
+      paste(y[1], suffix - 1L, sep = ".")
+    },
+    FUN.VALUE = character(1),
+    USE.NAMES = FALSE
+  )
   exp <- make.unique(x, sep = ".")
   expect_equal(out, exp)
 })


### PR DESCRIPTION
# Summary

On the current master branch, target names generated by `map(.id = FALSE)` are awkward. They use dots as separators, and the indexing starts from 0 (inconsistent with the rest of R).

```r
drake_plan(
  y = target(f(x), transform = map(x = c("a", "b", "c"), .id = FALSE))
)
#> # A tibble: 3 x 2
#>   target command
#>   <chr>  <expr> 
#> 1 y      f("a") 
#> 2 y.1    f("b") 
#> 3 y.2    f("c") 
```

This PR sticks to the more fitting base-1 indexing and uses underscores as separators.

```r
drake_plan(
  y = target(f(x), transform = map(x = c("a", "b", "c"), .id = FALSE))
)
#> # A tibble: 3 x 2
#>   target command
#>   <chr>  <expr> 
#> 1 y      f("a") 
#> 2 y_2    f("b") 
#> 3 y_3    f("c") 
```

One snag: I had to write a custom `make_unique()` function, which is not as fast as the base `make.unique()`. I will need to rerun some benchmarks and see if I have introduced a bottleneck.

# Related GitHub issues and pull requests

- Ref: #755

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [ ] I think this pull request is ready to merge.
