### PR TITLE
Native data splitting

### DIFF
--- a/R/api-plan.R
+++ b/R/api-plan.R
@@ -11,9 +11,10 @@
 #' @details `drake` has special syntax for generating large plans.
 #'  Your code will look something like
 #'  `drake_plan(x = target(cmd, transform = f(y, z), group = g)`
-#'  where `f()` is either `map()`, `cross()`, or `combine()`
-#'  (similar to `purrr::pmap()`, `tidy::crossing()`, and `dplyr::summarize()`,
-#'  respectively). These verbs mimic Tidyverse behavior to scale up
+#'  where `f()` is either `map()`, `cross()`, `split()`, or `combine()`
+#'  (similar to `purrr::pmap()`, `tidy::crossing()`, `base::split()`,
+#'  and  `dplyr::summarize()`, respectively).
+#'  These verbs mimic Tidyverse behavior to scale up
 #'  existing plans to large numbers of targets.
 #'  You can read about this interface at
 #'  <https://ropenscilabs.github.io/drake-manual/plans.html#create-large-plans-the-easy-way>. # nolint

--- a/R/api-plan.R
+++ b/R/api-plan.R
@@ -95,6 +95,20 @@
 #'   )
 #' )
 #'
+#' # Split data among multiple targets.
+#' drake_plan(
+#'   large_data = get_data(),
+#'   slice_analysis = target(
+#'     large_data %>%
+#'       analyze(),
+#'     transform = split(large_data, slices = 4)
+#'   ),
+#'   results = target(
+#'     dplyr::bind_rows(slice_analysis),
+#'     transform = combine(slice_analysis)
+#'   )
+#' )
+#'
 #' # Set trace = TRUE to show what happened during the transformation process.
 #' drake_plan(
 #'   data = target(

--- a/R/api-plan.R
+++ b/R/api-plan.R
@@ -104,7 +104,7 @@
 #'     transform = split(large_data, slices = 4)
 #'   ),
 #'   results = target(
-#'     dplyr::bind_rows(slice_analysis),
+#'     rbind(slice_analysis),
 #'     transform = combine(slice_analysis)
 #'   )
 #' )

--- a/man/drake_plan.Rd
+++ b/man/drake_plan.Rd
@@ -128,7 +128,7 @@ drake_plan(
     transform = split(large_data, slices = 4)
   ),
   results = target(
-    dplyr::bind_rows(slice_analysis),
+    rbind(slice_analysis),
     transform = combine(slice_analysis)
   )
 )

--- a/man/drake_plan.Rd
+++ b/man/drake_plan.Rd
@@ -119,6 +119,20 @@ drake_plan(
   )
 )
 
+# Split data among multiple targets.
+drake_plan(
+  large_data = get_data(),
+  slice_analysis = target(
+    large_data \%>\%
+      analyze(),
+    transform = split(large_data, slices = 4)
+  ),
+  results = target(
+    dplyr::bind_rows(slice_analysis),
+    transform = combine(slice_analysis)
+  )
+)
+
 # Set trace = TRUE to show what happened during the transformation process.
 drake_plan(
   data = target(

--- a/man/drake_plan.Rd
+++ b/man/drake_plan.Rd
@@ -60,9 +60,10 @@ code strings or a list of language objects.
 \code{drake} has special syntax for generating large plans.
 Your code will look something like
 \code{drake_plan(x = target(cmd, transform = f(y, z), group = g)}
-where \code{f()} is either \code{map()}, \code{cross()}, or \code{combine()}
-(similar to \code{purrr::pmap()}, \code{tidy::crossing()}, and \code{dplyr::summarize()},
-respectively). These verbs mimic Tidyverse behavior to scale up
+where \code{f()} is either \code{map()}, \code{cross()}, \code{split()}, or \code{combine()}
+(similar to \code{purrr::pmap()}, \code{tidy::crossing()}, \code{base::split()},
+and  \code{dplyr::summarize()}, respectively).
+These verbs mimic Tidyverse behavior to scale up
 existing plans to large numbers of targets.
 You can read about this interface at
 \url{https://ropenscilabs.github.io/drake-manual/plans.html#create-large-plans-the-easy-way}. # nolint

--- a/tests/testthat/test-dsl.R
+++ b/tests/testthat/test-dsl.R
@@ -2399,3 +2399,19 @@ test_with_dir("max_expand with a .data grid for cross()", {
   )
   equivalent_plans(out, exp)
 })
+
+test_with_dir("basic splitting", {
+  out <- drake_plan(
+    large_data = get_data(),
+    slice_analysis = target(
+      large_data %>%
+        analyze(),
+      transform = split(large_data, slices = 4)
+    ),
+    results = target(
+      dplyr::bind_rows(slice_analysis),
+      transform = combine(slice_analysis)
+    )
+  )
+
+})

--- a/tests/testthat/test-dsl.R
+++ b/tests/testthat/test-dsl.R
@@ -2413,5 +2413,91 @@ test_with_dir("basic splitting", {
       transform = combine(slice_analysis)
     )
   )
+  exp <- drake_plan(
+    large_data = get_data(),
+    slice_analysis_1 = drake_slice(
+      data = large_data, slices = 4, index = 1) %>% analyze(),
+    slice_analysis_2 = drake_slice(
+      data = large_data, slices = 4, index = 2) %>% analyze(),
+    slice_analysis_3 = drake_slice(
+      data = large_data, slices = 4, index = 3) %>% analyze(),
+    slice_analysis_4 = drake_slice(
+      data = large_data, slices = 4, index = 4) %>% analyze(),
+    results = dplyr::bind_rows(
+      slice_analysis_1, slice_analysis_2, slice_analysis_3,
+      slice_analysis_4
+    )
+  )
+  equivalent_plans(out, exp)
+})
 
+test_with_dir("splitting with all args", {
+  out <- drake_plan(
+    large_data = get_data(),
+    slice_analysis = target(
+      large_data %>%
+        analyze(),
+      transform = split(large_data, margin = 2, drop = TRUE, slices = 4)
+    ),
+    results = target(
+      dplyr::bind_rows(slice_analysis),
+      transform = combine(slice_analysis)
+    )
+  )
+  exp <- drake_plan(
+    large_data = get_data(),
+    slice_analysis_1 = drake_slice(
+      data = large_data, slices = 4, index = 1, margin = 2,
+      drop = TRUE
+    ) %>% analyze(),
+    slice_analysis_2 = drake_slice(
+      data = large_data, slices = 4, index = 2, margin = 2,
+      drop = TRUE
+    ) %>% analyze(),
+    slice_analysis_3 = drake_slice(
+      data = large_data, slices = 4, index = 3, margin = 2,
+      drop = TRUE
+    ) %>% analyze(),
+    slice_analysis_4 = drake_slice(
+      data = large_data, slices = 4, index = 4, margin = 2,
+      drop = TRUE
+    ) %>% analyze(),
+    results = dplyr::bind_rows(
+      slice_analysis_1, slice_analysis_2, slice_analysis_3,
+      slice_analysis_4
+    )
+  )
+  equivalent_plans(out, exp)
+})
+
+test_with_dir("splitting with tidy eval", {
+  s <- 4
+  out <- drake_plan(
+    large_data = get_data(),
+    slice_analysis = target(
+      large_data %>%
+        analyze(),
+      transform = split(large_data, slices = !!s)
+    ),
+    results = target(
+      dplyr::bind_rows(slice_analysis),
+      transform = combine(slice_analysis)
+    )
+  )
+  exp <- drake_plan(
+    large_data = get_data(),
+    slice_analysis_1 = drake_slice(
+      data = large_data, slices = 4, index = 1) %>% analyze(),
+    slice_analysis_2 = drake_slice(
+      data = large_data, slices = 4, index = 2) %>% analyze(),
+    slice_analysis_3 = drake_slice(
+      data = large_data, slices = 4, index = 3) %>% analyze(),
+    slice_analysis_4 = drake_slice(
+      data = large_data, slices = 4, index = 4) %>% analyze(),
+    results = dplyr::bind_rows(
+      slice_analysis_1, slice_analysis_2, slice_analysis_3,
+      slice_analysis_4
+    )
+  )
+  equivalent_plans(out, exp)
 })

--- a/tests/testthat/test-dsl.R
+++ b/tests/testthat/test-dsl.R
@@ -2409,7 +2409,7 @@ test_with_dir("basic splitting", {
       transform = split(large_data, slices = 4)
     ),
     results = target(
-      dplyr::bind_rows(slice_analysis),
+      rbind(slice_analysis),
       transform = combine(slice_analysis)
     )
   )
@@ -2423,7 +2423,7 @@ test_with_dir("basic splitting", {
       data = large_data, slices = 4, index = 3) %>% analyze(),
     slice_analysis_4 = drake_slice(
       data = large_data, slices = 4, index = 4) %>% analyze(),
-    results = dplyr::bind_rows(
+    results = rbind(
       slice_analysis_1, slice_analysis_2, slice_analysis_3,
       slice_analysis_4
     )
@@ -2440,7 +2440,7 @@ test_with_dir("splitting with all args", {
       transform = split(large_data, margin = 2, drop = TRUE, slices = 4)
     ),
     results = target(
-      dplyr::bind_rows(slice_analysis),
+      rbind(slice_analysis),
       transform = combine(slice_analysis)
     )
   )
@@ -2462,7 +2462,7 @@ test_with_dir("splitting with all args", {
       data = large_data, slices = 4, index = 4, margin = 2,
       drop = TRUE
     ) %>% analyze(),
-    results = dplyr::bind_rows(
+    results = rbind(
       slice_analysis_1, slice_analysis_2, slice_analysis_3,
       slice_analysis_4
     )
@@ -2480,7 +2480,7 @@ test_with_dir("splitting with tidy eval", {
       transform = split(large_data, slices = !!s)
     ),
     results = target(
-      dplyr::bind_rows(slice_analysis),
+      rbind(slice_analysis),
       transform = combine(slice_analysis)
     )
   )
@@ -2494,7 +2494,7 @@ test_with_dir("splitting with tidy eval", {
       data = large_data, slices = 4, index = 3) %>% analyze(),
     slice_analysis_4 = drake_slice(
       data = large_data, slices = 4, index = 4) %>% analyze(),
-    results = dplyr::bind_rows(
+    results = rbind(
       slice_analysis_1, slice_analysis_2, slice_analysis_3,
       slice_analysis_4
     )


### PR DESCRIPTION
# Summary

cc @kendonB, @AlexAxthelm. Turned out to be surprisingly lightweight in the implementation.

``` r
library(drake)
plan <- drake_plan(
  large_data = get_data(),
  slice_analysis = target(
    large_data %>%
      analyze(),
    transform = split(large_data, margin = 2, drop = TRUE, slices = 4)
  ),
  results = target(
    dplyr::bind_rows(slice_analysis),
    transform = combine(slice_analysis)
  )
)

plan
#> # A tibble: 6 x 2
#>   target         command                                                   
#>   <chr>          <expr>                                                    
#> 1 large_data     get_data()                                               …
#> 2 slice_analysi… drake_slice(data = large_data, slices = 4, index = 1, mar…
#> 3 slice_analysi… drake_slice(data = large_data, slices = 4, index = 2, mar…
#> 4 slice_analysi… drake_slice(data = large_data, slices = 4, index = 3, mar…
#> 5 slice_analysi… drake_slice(data = large_data, slices = 4, index = 4, mar…
#> 6 results        dplyr::bind_rows(slice_analysis_1, slice_analysis_2, slic…

drake_plan_source(plan)
#> drake_plan(
#>   large_data = get_data(),
#>   slice_analysis_1 = drake_slice(
#>     data = large_data, slices = 4, index = 1, margin = 2,
#>     drop = TRUE
#>   ) %>% analyze(),
#>   slice_analysis_2 = drake_slice(
#>     data = large_data, slices = 4, index = 2, margin = 2,
#>     drop = TRUE
#>   ) %>% analyze(),
#>   slice_analysis_3 = drake_slice(
#>     data = large_data, slices = 4, index = 3, margin = 2,
#>     drop = TRUE
#>   ) %>% analyze(),
#>   slice_analysis_4 = drake_slice(
#>     data = large_data, slices = 4, index = 4, margin = 2,
#>     drop = TRUE
#>   ) %>% analyze(),
#>   results = dplyr::bind_rows(
#>     slice_analysis_1, slice_analysis_2, slice_analysis_3,
#>     slice_analysis_4
#>   )
#> )

config <- drake_config(plan)
vis_drake_graph(config)
```

![](https://i.imgur.com/kSn82rp.png)

<sup>Created on 2019-05-22 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

 Should be powerful when it comes to `file_in()` files. If we split on index sets instead of the data itself, we don't have to load all the data into memory at once.

# Related GitHub issues and pull requests

- Ref: #833

# Checklist

- [x] I understand and agree to `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CODE_OF_CONDUCT.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) for any new functionality.
- [x] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).
