### PR TITLE
file_in()/file_out() directories

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 
 ## Enhancements
 
+- `file_in()` and `file_out()` can now handle entire directories, e.g. `file_in("your_folder_of_input_data_files")` and `file_out("directory_with_a_bunch_of_output_files")`.
 - Improve `drake_ggraph()`
   - Hide node labels by default and render the arrows behind the nodes.
   - Print an informative error message when the user supplies a `drake` plan to the `config` argument of a function.

--- a/R/api-clean.R
+++ b/R/api-clean.R
@@ -169,7 +169,7 @@ clean_single_target <- function(
     }
   }
   if (length(files)) {
-    unlink(decode_path(files))
+    unlink(decode_path(files), recursive = TRUE)
   }
 }
 

--- a/R/api-plan.R
+++ b/R/api-plan.R
@@ -343,11 +343,16 @@ file_in <- function(...) {
 #' }
 file_out <- file_in
 
-#' @title Declare the `knitr`/`rmarkdown` source files
-#'   of a workflow plan command.
-#' @description Use this function to help write the commands
-#'   in your workflow plan data frame. See the examples
-#'   for a full explanation.
+#' @title Declare `knitr`/`rmarkdown` source files
+#'   as dependencies.
+#' @description `knitr_in()` marks individual `knitr`/R Markdown
+#'   reports as dependencies. In `drake`, these reports are pieces
+#'   of the pipeline. R Markdown is a great tool for *displaying*
+#'   precomputed results, but not for running a large workflow
+#'   from end to end. These reports should do as little
+#'   computation as possible.
+#' @details Unlike [file_in()] and [file_out()], `knitr_in()`
+#'   does not work with entire directories.
 #' @export
 #' @seealso [file_in()], [file_out()], [ignore()]
 #' @return A character vector of declared input file paths.

--- a/R/api-plan.R
+++ b/R/api-plan.R
@@ -87,7 +87,7 @@
 #'   summ = target(
 #'     sum_fun(data, reg),
 #'    transform = cross(sum_fun = c(coef, residuals), reg)
-#'   ), 
+#'   ),
 #'   winners = target(
 #'     min(summ),
 #'     transform = combine(summ, .by = c(data, sum_fun))
@@ -108,7 +108,7 @@
 #'   summ = target(
 #'     sum_fun(data, reg),
 #'    transform = cross(sum_fun = c(coef, residuals), reg)
-#'   ), 
+#'   ),
 #'   winners = target(
 #'     min(summ),
 #'     transform = combine(summ, .by = c(data, sum_fun))
@@ -239,15 +239,13 @@ complete_target_names <- function(commands_list) {
   commands_list
 }
 
-#' @title Declare the file inputs of a workflow plan command.
-#' @description Use this function to help write the commands
-#'   in your workflow plan data frame. See the examples
-#'   for a full explanation.
+#' @title Declare input files and directories.
+#' @description `file_in()` marks individual files
+#'   (and whole directories) that your targets depend on.
 #' @export
 #' @seealso [file_out()], [knitr_in()], [ignore()]
-#' @return A character vector of declared input file paths.
-#' @param ... Character strings. File paths of input files
-#'   to a command in your workflow plan data frame.
+#' @return A character vector of declared input file or directory paths.
+#' @param ... Character vector, paths to files and directories.
 #' @export
 #' @examples
 #' \dontrun{
@@ -259,7 +257,7 @@ complete_target_names <- function(commands_list) {
 #' # in your workflow plan data frame.
 #' suppressWarnings(
 #'   plan <- drake_plan(
-#'     write.csv(mtcars, file_out("mtcars.csv")),
+#'     out = write.csv(mtcars, file_out("mtcars.csv")),
 #'     contents = read.csv(file_in("mtcars.csv"))
 #'   )
 #' )
@@ -268,37 +266,51 @@ complete_target_names <- function(commands_list) {
 #' # and a dependency of `contents`. See for yourself:
 #' make(plan)
 #' file.exists("mtcars.csv")
-#' # See also `knitr_in()`. `knitr_in()` is like `file_in()`
-#' # except that it analyzes active code chunks in your `knitr`
-#' # source file and detects non-file dependencies.
-#' # That way, updates to the right dependencies trigger rebuilds
-#' # in your report.
+#' # You can also work with entire directories this way.
+#' # However, in `file_out("your_directory")`, the directory
+#' # becomes an entire unit. Thus, `file_in("your_directory")`
+#' # is more appropriate for subsequent steps than
+#' # `file_in("your_directory/file_inside.txt")`.
+#' suppressWarnings(
+#'   plan <- drake_plan(
+#'     out = {
+#'       dir.create(file_out("dir"))
+#'       write.csv(mtcars, "dir/mtcars.csv")
+#'     },
+#'     contents = read.csv(file.path(file_in("dir"), "mtcars.csv"))
+#'   )
+#' )
+#' plan
+#' make(plan)
+#' file.exists("dir/mtcars.csv")
+#' # See the connections that the file relationships create:
+#' # config <- drake_config(plan) # nolint
+#' # vis_drake_graph(config)      # nolint
 #' })
 #' }
 file_in <- function(...) {
   as.character(c(...))
 }
 
-#' @title Declare the file outputs of a workflow plan command.
-#' @description Use this function to help write the commands
-#'   in your workflow plan data frame. You can only specify
-#'   one file output per command. See the examples
-#'   for a full explanation.
+#' @title Declare output files and directories.
+#' @description `file_in()` marks individual files
+#'   (and whole directories) that your targets create.
 #' @export
-#' @seealso [file_in()], [knitr_in()], [ignore()]
-#' @return A character vector of declared output file paths.
-#' @param ... Character vector of output file paths.
+#' @seealso [file_out()], [knitr_in()], [ignore()]
+#' @return A character vector of declared output file or directory paths.
+#' @param ... Character vector, paths to files and directories.
+#' @export
 #' @examples
 #' \dontrun{
 #' test_with_dir("Contain side effects", {
 #' # The `file_out()` and `file_in()` functions
 #' # just takes in strings and returns them.
-#' file_out("summaries.txt", "output.csv")
+#' file_out("summaries.txt")
 #' # Their main purpose is to orchestrate your custom files
 #' # in your workflow plan data frame.
 #' suppressWarnings(
 #'   plan <- drake_plan(
-#'     write.csv(mtcars, file_out("mtcars.csv")),
+#'     out = write.csv(mtcars, file_out("mtcars.csv")),
 #'     contents = read.csv(file_in("mtcars.csv"))
 #'   )
 #' )
@@ -307,11 +319,26 @@ file_in <- function(...) {
 #' # and a dependency of `contents`. See for yourself:
 #' make(plan)
 #' file.exists("mtcars.csv")
-#' # See also `knitr_in()`. `knitr_in()` is like `file_in()`
-#' # except that it analyzes active code chunks in your `knitr`
-#' # source file and detects non-file dependencies.
-#' # That way, updates to the right dependencies trigger rebuilds
-#' # in your report.
+#' # You can also work with entire directories this way.
+#' # However, in `file_out("your_directory")`, the directory
+#' # becomes an entire unit. Thus, `file_in("your_directory")`
+#' # is more appropriate for subsequent steps than
+#' # `file_in("your_directory/file_inside.txt")`.
+#' suppressWarnings(
+#'   plan <- drake_plan(
+#'     out = {
+#'       dir.create(file_out("dir"))
+#'       write.csv(mtcars, "dir/mtcars.csv")
+#'     },
+#'     contents = read.csv(file.path(file_in("dir"), "mtcars.csv"))
+#'   )
+#' )
+#' plan
+#' make(plan)
+#' # See the connections that the file relationships create:
+#' # config <- drake_config(plan) # nolint
+#' # vis_drake_graph(config)      # nolint
+#' file.exists("dir/mtcars.csv")
 #' })
 #' }
 file_out <- file_in

--- a/R/exec-meta.R
+++ b/R/exec-meta.R
@@ -86,7 +86,7 @@ input_file_hash <- function(
   out <- ht_memo(
     ht = config$ht_get_hash,
     x = files,
-    fun = file_hash,
+    fun = storage_hash,
     config = config,
     size_cutoff = size_cutoff
   )
@@ -110,7 +110,7 @@ output_file_hash <- function(
   }
   out <- vapply(
     X = files,
-    FUN = file_hash,
+    FUN = storage_hash,
     FUN.VALUE = character(1),
     config = config,
     size_cutoff = size_cutoff
@@ -186,7 +186,7 @@ should_rehash_storage <- function(filename, new_mtime, old_mtime,
   do_rehash
 }
 
-file_hash <- function(
+storage_hash <- function(
   target,
   config,
   size_cutoff = rehash_storage_size_cutoff

--- a/R/exec-meta.R
+++ b/R/exec-meta.R
@@ -149,7 +149,7 @@ safe_rehash_storage <- function(target, config) {
 
 should_rehash_storage <- function(filename, new_mtime, old_mtime,
   size_cutoff) {
-  do_rehash <- file.size(filename) < size_cutoff | new_mtime > old_mtime
+  do_rehash <- storage_size(filename) < size_cutoff | new_mtime > old_mtime
   if (safe_is_na(do_rehash)) {
     do_rehash <- TRUE
   }
@@ -205,6 +205,14 @@ storage_mtime <- function(x) {
   }
 }
 
+storage_size <- function(x) {
+  if (dir.exists(x)) {
+    dir_size(x)
+  } else {
+    file.size(x)
+  }
+}
+
 dir_mtime <- function(x) {
   files <- list.files(
     path = x,
@@ -214,4 +222,15 @@ dir_mtime <- function(x) {
     include.dirs = FALSE
   )
   max(vapply(files, file.mtime, FUN.VALUE = numeric(1)))
+}
+
+dir_size <- function(x) {
+  files <- list.files(
+    path = x,
+    all.files = TRUE,
+    full.names = TRUE,
+    recursive = TRUE,
+    include.dirs = FALSE
+  )
+  max(vapply(files, file.size, FUN.VALUE = numeric(1)))
 }

--- a/R/exec-meta.R
+++ b/R/exec-meta.R
@@ -128,13 +128,43 @@ rehash_storage <- function(target, config) {
     return(NA_character_)
   }
   file <- decode_path(target, config)
-  if (!file.exists(file) || file.info(file)$isdir) {
+  if (!file.exists(file)) {
     return(NA_character_)
   }
+  if (dir.exists(file)) {
+    rehash_dir(file, config)
+  } else {
+    rehash_file(file, config)
+  }
+}
+
+rehash_file <- function(file, config) {
   digest::digest(
     object = file,
     algo = config$cache$driver$hash_algorithm,
     file = TRUE,
+    serialize = FALSE
+  )
+}
+
+rehash_dir <- function(dir, config) {
+  files <- list.files(
+    path = dir,
+    all.files = TRUE,
+    full.names = TRUE,
+    recursive = TRUE,
+    include.dirs = FALSE
+  )
+  out <- vapply(
+    files,
+    rehash_file,
+    FUN.VALUE = character(1),
+    config = config
+  )
+  out <- paste(out, collapse = "")
+  digest::digest(
+    out,
+    algo = config$cache$driver$hash_algorithm,
     serialize = FALSE
   )
 }

--- a/R/exec-meta.R
+++ b/R/exec-meta.R
@@ -251,7 +251,8 @@ dir_mtime <- function(x) {
     recursive = TRUE,
     include.dirs = FALSE
   )
-  max(vapply(files, file.mtime, FUN.VALUE = numeric(1)))
+  times <- vapply(files, file.mtime, FUN.VALUE = numeric(1))
+  max(times %||% Inf)
 }
 
 dir_size <- function(x) {
@@ -262,5 +263,6 @@ dir_size <- function(x) {
     recursive = TRUE,
     include.dirs = FALSE
   )
-  max(vapply(files, file.size, FUN.VALUE = numeric(1)))
+  sizes <- vapply(files, file.size, FUN.VALUE = numeric(1))
+  max(sizes %||% 0)
 }

--- a/R/exec-store.R
+++ b/R/exec-store.R
@@ -92,7 +92,7 @@ store_object <- function(target, value, meta, config) {
 store_file <- function(target, meta, config) {
   store_object(
     target = target,
-    value = safe_rehash_file(target = target, config = config),
+    value = safe_rehash_storage(target = target, config = config),
     meta = meta,
     config = config
   )
@@ -102,7 +102,7 @@ store_output_files <- function(files, meta, config) {
   meta$isfile <- TRUE
   for (file in files) {
     meta$name <- file
-    meta$mtime <- file.mtime(decode_path(file, config))
+    meta$mtime <- storage_mtime(decode_path(file, config))
     meta$isfile <- TRUE
     store_single_output(
       target = file,

--- a/R/utils-checksums.R
+++ b/R/utils-checksums.R
@@ -16,7 +16,7 @@ mc_get_outfile_checksum <- function(target, config) {
   files <- sort(unique(as.character(deps$file_out)))
   out <- vapply(
     X = files,
-    FUN = rehash_file,
+    FUN = rehash_storage,
     FUN.VALUE = character(1),
     config = config
   )

--- a/R/utils-utils.R
+++ b/R/utils-utils.R
@@ -206,7 +206,7 @@ random_tempdir <- function() {
   dir
 }
 
-rehash_file_size_cutoff <- 1e5
+rehash_storage_size_cutoff <- 1e5
 
 safe_is_na <- function(x) {
   tryCatch(is.na(x), error = error_false, warning = error_false)

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -62,6 +62,7 @@ Genotype
 ggplot
 github
 globals
+gridlines
 gsp
 Halotype
 hotfix
@@ -129,6 +130,7 @@ phyloQTLpaper
 Pinnoi
 pre
 preCCProbPaper
+precomputed
 Preprocess
 prettycode
 prework

--- a/man/drake_plan.Rd
+++ b/man/drake_plan.Rd
@@ -108,7 +108,7 @@ drake_plan(
   summ = target(
     sum_fun(data, reg),
    transform = cross(sum_fun = c(coef, residuals), reg)
-  ), 
+  ),
   winners = target(
     min(summ),
     transform = combine(summ, .by = c(data, sum_fun))
@@ -129,7 +129,7 @@ drake_plan(
   summ = target(
     sum_fun(data, reg),
    transform = cross(sum_fun = c(coef, residuals), reg)
-  ), 
+  ),
   winners = target(
     min(summ),
     transform = combine(summ, .by = c(data, sum_fun))

--- a/man/file_in.Rd
+++ b/man/file_in.Rd
@@ -2,21 +2,19 @@
 % Please edit documentation in R/api-plan.R
 \name{file_in}
 \alias{file_in}
-\title{Declare the file inputs of a workflow plan command.}
+\title{Declare input files and directories.}
 \usage{
 file_in(...)
 }
 \arguments{
-\item{...}{Character strings. File paths of input files
-to a command in your workflow plan data frame.}
+\item{...}{Character vector, paths to files and directories.}
 }
 \value{
-A character vector of declared input file paths.
+A character vector of declared input file or directory paths.
 }
 \description{
-Use this function to help write the commands
-in your workflow plan data frame. See the examples
-for a full explanation.
+\code{file_in()} marks individual files
+(and whole directories) that your targets depend on.
 }
 \examples{
 \dontrun{
@@ -28,7 +26,7 @@ file_out("summaries.txt")
 # in your workflow plan data frame.
 suppressWarnings(
   plan <- drake_plan(
-    write.csv(mtcars, file_out("mtcars.csv")),
+    out = write.csv(mtcars, file_out("mtcars.csv")),
     contents = read.csv(file_in("mtcars.csv"))
   )
 )
@@ -37,11 +35,26 @@ plan
 # and a dependency of `contents`. See for yourself:
 make(plan)
 file.exists("mtcars.csv")
-# See also `knitr_in()`. `knitr_in()` is like `file_in()`
-# except that it analyzes active code chunks in your `knitr`
-# source file and detects non-file dependencies.
-# That way, updates to the right dependencies trigger rebuilds
-# in your report.
+# You can also work with entire directories this way.
+# However, in `file_out("your_directory")`, the directory
+# becomes an entire unit. Thus, `file_in("your_directory")`
+# is more appropriate for subsequent steps than
+# `file_in("your_directory/file_inside.txt")`.
+suppressWarnings(
+  plan <- drake_plan(
+    out = {
+      dir.create(file_out("dir"))
+      write.csv(mtcars, "dir/mtcars.csv")
+    },
+    contents = read.csv(file.path(file_in("dir"), "mtcars.csv"))
+  )
+)
+plan
+make(plan)
+file.exists("dir/mtcars.csv")
+# See the connections that the file relationships create:
+# config <- drake_config(plan) # nolint
+# vis_drake_graph(config)      # nolint
 })
 }
 }

--- a/man/file_out.Rd
+++ b/man/file_out.Rd
@@ -2,33 +2,31 @@
 % Please edit documentation in R/api-plan.R
 \name{file_out}
 \alias{file_out}
-\title{Declare the file outputs of a workflow plan command.}
+\title{Declare output files and directories.}
 \usage{
 file_out(...)
 }
 \arguments{
-\item{...}{Character vector of output file paths.}
+\item{...}{Character vector, paths to files and directories.}
 }
 \value{
-A character vector of declared output file paths.
+A character vector of declared output file or directory paths.
 }
 \description{
-Use this function to help write the commands
-in your workflow plan data frame. You can only specify
-one file output per command. See the examples
-for a full explanation.
+\code{file_in()} marks individual files
+(and whole directories) that your targets create.
 }
 \examples{
 \dontrun{
 test_with_dir("Contain side effects", {
 # The `file_out()` and `file_in()` functions
 # just takes in strings and returns them.
-file_out("summaries.txt", "output.csv")
+file_out("summaries.txt")
 # Their main purpose is to orchestrate your custom files
 # in your workflow plan data frame.
 suppressWarnings(
   plan <- drake_plan(
-    write.csv(mtcars, file_out("mtcars.csv")),
+    out = write.csv(mtcars, file_out("mtcars.csv")),
     contents = read.csv(file_in("mtcars.csv"))
   )
 )
@@ -37,14 +35,29 @@ plan
 # and a dependency of `contents`. See for yourself:
 make(plan)
 file.exists("mtcars.csv")
-# See also `knitr_in()`. `knitr_in()` is like `file_in()`
-# except that it analyzes active code chunks in your `knitr`
-# source file and detects non-file dependencies.
-# That way, updates to the right dependencies trigger rebuilds
-# in your report.
+# You can also work with entire directories this way.
+# However, in `file_out("your_directory")`, the directory
+# becomes an entire unit. Thus, `file_in("your_directory")`
+# is more appropriate for subsequent steps than
+# `file_in("your_directory/file_inside.txt")`.
+suppressWarnings(
+  plan <- drake_plan(
+    out = {
+      dir.create(file_out("dir"))
+      write.csv(mtcars, "dir/mtcars.csv")
+    },
+    contents = read.csv(file.path(file_in("dir"), "mtcars.csv"))
+  )
+)
+plan
+make(plan)
+# See the connections that the file relationships create:
+# config <- drake_config(plan) # nolint
+# vis_drake_graph(config)      # nolint
+file.exists("dir/mtcars.csv")
 })
 }
 }
 \seealso{
-\code{\link[=file_in]{file_in()}}, \code{\link[=knitr_in]{knitr_in()}}, \code{\link[=ignore]{ignore()}}
+\code{\link[=file_out]{file_out()}}, \code{\link[=knitr_in]{knitr_in()}}, \code{\link[=ignore]{ignore()}}
 }

--- a/man/knitr_in.Rd
+++ b/man/knitr_in.Rd
@@ -2,8 +2,8 @@
 % Please edit documentation in R/api-plan.R
 \name{knitr_in}
 \alias{knitr_in}
-\title{Declare the \code{knitr}/\code{rmarkdown} source files
-of a workflow plan command.}
+\title{Declare \code{knitr}/\code{rmarkdown} source files
+as dependencies.}
 \usage{
 knitr_in(...)
 }
@@ -15,9 +15,16 @@ source files supplied to a command in your workflow plan data frame.}
 A character vector of declared input file paths.
 }
 \description{
-Use this function to help write the commands
-in your workflow plan data frame. See the examples
-for a full explanation.
+\code{knitr_in()} marks individual \code{knitr}/R Markdown
+reports as dependencies. In \code{drake}, these reports are pieces
+of the pipeline. R Markdown is a great tool for \emph{displaying}
+precomputed results, but not for running a large workflow
+from end to end. These reports should do as little
+computation as possible.
+}
+\details{
+Unlike \code{\link[=file_in]{file_in()}} and \code{\link[=file_out]{file_out()}}, \code{knitr_in()}
+does not work with entire directories.
 }
 \examples{
 \dontrun{

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -5,17 +5,38 @@ test_with_dir("clean() removes the correct files", {
   cache <- storr::storr_environment()
   writeLines("123", "a.txt")
   writeLines("123", "b.txt")
+  dir.create("abc")
+  writeLines("123", "abc/c.txt")
   plan <- drake_plan(
     a = file_in("a.txt"),
     b = knitr_in("b.txt"),
-    d = writeLines("123", file_out("d.rds"))
+    d = writeLines("123", file_out("d.rds")),
+    x = file_in("abc"),
+    y = {
+      dir.create(file_out("xyz"))
+      writeLines("123", "xyz/e.txt")
+    }
   )
-  config <- drake_config(plan, session_info = FALSE, skip_targets = TRUE)
-  make(config = config)
-  clean()
+  make(
+    plan,
+    cache = cache,
+    session_info = FALSE
+  )
   expect_true(file.exists("a.txt"))
   expect_true(file.exists("b.txt"))
-  expect_false(file.exists("d.txt"))
+  expect_true(file.exists("d.rds"))
+  expect_true(dir.exists("abc"))
+  expect_true(dir.exists("xyz"))
+  expect_true(file.exists("abc/c.txt"))
+  expect_true(file.exists("xyz/e.txt"))
+  clean(cache = cache)
+  expect_true(file.exists("a.txt"))
+  expect_true(file.exists("b.txt"))
+  expect_false(file.exists("d.rds"))
+  expect_true(dir.exists("abc"))
+  expect_false(dir.exists("xyz"))
+  expect_true(file.exists("abc/c.txt"))
+  expect_false(file.exists("xyz/e.txt"))
 })
 
 test_with_dir("drake_version", {

--- a/tests/testthat/test-edge-cases.R
+++ b/tests/testthat/test-edge-cases.R
@@ -263,10 +263,11 @@ test_with_dir("warning when file_out() files not produced", {
   )
 })
 
-test_with_dir("file hash of a non-file", {
-  expect_true(is.na(file_hash("asdf", list())))
+test_with_dir("storage hash of a non-existent path", {
+  expect_false(file.exists("asdf"))
+  expect_true(is.na(storage_hash("asdf", list())))
   expect_true(is.na(rehash_storage("asdf", list())))
-  expect_true(is.na(file_hash(encode_path("asdf"), list())))
+  expect_true(is.na(storage_hash(encode_path("asdf"), list())))
   expect_true(is.na(rehash_storage(encode_path("asdf"), list())))
 })
 

--- a/tests/testthat/test-edge-cases.R
+++ b/tests/testthat/test-edge-cases.R
@@ -265,9 +265,9 @@ test_with_dir("warning when file_out() files not produced", {
 
 test_with_dir("file hash of a non-file", {
   expect_true(is.na(file_hash("asdf", list())))
-  expect_true(is.na(rehash_file("asdf", list())))
+  expect_true(is.na(rehash_storage("asdf", list())))
   expect_true(is.na(file_hash(encode_path("asdf"), list())))
-  expect_true(is.na(rehash_file(encode_path("asdf"), list())))
+  expect_true(is.na(rehash_storage(encode_path("asdf"), list())))
 })
 
 test_with_dir("imported functions cannot depend on targets", {

--- a/tests/testthat/test-examples.R
+++ b/tests/testthat/test-examples.R
@@ -64,8 +64,8 @@ test_with_dir("mtcars example works", {
   expect_false(any(dats %in% jb))
 
   # Check that file is not rehashed.
-  # Code coverage should cover every line of file_hash().
-  expect_true(is.character(file_hash(
+  # Code coverage should cover every line of storage_hash().
+  expect_true(is.character(storage_hash(
     target = encode_path("report.Rmd"), config = con, size_cutoff = -1)))
   config <- drake_config(
     my_plan, envir = e, jobs = jobs, parallelism = parallelism,

--- a/tests/testthat/test-hash.R
+++ b/tests/testthat/test-hash.R
@@ -32,17 +32,17 @@ test_with_dir("stress test file hash", {
 test_with_dir("stress test hashing decisions", {
   skip_on_cran() # CRAN gets whitelist tests only (check time limits).
   file <- "input.rds"
-  expect_true(should_rehash_file(
+  expect_true(should_rehash_storage(
     filename = file, new_mtime = 0, old_mtime = 0, size_cutoff = Inf))
-  expect_true(should_rehash_file(
+  expect_true(should_rehash_storage(
     filename = file, new_mtime = 1, old_mtime = 0, size_cutoff = Inf))
-  expect_true(should_rehash_file(
+  expect_true(should_rehash_storage(
     filename = file, new_mtime = 0, old_mtime = 1, size_cutoff = Inf))
-  expect_true(should_rehash_file(
+  expect_true(should_rehash_storage(
     filename = file, new_mtime = 0, old_mtime = 0, size_cutoff = -1))
-  expect_true(should_rehash_file(
+  expect_true(should_rehash_storage(
     filename = file, new_mtime = 1, old_mtime = 0, size_cutoff = -1))
-  expect_true(should_rehash_file(
+  expect_true(should_rehash_storage(
     filename = file, new_mtime = 0, old_mtime = 1, size_cutoff = -1))
 })
 
@@ -51,16 +51,16 @@ test_with_dir("more stress testing of hashing decisions", {
   file <- "input.rds"
   saveRDS(1, file = file)
   expect_true(file.exists(file))
-  expect_true(should_rehash_file(
+  expect_true(should_rehash_storage(
     filename = file, new_mtime = 1, old_mtime = 0, size_cutoff = Inf))
-  expect_true(should_rehash_file(
+  expect_true(should_rehash_storage(
     filename = file, new_mtime = 0, old_mtime = 1, size_cutoff = Inf))
-  expect_true(should_rehash_file(
+  expect_true(should_rehash_storage(
     filename = file, new_mtime = 0, old_mtime = 0, size_cutoff = Inf))
-  expect_true(should_rehash_file(
+  expect_true(should_rehash_storage(
     filename = file, new_mtime = 1, old_mtime = 0, size_cutoff = -1))
-  expect_false(should_rehash_file(
+  expect_false(should_rehash_storage(
     filename = file, new_mtime = 0, old_mtime = 1, size_cutoff = -1))
-  expect_false(should_rehash_file(
+  expect_false(should_rehash_storage(
     filename = file, new_mtime = 0, old_mtime = 0, size_cutoff = -1))
 })

--- a/tests/testthat/test-hash.R
+++ b/tests/testthat/test-hash.R
@@ -29,9 +29,29 @@ test_with_dir("stress test storage hash", {
   }
 })
 
+test_with_dir("same with a directory", {
+  skip_on_cran() # CRAN gets whitelist tests only (check time limits).
+  dir.create("dir")
+  writeLines("123", "dir/a.txt")
+  writeLines("456", "dir/b.txt")
+  plan <- drake_plan(x = file_in("dir"))
+  con <- drake_config(
+    plan, verbose = FALSE, session_info = FALSE,
+    cache = storr::storr_environment()
+  )
+  make(config = con)
+  # Can debug storage_hash() to make sure hashing is skipped
+  # at the appropriate times.
+  for (file in file_store("dir")) {
+    expect_true(is.character(storage_hash(file, config = con, 0)))
+    expect_true(is.character(storage_hash(file, config = con, Inf)))
+  }
+})
+
 test_with_dir("stress test hashing decisions", {
   skip_on_cran() # CRAN gets whitelist tests only (check time limits).
-  file <- "input.rds"
+  file <- "nobodyhome"
+  expect_false(file.exists(file))
   expect_true(should_rehash_storage(
     filename = file, new_mtime = 0, old_mtime = 0, size_cutoff = Inf))
   expect_true(should_rehash_storage(
@@ -50,6 +70,27 @@ test_with_dir("more stress testing of hashing decisions", {
   skip_on_cran() # CRAN gets whitelist tests only (check time limits).
   file <- "input.rds"
   saveRDS(1, file = file)
+  expect_true(file.exists(file))
+  expect_true(should_rehash_storage(
+    filename = file, new_mtime = 1, old_mtime = 0, size_cutoff = Inf))
+  expect_true(should_rehash_storage(
+    filename = file, new_mtime = 0, old_mtime = 1, size_cutoff = Inf))
+  expect_true(should_rehash_storage(
+    filename = file, new_mtime = 0, old_mtime = 0, size_cutoff = Inf))
+  expect_true(should_rehash_storage(
+    filename = file, new_mtime = 1, old_mtime = 0, size_cutoff = -1))
+  expect_false(should_rehash_storage(
+    filename = file, new_mtime = 0, old_mtime = 1, size_cutoff = -1))
+  expect_false(should_rehash_storage(
+    filename = file, new_mtime = 0, old_mtime = 0, size_cutoff = -1))
+})
+
+test_with_dir("same with a directory", {
+  skip_on_cran() # CRAN gets whitelist tests only (check time limits).
+  file <- "myinputdir"
+  dir.create(file)
+  writeLines("12sddsfff3", "myinputdir/a.txt")
+  writeLines("4sdfasdf56", "myinputdir/b.txt")
   expect_true(file.exists(file))
   expect_true(should_rehash_storage(
     filename = file, new_mtime = 1, old_mtime = 0, size_cutoff = Inf))

--- a/tests/testthat/test-hash.R
+++ b/tests/testthat/test-hash.R
@@ -12,7 +12,7 @@ test_with_dir("illegal hashes", {
   )
 })
 
-test_with_dir("stress test file hash", {
+test_with_dir("stress test storage hash", {
   skip_on_cran() # CRAN gets whitelist tests only (check time limits).
   skip_if_not_installed("knitr")
   load_mtcars_example()
@@ -21,11 +21,11 @@ test_with_dir("stress test file hash", {
     cache = storr::storr_environment()
   )
   make(config = con)
-  # Can debug file_hash() to make sure hashing is skipped
+  # Can debug storage_hash() to make sure hashing is skipped
   # at the appropriate times.
   for (file in file_store(c("report.Rmd"))) {
-    expect_true(is.character(file_hash(file, config = con, 0)))
-    expect_true(is.character(file_hash(file, config = con, Inf)))
+    expect_true(is.character(storage_hash(file, config = con, 0)))
+    expect_true(is.character(storage_hash(file, config = con, Inf)))
   }
 })
 

--- a/tests/testthat/test-import-file.R
+++ b/tests/testthat/test-import-file.R
@@ -52,9 +52,18 @@ test_with_dir("same with an imported directory", {
   )
   testrun(config)
   final0 <- readd(final)
+
   # add another file to the directory
   saveRDS(2:10, "inputdir/otherinput.rds")
   testrun(config)
   expect_equal(justbuilt(config), "myinput")
   expect_equal(length(final0), length(readd(final, search = FALSE)))
+
+  # change the real input file
+  saveRDS(2:10, "inputdir/input.rds")
+  testrun(config)
+  expect_equal(justbuilt(config), sort(c(
+    "drake_target_1", "combined", "final", "myinput", "nextone")))
+  expect_false(length(final0) == length(readd(final, search = FALSE)))
+
 })


### PR DESCRIPTION
# Summary

In this PR, `file_in()` and `file_out()` can now handle entire directories, e.g. `file_in("your_folder_of_input_data_files")` and `file_out("directory_with_a_bunch_of_output_files")`. 

Internal conventions:

- Hashes: the hash of a directory is a hash of the hashes of all the constituent non-directory files.
- Timestamps: the timestamp of a directory is the max of all the timestamps of the constituent non-directory files. Brittle, but okay since we only use timestamps to decide whether to even bother checking hashes. It's just a performance shortcut.

Otherwise, `drake` assumes directories are irreducible units of data. A target with `file_in("dir/file")` will not necessarily be connected to another target with a `file_out("dir")`. Careful about your dependency relationships.

``` r
library(drake)
  
# good
plan <- drake_plan(
  A = file_out("dir"),
  B = file_in("dir")
)
config <- drake_config(plan)
vis_drake_graph(config)
```

![](https://i.imgur.com/BMUiUna.png)

``` r

# bad
plan <- drake_plan(
  A = file_out("dir"),
  B = file_in("dir/file_produced_by_A")
)
config <- drake_config(plan)
vis_drake_graph(config)
```

![](https://i.imgur.com/uusb11o.png)

<sup>Created on 2019-03-22 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

The potential performance and complexity penalties of the "bad" case above do not seem worth accommodating the use case.

# Related GitHub issues and pull requests

- Ref: #12, #794

# Checklist

- [x] I have read `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CODE_OF_CONDUCT.md), and I agree to follow its rules.
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) to confirm that any new features or functionality work correctly.
- [x] I have tested this pull request locally with `devtools::check()`
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.
