### PR TITLE
HPC improvements

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Bug fixes
 
-- Move "`config$lock_envir <- FALSE`" from `loop_build()` to  `backend_loop()`.
+- Move "`config$lock_envir <- FALSE`" from `loop_build()` to  `backend_loop()`. This makes sure `config$envir` is correctly locked in `make(parallelism = "clustermq")`.
 
 ## Enhancements
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 
 ## Enhancements
 
-- Delay the initialization of `clustermq` workers for as long as possible. Before launching them, build/check targets locally until we reach an outdated target with `hpc` equal to `FALSE`.
+- Delay the initialization of `clustermq` workers for as long as possible. Before launching them, build/check targets locally until we reach an outdated target with `hpc` equal to `FALSE`. In other words, if no targets actually require `clustermq` workers, no workers get created.
 - In `make(parallelism = "future")`, reset the `config$sleep()` backoff interval whenever a new target gets checked.
 
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # Version 7.2.0.9000
 
+## Bugfixes
+
+- Move "`config$lock_envir <- FALSE`" from `loop_build()` to  `backend_loop()`.
+
+## Enhancements
+
+- Delay the initialization of `clustermq` workers for as long as possible. Before launching them, build/check targets locally until we reach an outdated target with `hpc` equal to `FALSE`.
+- In `make(parallelism = "future")`, reset the `config$sleep()` backoff interval whenever a new target gets checked.
+
 
 # Version 7.2.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # Version 7.2.0.9000
 
-## Bugfixes
+## Bug fixes
 
 - Move "`config$lock_envir <- FALSE`" from `loop_build()` to  `backend_loop()`.
 

--- a/R/backend-clustermq.R
+++ b/R/backend-clustermq.R
@@ -4,16 +4,36 @@ backend_clustermq <- function(config) {
     config = config,
     jobs = config$jobs_preprocess
   )
-  if (!config$queue$empty()) {
-    config$workers <- clustermq::workers(
-      n_jobs = config$jobs,
-      template = config$template
-    )
-    log_msg("setting common data", config = config)
-    cmq_set_common_data(config)
-    config$counter <- new.env(parent = emptyenv())
-    config$counter$remaining <- config$queue$size()
-    cmq_master(config)
+  cmq_local_master(config)
+  if (config$queue$empty()) {
+    return()
+  }
+  config$workers <- clustermq::workers(
+    n_jobs = config$jobs,
+    template = config$template
+  )
+  log_msg("setting common data", config = config)
+  cmq_set_common_data(config)
+  config$counter <- new.env(parent = emptyenv())
+  config$counter$remaining <- config$queue$size()
+  cmq_master(config)
+}
+
+cmq_local_master <- function(config) {
+  while (!config$queue$empty()) {
+    target <- config$queue$peek0()
+    if (identical(config$layout[[target]]$hpc, FALSE)) {
+      config$queue$pop0()
+      cmq_local_build(target, config)
+      next
+    }
+    meta <- drake_meta_(target = target, config = config)
+    if (should_build_target(target, meta, config)) {
+      return()
+    }
+    log_msg("skip", target, config = config)
+    config$queue$pop0()
+    cmq_conclude_target(target, config)
   }
 }
 
@@ -61,6 +81,7 @@ cmq_next_target <- function(config) {
     return() # nocov
   }
   if (identical(config$layout[[target]]$hpc, FALSE)) {
+    config$workers$send_wait()
     cmq_local_build(target, config)
   } else {
     cmq_send_target(target, config)
@@ -124,7 +145,6 @@ cmq_deps_list <- function(target, config) {
 
 cmq_local_build <- function(target, config) {
   log_msg("local target", target, config = config)
-  config$workers$send_wait()
   loop_build(target, config, downstream = NULL)
   cmq_conclude_target(target = target, config = config)
 }

--- a/R/backend-future.R
+++ b/R/backend-future.R
@@ -8,7 +8,6 @@ backend_future <- function(config) {
   while (work_remains(queue = queue, workers = workers, config = config)) {
     for (id in seq_along(workers)) {
       if (is_idle(workers[[id]])) {
-        i <- 1
         # Also calls decrease-key on the queue.
         workers[[id]] <- conclude_worker(
           worker = workers[[id]],
@@ -22,8 +21,13 @@ backend_future <- function(config) {
           # suitable enough for unit testing, but
           # I did artificially stall targets and verified that this line
           # is reached in the future::multisession backend as expected.
-          next # nocov
+          # nocov start
+          Sys.sleep(config$sleep(max(0L, i)))
+          i <- i + 1
+          next
+          # nocov end
         }
+        i <- 1
         running <- running_targets(workers = workers, config = config)
         protect <- c(running, queue$list())
         if (identical(config$layout[[next_target]]$hpc, FALSE)) {
@@ -39,8 +43,6 @@ backend_future <- function(config) {
         }
       }
     }
-    Sys.sleep(config$sleep(max(0L, i)))
-    i <- i + 1
   }
 }
 

--- a/R/backend-loop.R
+++ b/R/backend-loop.R
@@ -3,6 +3,7 @@ backend_loop <- function(config) {
     lock_environment(config$envir)
     on.exit(unlock_environment(config$envir))
   }
+  config$lock_envir <- FALSE
   targets <- igraph::topo_sort(config$graph)$name
   for (i in seq_along(targets)) {
     loop_build(
@@ -15,7 +16,6 @@ backend_loop <- function(config) {
 }
 
 loop_build <- function(target, config, downstream) {
-  config$lock_envir <- FALSE # Already locked it in backend_loop().
   meta <- drake_meta_(target = target, config = config)
   if (!should_build_target(target, meta, config)) {
     log_msg("skip", target, config = config)

--- a/R/test-testthat.R
+++ b/R/test-testthat.R
@@ -178,7 +178,7 @@ equivalent_plans <- function(out, exp) {
 # Below, toggle the if() condition on in test mode
 # and off in production mode.
 # nocov start
-if (FALSE) {
+if (TRUE) {
   `&&` <- function(x, y) {
     if (length(x) != 1) {
       stop("length x not 1")

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -8,6 +8,7 @@ Ane
 args
 Args
 Axthelm
+backoff
 Badi
 Baltagi
 batchtools
@@ -17,6 +18,10 @@ Boneri
 Bostock
 Broman
 Broman's
+bugfix
+Bugfix
+bugfixes
+Bugfixes
 changelog
 Changelog
 checksum

--- a/tests/testthat/test-clustermq.R
+++ b/tests/testthat/test-clustermq.R
@@ -68,3 +68,47 @@ test_with_dir("clustermq parallelism", {
     detach("package:clustermq", unload = TRUE) # nolint
   }
 })
+
+test_with_dir("No hpc targets? No workers.", {
+  plan <- drake_plan(x = target(1, hpc = FALSE), y = target(x, hpc = FALSE))
+  drake:::with_options(
+    list(clustermq.scheduler = "does_not_exist"),
+    make(
+      plan,
+      parallelism = "clustermq",
+      jobs = 2,
+      session_info = FALSE,
+      cache = storr::storr_environment()
+    )
+  )
+})
+
+test_with_dir("Start off with non-HPC targets, then go to HPC targets.", {
+  skip_on_cran()
+  if ("package:clustermq" %in% search()) {
+    detach("package:clustermq", unload = TRUE) # nolint
+  }
+  options(clustermq.scheduler = "multicore")
+  skip_if_not_installed("clustermq")
+  skip_on_os("windows")
+  scenario <- get_testing_scenario()
+  e <- eval(parse(text = scenario$envir))
+  jobs <- scenario$jobs # ignoring for now, using 2 jobs
+  load_mtcars_example(envir = e)
+  e$my_plan$hpc <- !(e$my_plan$target %in% c("small", "large"))
+  make(
+    e$my_plan,
+    parallelism = "clustermq",
+    jobs = jobs,
+    envir = e,
+    verbose = 1L,
+    garbage_collection = TRUE,
+    lock_envir = TRUE
+  )
+  config <- drake_config(e$my_plan, envir = e)
+  expect_equal(sort(justbuilt(config)), sort(e$my_plan$target))
+  expect_equal(outdated(config), character(0))
+  if ("package:clustermq" %in% search()) {
+    detach("package:clustermq", unload = TRUE) # nolint
+  }
+})

--- a/tests/testthat/test-clustermq.R
+++ b/tests/testthat/test-clustermq.R
@@ -2,12 +2,12 @@ drake_context("clustermq")
 
 test_with_dir("clustermq parallelism", {
   skip_on_cran()
+  skip_if_not_installed("clustermq")
+  skip_on_os("windows")
   if ("package:clustermq" %in% search()) {
     detach("package:clustermq", unload = TRUE) # nolint
   }
   options(clustermq.scheduler = "multicore")
-  skip_if_not_installed("clustermq")
-  skip_on_os("windows")
   scenario <- get_testing_scenario()
   e <- eval(parse(text = scenario$envir))
   jobs <- scenario$jobs # ignoring for now, using 2 jobs
@@ -70,6 +70,13 @@ test_with_dir("clustermq parallelism", {
 })
 
 test_with_dir("No hpc targets? No workers.", {
+  skip_on_cran()
+  skip_if_not_installed("clustermq")
+  skip_on_os("windows")
+  if ("package:clustermq" %in% search()) {
+    detach("package:clustermq", unload = TRUE) # nolint
+  }
+  options(clustermq.scheduler = "multicore")
   plan <- drake_plan(x = target(1L, hpc = FALSE), y = target(x, hpc = FALSE))
   drake:::with_options(
     list(clustermq.scheduler = "does_not_exist"),
@@ -81,9 +88,19 @@ test_with_dir("No hpc targets? No workers.", {
       cache = storr::storr_environment()
     )
   )
+  if ("package:clustermq" %in% search()) {
+    detach("package:clustermq", unload = TRUE) # nolint
+  }
 })
 
 test_with_dir("All hpc targets up to date? No workers.", {
+  skip_on_cran()
+  skip_if_not_installed("clustermq")
+  skip_on_os("windows")
+  if ("package:clustermq" %in% search()) {
+    detach("package:clustermq", unload = TRUE) # nolint
+  }
+  options(clustermq.scheduler = "multicore")
   plan <- drake_plan(x = target(1L, hpc = FALSE), y = target(x, hpc = TRUE))
   cache <- storr::storr_environment()
   make(plan, session_info = FALSE, cache = cache)
@@ -107,16 +124,19 @@ test_with_dir("All hpc targets up to date? No workers.", {
     )
   )
   expect_equal(justbuilt(config), "x")
+  if ("package:clustermq" %in% search()) {
+    detach("package:clustermq", unload = TRUE) # nolint
+  }
 })
 
 test_with_dir("Start off with non-HPC targets, then go to HPC targets.", {
   skip_on_cran()
+  skip_if_not_installed("clustermq")
+  skip_on_os("windows")
   if ("package:clustermq" %in% search()) {
     detach("package:clustermq", unload = TRUE) # nolint
   }
   options(clustermq.scheduler = "multicore")
-  skip_if_not_installed("clustermq")
-  skip_on_os("windows")
   scenario <- get_testing_scenario()
   e <- eval(parse(text = scenario$envir))
   jobs <- scenario$jobs # ignoring for now, using 2 jobs


### PR DESCRIPTION
# Summary

- Delay the initialization of `clustermq` workers for as long as possible. Before launching them, build/check targets locally until we reach an outdated target with `hpc` equal to `FALSE`. In other words, if no targets actually require `clustermq` workers, no workers get created.
- In `make(parallelism = "future")`, reset the `config$sleep()` backoff interval whenever a new target gets checked.
- Bugfix: move "`config$lock_envir <- FALSE`" from `loop_build()` to  `backend_loop()`. This makes sure `config$envir` is correctly locked in `make(parallelism = "clustermq")`.

# Related GitHub issues and pull requests

- Ref: #848

# Checklist

- [x] I understand and agree to `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CODE_OF_CONDUCT.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) for any new functionality.
- [x] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).
