### PR TITLE
Restore compatibility with `clustermq`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -93,7 +93,7 @@ Suggests:
   bindr,
   callr,
   cli (>= 1.1.0),
-  clustermq,
+  clustermq (>= 0.8.8),
   crayon,
   curl,
   datasets,

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@ These changes are technically breaking changes, but they should only affect adva
 
 ## Bug fixes
 
+- Restore compatibility with `clustermq` ([#898](https://github.com/ropensci/drake/issues/898)). Suggest version >= 0.8.8 but allow 0.8.7 as well.
 - Ensure `drake` recomputes `config$layout` when `knitr` reports change ([#887](https://github.com/ropensci/drake/issues/887)).
 - Do not rehash large imported files every `make()` ([#878](https://github.com/ropensci/drake/issues/878)).
 - Repair parsing of long tidy eval inputs in the DSL ([#878](https://github.com/ropensci/drake/issues/881)).

--- a/R/backend-clustermq.R
+++ b/R/backend-clustermq.R
@@ -43,14 +43,33 @@ cmq_set_common_data <- function(config) {
     export <- as.list(config$envir, all.names = TRUE) # nocov
   }
   export$config <- cmq_config(config)
-  config$workers$set_common_data(
-    export = export,
-    fun = identity,
-    const = list(),
-    rettype = list(),
-    common_seed = config$seed,
-    token = "set_common_data_token"
-  )
+  use_pkgs <- utils::compareVersion(
+    paste0(utils::packageVersion("clustermq"), collapse = "."),
+    "0.8.8"
+  ) >= 0L
+  if (use_pkgs) {
+    config$workers$set_common_data(
+      export = export,
+      fun = identity,
+      const = list(),
+      rettype = list(),
+      pkgs = character(0),
+      common_seed = config$seed,
+      token = "set_common_data_token"
+    )
+  } else {
+    # Need to test manually with old clustermq.
+    # nocov start
+    config$workers$set_common_data(
+      export = export,
+      fun = identity,
+      const = list(),
+      rettype = list(),
+      common_seed = config$seed,
+      token = "set_common_data_token"
+    )
+    # nocov end
+  }
 }
 
 cmq_master <- function(config) {

--- a/tests/testthat/test-clustermq.R
+++ b/tests/testthat/test-clustermq.R
@@ -1,7 +1,6 @@
 drake_context("clustermq")
 
 test_with_dir("clustermq parallelism", {
-  skip_on_cran()
   skip_if_not_installed("clustermq")
   skip_on_os("windows")
   if ("package:clustermq" %in% search()) {

--- a/tests/testthat/test-future.R
+++ b/tests/testthat/test-future.R
@@ -1,7 +1,6 @@
 drake_context("future")
 
 test_with_dir("future package functionality", {
-  skip_on_cran() # CRAN gets whitelist tests only (check time limits).
   skip_if_not_installed("future")
   future::plan(future::sequential)
   scenario <- get_testing_scenario()


### PR DESCRIPTION
# Summary

`clustermq` version 0.8.8 (just released) is not compatible with `drake`. This PR restores compatibility.

- Set the `pkgs` argument in `config$workers$set_common_data()` if the `clustermq` version is 0.8.8 or above. Otherwise do not set a `pkgs` argument.
- Enable the `future` and `clustermq` tests to run on CRAN.

cc @mschubert

# Related GitHub issues and pull requests

- Ref: #898 

# Checklist

- [x] I understand and agree to `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CODE_OF_CONDUCT.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) for any new functionality.
- [x] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).
