### PR TITLE
Interpret custom columns as non-language objects

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 
 ## Enhancements
 
+- In `drake_plan()`, interpret custom columns as non-language objects (#942).
 - Suggest and assert `clustermq` >= 0.8.8.
 - Log the target name in a special column in the console log file ([#909](https://github.com/ropensci/drake/issues/909)).
 - Rename the "memory" memory strategy to "preclean" (with deprecation; #917).

--- a/R/api-dsl.R
+++ b/R/api-dsl.R
@@ -41,6 +41,7 @@ transform_plan <- function(
   max_expand = NULL,
   tidy_eval = TRUE
 ) {
+  force(envir)
   transform_plan_(
     plan = plan,
     envir = envir,
@@ -85,7 +86,7 @@ transform_plan_ <- function(
     }
   }
   if (sanitize) {
-    plan <- sanitize_plan(plan)
+    plan <- sanitize_plan(plan, envir = envir)
   }
   plan
 }

--- a/R/drake_plan_keywords.R
+++ b/R/drake_plan_keywords.R
@@ -40,13 +40,13 @@ target <- function(command = NULL, ...) {
   lst <- select_nonempty(lst)
   lst <- lst[nzchar(names(lst))]
   lst <- c(command = call$command, lst)
-  lst <- lapply(lst, function(x) {
-    if (is.language(x)) x <- list(x)
-    x
-  })
   out <- data.frame(command = NA, stringsAsFactors = FALSE)
   for (col in names(lst)) {
-    out[[col]] <- lst[[col]]
+    if (is.language(lst[[col]])) {
+      out[[col]] <- list(lst[[col]])
+    } else {
+      out[[col]] <- lst[[col]]
+    }
   }
   out
 }

--- a/R/preprocess-config.R
+++ b/R/preprocess-config.R
@@ -568,10 +568,10 @@ drake_config <- function(
       # 2019-06-22 # nolint
     )
   }
-  plan <- sanitize_plan(plan)
+  force(envir)
+  plan <- sanitize_plan(plan, envir = envir)
   plan_checks(plan)
   targets <- sanitize_targets(targets, plan)
-  force(envir)
   trigger <- convert_old_trigger(trigger)
   sleep <- `environment<-`(sleep, new.env(parent = globalenv()))
   if (is.null(cache)) {

--- a/tests/testthat/test-dsl.R
+++ b/tests/testthat/test-dsl.R
@@ -995,200 +995,70 @@ test_with_dir("dsl with differently typed group levels", {
 })
 
 test_with_dir("tidy eval in the DSL", {
-  sms <- rlang::syms(letters)
+  h <- function(x) {
+    x
+  }
   out <- drake_plan(
     x = target(
       f(char),
       trigger = trigger(condition = g(char)),
       custom = h(char),
-      transform = map(char = !!sms)
+      transform = map(char = !!letters[1:2])
     )
   )
   exp <- drake_plan(
     x_a = target(
-      command = f(a),
+      command = f("a"),
       trigger = trigger(
-        condition = g(a)
+        condition = g("a")
       ),
-      custom = h(a)
+      custom = "a"
     ),
     x_b = target(
-      command = f(b),
+      command = f("b"),
       trigger = trigger(
-        condition = g(b)
+        condition = g("b")
       ),
-      custom = h(b)
-    ),
-    x_c = target(
-      command = f(c),
-      trigger = trigger(
-        condition = g(c)
-      ),
-      custom = h(c)
-    ),
-    x_d = target(
-      command = f(d),
-      trigger = trigger(
-        condition = g(d)
-      ),
-      custom = h(d)
-    ),
-    x_e = target(
-      command = f(e),
-      trigger = trigger(
-        condition = g(e)
-      ),
-      custom = h(e)
-    ),
-    x_f = target(
-      command = f(f),
-      trigger = trigger(
-        condition = g(f)
-      ),
-      custom = h(f)
-    ),
-    x_g = target(
-      command = f(g),
-      trigger = trigger(
-        condition = g(g)
-      ),
-      custom = h(g)
-    ),
-    x_h = target(
-      command = f(h),
-      trigger = trigger(
-        condition = g(h)
-      ),
-      custom = h(h)
-    ),
-    x_i = target(
-      command = f(i),
-      trigger = trigger(
-        condition = g(i)
-      ),
-      custom = h(i)
-    ),
-    x_j = target(
-      command = f(j),
-      trigger = trigger(
-        condition = g(j)
-      ),
-      custom = h(j)
-    ),
-    x_k = target(
-      command = f(k),
-      trigger = trigger(
-        condition = g(k)
-      ),
-      custom = h(k)
-    ),
-    x_l = target(
-      command = f(l),
-      trigger = trigger(
-        condition = g(l)
-      ),
-      custom = h(l)
-    ),
-    x_m = target(
-      command = f(m),
-      trigger = trigger(
-        condition = g(m)
-      ),
-      custom = h(m)
-    ),
-    x_n = target(
-      command = f(n),
-      trigger = trigger(
-        condition = g(n)
-      ),
-      custom = h(n)
-    ),
-    x_o = target(
-      command = f(o),
-      trigger = trigger(
-        condition = g(o)
-      ),
-      custom = h(o)
-    ),
-    x_p = target(
-      command = f(p),
-      trigger = trigger(
-        condition = g(p)
-      ),
-      custom = h(p)
-    ),
-    x_q = target(
-      command = f(q),
-      trigger = trigger(
-        condition = g(q)
-      ),
-      custom = h(q)
-    ),
-    x_r = target(
-      command = f(r),
-      trigger = trigger(
-        condition = g(r)
-      ),
-      custom = h(r)
-    ),
-    x_s = target(
-      command = f(s),
-      trigger = trigger(
-        condition = g(s)
-      ),
-      custom = h(s)
-    ),
-    x_t = target(
-      command = f(t),
-      trigger = trigger(
-        condition = g(t)
-      ),
-      custom = h(t)
-    ),
-    x_u = target(
-      command = f(u),
-      trigger = trigger(
-        condition = g(u)
-      ),
-      custom = h(u)
-    ),
-    x_v = target(
-      command = f(v),
-      trigger = trigger(
-        condition = g(v)
-      ),
-      custom = h(v)
-    ),
-    x_w = target(
-      command = f(w),
-      trigger = trigger(
-        condition = g(w)
-      ),
-      custom = h(w)
-    ),
-    x_x = target(
-      command = f(x),
-      trigger = trigger(
-        condition = g(x)
-      ),
-      custom = h(x)
-    ),
-    x_y = target(
-      command = f(y),
-      trigger = trigger(
-        condition = g(y)
-      ),
-      custom = h(y)
-    ),
-    x_z = target(
-      command = f(z),
-      trigger = trigger(
-        condition = g(z)
-      ),
-      custom = h(z)
+      custom = "b"
     )
   )
   equivalent_plans(out, exp)
+})
+
+test_with_dir("resource column is not a language object (#942)", {
+  mem <- 1024
+  x <- "b"
+  out <- drake_plan(
+    data = target(
+      download_data(),
+      resources = list(cores = 1, gpus = 0, mem = !!mem),
+      x = "a"
+    ),
+    model = target(
+      big_machine_learning_model(data),
+      resources = list(cores = 4, gpus = 1, mem = !!mem),
+      x = !!x
+    )
+  )
+  exp <- drake_plan(
+    data = target(
+      command = download_data(),
+      resources = list(cores = 1, gpus = 0, mem = 1024),
+      x = "a"
+    ),
+    model = target(
+      command = big_machine_learning_model(data),
+      resources = list(cores = 4, gpus = 1, mem = 1024),
+      x = "b"
+    )
+  )
+  equivalent_plans(out, exp)
+  out <- out$resources
+  exp <- list(
+    list(cores = 1, gpus = 0, mem = 1024),
+    list(cores = 4, gpus = 1, mem = 1024)
+  )
+  expect_equal(out, exp)
 })
 
 test_with_dir("dsl: exact same plan as mtcars", {

--- a/tests/testthat/test-graph.R
+++ b/tests/testthat/test-graph.R
@@ -27,10 +27,10 @@ test_with_dir("lang cluster cols", {
   skip_on_cran() # CRAN gets whitelist tests only (check time limits).
   skip_if_not_installed("lubridate")
   skip_if_not_installed("visNetwork")
-  plan <- drake_plan(x = target(1, col = g(f(x))))
+  plan <- drake_plan(x = target(1, transform = g(f(x))), transform = FALSE)
   config <- drake_config(plan)
-  x <- drake_graph_info(config = config, group = "col")
-  expect_equal(x$nodes$col, "g(f(x))")
+  x <- drake_graph_info(config = config, group = "transform")
+  expect_equal(x$nodes$transform, "g(f(x))")
 })
 
 test_with_dir("circular non-DAG drake_plans quit in error", {

--- a/tests/testthat/test-plans.R
+++ b/tests/testthat/test-plans.R
@@ -241,17 +241,17 @@ test_with_dir("custom column interface", {
   skip_on_cran() # CRAN gets whitelist tests only (check time limits).
   tidyvar <- 2
   x <- drake_plan(x = target(
-    stop(!!tidyvar), worker = !!tidyvar, cpu = 4, custom = stop(), c2 = 5)
+    stop(!!tidyvar), worker = !!tidyvar, cpu = 4, custom = list(123), c2 = 5)
   )
   expect_true(is.list(x$custom))
-  expect_true(is.language(x$custom[[1]]))
+  expect_true(is.list(x$custom[[1]]))
   x$custom <- safe_deparse(x$custom[[1]])
   y <- weak_tibble(
     target = "x",
     command = "stop(2)",
     worker = 2,
     cpu = 4,
-    custom = "stop()",
+    custom = "list(123)",
     c2 = 5
   )
   equivalent_plans(x, y)


### PR DESCRIPTION
# Summary

If the user supplies `resources` to `target()`, the result should be a list, not a language object. cc @joelnitta

``` r
library(drake)

mem <- 1024
x <- "b"

plan <- drake_plan(
  data = target(
    download_data(),
    resources = list(cores = 1, gpus = 0, mem = !!mem),
    x = "a"
  ),
  model = target(
    big_machine_learning_model(data),
    resources = list(cores = 4, gpus = 1, mem = !!mem),
    x = !!x
  )
)

plan
#> # A tibble: 2 x 4
#>   target command                          resources        x    
#>   <chr>  <expr>                           <list>           <chr>
#> 1 data   download_data()                  <named list [3]> a    
#> 2 model  big_machine_learning_model(data) <named list [3]> b

str(plan$resources)
#> List of 2
#>  $ :List of 3
#>   ..$ cores: num 1
#>   ..$ gpus : num 0
#>   ..$ mem  : num 1024
#>  $ :List of 3
#>   ..$ cores: num 4
#>   ..$ gpus : num 1
#>   ..$ mem  : num 1024
```

<sup>Created on 2019-07-14 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

# Related GitHub issues and pull requests

- Ref: #942.

# Checklist

- [x] I understand and agree to `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CODE_OF_CONDUCT.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) for any new functionality.
- [x] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).
