### PR TITLE
added a `progress` argument to filter the results of `progress()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,12 +53,19 @@ Authors@R: c(
     email = "slaughter@nceas.ucsb.edu",
     role = "rev"
   ),
-    person(
+  person(
     family = "Bond-Lamberty",
     given = "Ben",
     email = "bondlamberty@pnnl.gov",
     role = "ctb",
     comment = c(ORCID = "0000-0001-9525-4633")
+  ),
+  person(
+    family = "Mahr",
+    given = "Tristan",
+    email = "tristan.mahr@wisc.edu",
+    role = "ctb",
+    comment = c(ORCID = "0000-0002-8890-5116")
   ),
   person(
     family = "Eli Lilly and Company",

--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,8 @@
 - The new `from_plan()` function allows the users to reference custom plan columns from within commands. Changes to values in these columns columns do not invalidate targets.
 - Add a menu prompt (https://github.com/ropensci/drake/pull/762) to safeguard against `make()` pitfalls in interactive mode (https://github.com/ropensci/drake/issues/761). Appears once per session. Disable with `options(drake_make_menu = FALSE)`.
 - Add new API functions `r_make()`, `r_outdated()`, etc. to run `drake` functions more reproducibly in a clean session. See the help file of `r_make()` for details.
+- `progress()` gains a `progress` argument for filtering results. For example, `progress(progress = "failed")` will report targets that failed.
+
 
 ## Enhancements
 

--- a/R/api-progress.R
+++ b/R/api-progress.R
@@ -78,14 +78,17 @@ progress <- function(
   out <- weak_tibble(target = targets, progress = progress_results)
   rownames(out) <- NULL
 
-  if (!is.null(progress)) {
-    progress <- match.arg(
-      progress,
-      choices = c("done", "running", "failed", "none"),
-      several.ok = TRUE)
-    out <- out[out$progress %in% progress, ]
+  if (is.null(progress)) {
+    return(out)
   }
 
+  progress <- match.arg(
+    progress,
+    choices = c("done", "running", "failed", "none"),
+    several.ok = TRUE
+  )
+
+  out <- out[out$progress %in% progress, ]
   out
 }
 

--- a/R/api-progress.R
+++ b/R/api-progress.R
@@ -24,7 +24,7 @@
 #'   imported objects that are not files).
 #'
 #' @param jobs Number of jobs/workers for parallel processing.
-#' 
+#'
 #' @param progress Character vector for filtering the build progress results.
 #'   Defaults to `NULL` (no filtering) to report progress of all objects.
 #'   Supported filters are `"done"`, `"running"`, `"failed"` and `"none"`.
@@ -77,30 +77,15 @@ progress <- function(
   )
   out <- weak_tibble(target = targets, progress = progress_results)
   rownames(out) <- NULL
-  
-  # Check then apply progress filters
+
   if (!is.null(progress)) {
-    progress <- unique(progress)
-    valid_filters <- c("done", "running", "failed", "none")
-    
-    if (!all(progress %in% valid_filters)) {
-      invalid_filters <- setdiff(progress, valid_filters)
-      
-      l1_filter <- ngettext(length(progress), "filter", "filters")
-      line1 <- paste0(
-        "Unsupported progress ", l1_filter, ": ", 
-        "`", rlang::expr_text(invalid_filters), "`."
-      )
-      line2 <- paste0(
-        "Use `NULL` for no filtering or one of ", 
-        "`", rlang::expr_text(valid_filters), "`."
-      )
-      warning(line1, "\n  ", line2)
-    }
-    
+    progress <- match.arg(
+      progress,
+      choices = c("done", "running", "failed", "none"),
+      several.ok = TRUE)
     out <- out[out$progress %in% progress, ]
   }
-  
+
   out
 }
 

--- a/man/progress.Rd
+++ b/man/progress.Rd
@@ -7,7 +7,8 @@ during a \code{\link[=make]{make()}}.}
 \usage{
 progress(..., list = character(0), no_imported_objects = NULL,
   path = getwd(), search = TRUE, cache = drake::get_cache(path =
-  path, search = search, verbose = verbose), verbose = 1L, jobs = 1)
+  path, search = search, verbose = verbose), verbose = 1L, jobs = 1,
+  progress = NULL)
 }
 \arguments{
 \item{...}{Objects to load from the cache, as names (unquoted)
@@ -46,6 +47,10 @@ If supplied, \code{path} and \code{search} are ignored.}
 }}
 
 \item{jobs}{Number of jobs/workers for parallel processing.}
+
+\item{progress}{Character vector for filtering the build progress results.
+Defaults to \code{NULL} (no filtering) to report progress of all objects.
+Supported filters are \code{"done"}, \code{"running"}, \code{"failed"} and \code{"none"}.}
 }
 \value{
 The build progress of each target reached by

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -488,16 +488,31 @@ test_with_dir("loadd() does not load imports", {
 test_with_dir("can filter progress", {
   skip_on_cran() # CRAN gets whitelist tests only (check time limits).
   plan <- drake_plan(a = TRUE, b = TRUE, c = stop())
-
   expect_error(make(plan))
 
-  expect_equal(nrow(progress()), 3)
-  expect_equal(nrow(progress(progress = c("done", "failed"))), 3)
-  expect_equal(nrow(progress(progress = "done")), 2)
-  expect_equal(nrow(progress(progress = "failed")), 1)
+  out <- progress(a, b, c, d)
+  exp <- weak_tibble(
+    target = c("a", "b", "c", "d"),
+    progress = c("done", "done", "failed", "none")
+  )
+  expect_equivalent(out, exp)
 
-  # nonexistent target gets "none"
-  expect_equal(nrow(progress(fake, progress = "none")), 1)
+  exp1 <- weak_tibble(
+    target = c("a", "b", "c"),
+    progress = c("done", "done", "failed")
+  )
+  exp2 <- weak_tibble(
+    target = c("a", "b"),
+    progress = c("done", "done")
+  )
+  exp3 <- weak_tibble(
+    target = "c",
+    progress = "failed"
+  )
+
+  expect_equivalent(progress(progress = c("done", "failed")), exp1)
+  expect_equivalent(progress(progress = "done"), exp2)
+  expect_equivalent(progress(progress = "failed"), exp3)
 
   expect_error(
     progress(progress = "stuck"),

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -488,18 +488,18 @@ test_with_dir("loadd() does not load imports", {
 test_with_dir("can filter progress", {
   skip_on_cran() # CRAN gets whitelist tests only (check time limits).
   plan <- drake_plan(a = TRUE, b = TRUE, c = stop())
-  
+
   expect_error(make(plan))
-  
+
   expect_equal(nrow(progress()), 3)
   expect_equal(nrow(progress(progress = c("done", "failed"))), 3)
   expect_equal(nrow(progress(progress = "done")), 2)
   expect_equal(nrow(progress(progress = "failed")), 1)
-  
+
   # nonexistent target gets "none"
   expect_equal(nrow(progress(fake, progress = "none")), 1)
-  
-  expect_warning(
-    progress(progress = "stuck"), 
-    "Unsupported progress filter")
+
+  expect_error(
+    progress(progress = "stuck"),
+    "should be one of")
 })

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -484,3 +484,22 @@ test_with_dir("loadd() does not load imports", {
     regexp = "No targets to load"
   )
 })
+
+test_with_dir("can filter progress", {
+  skip_on_cran() # CRAN gets whitelist tests only (check time limits).
+  plan <- drake_plan(a = TRUE, b = TRUE, c = stop())
+  
+  expect_error(make(plan))
+  
+  expect_equal(nrow(progress()), 3)
+  expect_equal(nrow(progress(progress = c("done", "failed"))), 3)
+  expect_equal(nrow(progress(progress = "done")), 2)
+  expect_equal(nrow(progress(progress = "failed")), 1)
+  
+  # nonexistent target gets "none"
+  expect_equal(nrow(progress(fake, progress = "none")), 1)
+  
+  expect_warning(
+    progress(progress = "stuck"), 
+    "Unsupported progress filter")
+})


### PR DESCRIPTION
# Summary

I added a `progress` argument to filter the results of `progress()`.

# Related GitHub issues and pull requests

- Ref: #743 

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [ ] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [ ] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [] I think this pull request is ready to merge.

An unrelated x86 test failed on my Windows machine.