### PR TITLE
make_spinner requires cli >=1.1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -92,7 +92,7 @@ Suggests:
   abind,
   bindr,
   callr,
-  cli,
+  cli (>= 1.1.0),
   clustermq,
   CodeDepends,
   crayon,


### PR DESCRIPTION
I just tried to install `drake` from CRAN which required compilation for windows.  It gave an error that I tracked down to needing to update `cli`.  I added the version requirement to the Suggests for the version of `cli` required to install (because of `make_spinner()`).