### PR TITLE
Fix link to drake manual in use_drake() template

### DIFF
--- a/inst/templates/usedrake/make.R
+++ b/inst/templates/usedrake/make.R
@@ -1,4 +1,4 @@
-# Walkthrough: https://ropenscilabs.github.io/drake-manual/intro.html
+# Walkthrough: https://ropenscilabs.github.io/drake-manual/index.html#intro
 # Download the code: drake_example("main") # nolint
 
 # Load your packages and supporting functions into your session.

--- a/inst/templates/usedrake/make.R
+++ b/inst/templates/usedrake/make.R
@@ -1,4 +1,4 @@
-# Walkthrough: https://ropenscilabs.github.io/drake-manual/index.html#intro
+# Walkthrough: https://ropenscilabs.github.io/drake-manual/walkthrough.html
 # Download the code: drake_example("main") # nolint
 
 # Load your packages and supporting functions into your session.


### PR DESCRIPTION
This is a small typo fix updating the link to the drake manual in the `use_drake()` templates.
