### PR TITLE
Custom target seeds

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 - Add a new `no_deps()` function, similar to `ignore()`. `no_deps()` suppresses dependency detection but still tracks changes to the literal code ([#910](https://github.com/ropensci/drake/issues/910)).
 - Add a new "autoclean" memory strategy (#917).
 - Export `transform_plan()`.
+- Allow a custom `seed` column of `drake` plans to set custom seeds (#947).
+- Add a new `seed` trigger to optionally ignore changes to the target seed (#947).
 
 ## Enhancements
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,7 +19,8 @@
 - Warn when the user supplies additional arguments to `make()` after `config` is already supplied.
 - Prevent users from running `make()` from inside the cache (#927).
 - Add `CITATION` file with JOSS paper.
-- in `deps_profile()`, include the seed and change the names.
+- In `deps_profile()`, include the seed and change the names.
+- Allow the user to set a different seed in `make()`. All this does is invalidate old targets.
 
 ## Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@
 - Warn when the user supplies additional arguments to `make()` after `config` is already supplied.
 - Prevent users from running `make()` from inside the cache (#927).
 - Add `CITATION` file with JOSS paper.
+- in `deps_profile()`, include the seed and change the names.
 
 ## Bug fixes
 

--- a/R/api-history.R
+++ b/R/api-history.R
@@ -89,7 +89,8 @@ drake_history <- function(
     hash = out$hash,
     exists = out$exists,
     command = out$command,
-    runtime = out$runtime
+    runtime = out$runtime,
+    seed = out$seed
   )
   out <- out[order(out$target, out$time), ]
   out$latest <- !duplicated(out$target, fromLast = TRUE)
@@ -111,6 +112,7 @@ history_from_cache <- function(meta_hash, cache) {
         exists = NA,
         command = NA_character_,
         runtime = NA,
+        seed = NA_integer_,
         stringsAsFactors = FALSE
       )
     )
@@ -120,6 +122,7 @@ history_from_cache <- function(meta_hash, cache) {
   out$exists <- cache$exists_object(meta$hash)
   out$command <- meta$command
   out$runtime <- meta$time_command$elapsed
+  out$seed <- meta$seed
   out$message <- meta_hash
   out
 }

--- a/R/exec-dependencies.R
+++ b/R/exec-dependencies.R
@@ -96,17 +96,21 @@ display_deps_list <- function(x) {
 #' @description The dependency profile can give you
 #'   a hint as to why a target is out of date.
 #'   It can tell you if
+#'   - the command changed
+#'     ([deps_profile()] reports the *hash* of the command,
+#'     not the command itself)
 #'   - at least one input file changed,
 #'   - at least one output file changed,
 #'   - or a non-file dependency changed. For this last part,
 #'     the imports need to be up to date in the cache,
 #'     which you can do with `outdated()` or
 #'     `make(skip_targets = TRUE)`.
+#'   - the pseudo-random number generator seed changed.
 #'   Unfortunately, `deps_profile()` does not
 #'   currently get more specific than that.
-#' @return A data frame of the old hashes and
-#'   new hashes of the data frame, along with
-#'   an indication of which hashes changed since
+#' @return A data frame of old and new values for each
+#'   of the main triggers, along with
+#'   an indication of which values changed since
 #'   the last [make()].
 #' @export
 #' @seealso [diagnose()],
@@ -152,21 +156,22 @@ deps_profile <- function(
   if (!length(meta$command)) {
     meta$command <- NA_character_
   }
-  old_hashes <- meta[c(
+  old_values <- meta[c(
     "command",
     "dependency_hash",
     "input_file_hash",
-    "output_file_hash"
+    "output_file_hash",
+    "seed"
   )]
-  old_hashes <- unlist(old_hashes)
-  old_hashes <- unname(old_hashes)
-  old_hashes[1] <- digest::digest(
-    paste(old_hashes[1], collapse = ""),
+  old_values <- unlist(old_values)
+  old_values <- unname(old_values)
+  old_values[1] <- digest::digest(
+    paste(old_values[1], collapse = ""),
     algo = config$cache$driver$hash_algorithm,
     serialize = FALSE
   )
   layout <- config$layout[[target]]
-  new_hashes <- c(
+  new_values <- c(
     digest::digest(
       paste(layout$command_standardized, collapse = ""),
       algo = config$cache$driver$hash_algorithm,
@@ -174,13 +179,16 @@ deps_profile <- function(
     ),
     dependency_hash(target, config),
     input_file_hash(target, config),
-    output_file_hash(target, config)
+    output_file_hash(target, config),
+    as.integer(
+      layout$seed %||NA% seed_from_basic_types(config$seed, target)
+    )
   )
   weak_tibble(
-    hash = c("command", "depend", "file_in", "file_out"),
-    changed = old_hashes != new_hashes,
-    old_hash = old_hashes,
-    new_hash = new_hashes
+    name = c("command", "depend", "file_in", "file_out", "seed"),
+    changed = old_values != new_values,
+    old = old_values,
+    new = new_values
   )
 }
 

--- a/R/exec-meta.R
+++ b/R/exec-meta.R
@@ -6,7 +6,9 @@ drake_meta_ <- function(target, config) {
     target = target,
     imported = layout$imported %||% TRUE,
     missing = !target_exists(target = target, config = config),
-    seed = seed_from_basic_types(config$seed, target),
+    seed = as.integer(
+      layout$seed %||NA% seed_from_basic_types(config$seed, target)
+    ),
     time_start = proc.time(),
     file_out = layout$deps_build$file_out
   )

--- a/R/exec-triggers.R
+++ b/R/exec-triggers.R
@@ -246,13 +246,13 @@ should_build_target <- function(target, meta, config) {
       return(TRUE)
     }
   }
-  if (identical(meta$trigger$seed, TRUE)) {
-    if (seed_trigger(target = target, meta = meta, config = config)) {
+  if (identical(meta$trigger$file, TRUE)) {
+    if (file_trigger(target = target, meta = meta, config = config)) {
       return(TRUE)
     }
   }
-  if (identical(meta$trigger$file, TRUE)) {
-    if (file_trigger(target = target, meta = meta, config = config)) {
+  if (identical(meta$trigger$seed, TRUE)) {
+    if (seed_trigger(target = target, meta = meta, config = config)) {
       return(TRUE)
     }
   }

--- a/R/exec-triggers.R
+++ b/R/exec-triggers.R
@@ -32,6 +32,10 @@
 #'   non-file dependency changes.
 #' @param file Logical, whether to rebuild the target
 #'   if a [file_in()]/[file_out()]/[knitr_in()] file changes.
+#' @param seed Logical, whether to rebuild the target
+#'   if the seed changes. Only makes a difference if you set
+#'   a custom `seed` column in your [drake_plan()] at some point
+#'   in your workflow.
 #' @param condition R code (expression or language object)
 #'   that returns a logical. The target will rebuild
 #'   if the code evaluates to `TRUE`.
@@ -88,6 +92,7 @@ trigger <- function(
   command = TRUE,
   depend = TRUE,
   file = TRUE,
+  seed = TRUE,
   condition = FALSE,
   change = NULL,
   mode = c("whitelist", "blacklist", "condition")
@@ -99,6 +104,7 @@ trigger <- function(
     command = command,
     depend = depend,
     file = file,
+    seed = seed,
     condition = rlang::quo_squash(rlang::enquo(condition)),
     change = rlang::quo_squash(rlang::enquo(change)),
     mode = match.arg(mode)
@@ -165,6 +171,15 @@ file_trigger <- function(target, meta, config) {
   FALSE
 }
 
+seed_trigger <- function(target, meta, config) {
+  seed <- read_from_meta(
+    key = target,
+    field = "seed",
+    cache = config$cache
+  )
+  !identical(seed, meta$seed)
+}
+
 condition_trigger <- function(target, meta, config) {
   if (!length(target) || !length(config) || !length(meta)) {
     return(FALSE)
@@ -228,6 +243,11 @@ should_build_target <- function(target, meta, config) {
   }
   if (identical(meta$trigger$depend, TRUE)) {
     if (depend_trigger(target = target, meta = meta, config = config)) {
+      return(TRUE)
+    }
+  }
+  if (identical(meta$trigger$seed, TRUE)) {
+    if (seed_trigger(target = target, meta = meta, config = config)) {
       return(TRUE)
     }
   }

--- a/R/utils-rng.R
+++ b/R/utils-rng.R
@@ -1,22 +1,7 @@
 choose_seed <- function(supplied, cache) {
-  previous <- get_previous_seed(cache = cache)
-  seed_conflict <-
-    !is.null(previous) &&
-    !is.null(supplied) &&
-    !identical(previous, supplied)
-  if (seed_conflict) {
-    stop(
-      "You supplied a seed of ", supplied,
-      " to either make() or drake_config(). ",
-      "Your project already has a different seed: ", previous, ". ",
-      "Use read_drake_seed() to see the seed for yourself. ",
-      "To reset the project's seed, you will have to destroy the cache ",
-      "and restart from scratch: clean(destroy = TRUE). This may seem ",
-      "excessive and inconvenient, but it ensures reproducible results.",
-      call. = FALSE
-    )
-  }
-  (previous %||% supplied) %||% 0
+  supplied %||%
+    get_previous_seed(cache = cache) %||%
+    0L
 }
 
 get_previous_seed <- function(cache) {

--- a/man/deps_profile.Rd
+++ b/man/deps_profile.Rd
@@ -16,9 +16,9 @@ deps_profile(target, config, character_only = FALSE)
 is a character string rather than a symbol.}
 }
 \value{
-A data frame of the old hashes and
-new hashes of the data frame, along with
-an indication of which hashes changed since
+A data frame of old and new values for each
+of the main triggers, along with
+an indication of which values changed since
 the last \code{\link[=make]{make()}}.
 }
 \description{
@@ -26,12 +26,16 @@ The dependency profile can give you
 a hint as to why a target is out of date.
 It can tell you if
 \itemize{
+\item the command changed
+(\code{\link[=deps_profile]{deps_profile()}} reports the \emph{hash} of the command,
+not the command itself)
 \item at least one input file changed,
 \item at least one output file changed,
 \item or a non-file dependency changed. For this last part,
 the imports need to be up to date in the cache,
 which you can do with \code{outdated()} or
 \code{make(skip_targets = TRUE)}.
+\item the pseudo-random number generator seed changed.
 Unfortunately, \code{deps_profile()} does not
 currently get more specific than that.
 }

--- a/man/trigger.Rd
+++ b/man/trigger.Rd
@@ -4,7 +4,7 @@
 \alias{trigger}
 \title{Customize the decision rules for rebuilding targets}
 \usage{
-trigger(command = TRUE, depend = TRUE, file = TRUE,
+trigger(command = TRUE, depend = TRUE, file = TRUE, seed = TRUE,
   condition = FALSE, change = NULL, mode = c("whitelist",
   "blacklist", "condition"))
 }
@@ -17,6 +17,11 @@ non-file dependency changes.}
 
 \item{file}{Logical, whether to rebuild the target
 if a \code{\link[=file_in]{file_in()}}/\code{\link[=file_out]{file_out()}}/\code{\link[=knitr_in]{knitr_in()}} file changes.}
+
+\item{seed}{Logical, whether to rebuild the target
+if the seed changes. Only makes a difference if you set
+a custom \code{seed} column in your \code{\link[=drake_plan]{drake_plan()}} at some point
+in your workflow.}
 
 \item{condition}{R code (expression or language object)
 that returns a logical. The target will rebuild

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -75,7 +75,7 @@ test_with_dir("dependency profile", {
   config$skip_targets <- TRUE
   make(config = config)
   dp <- deps_profile(target = a, config = config)
-  expect_true(as.logical(dp[dp$hash == "depend", "changed"]))
+  expect_true(as.logical(dp[dp$name == "depend", "changed"]))
   expect_equal(sum(dp$changed), 1)
   config$plan$command <- "b + c"
   config$layout <- create_drake_layout(
@@ -84,7 +84,7 @@ test_with_dir("dependency profile", {
     cache = config$cache
   )$layout
   dp <- deps_profile(target = a, config = config)
-  expect_true(as.logical(dp[dp$hash == "command", "changed"]))
+  expect_true(as.logical(dp[dp$name == "command", "changed"]))
   expect_equal(sum(dp$changed), 2)
   load_mtcars_example()
   config <- drake_config(
@@ -99,7 +99,7 @@ test_with_dir("dependency profile", {
     character_only = TRUE,
     config
   )
-  expect_equal(nrow(out), 4)
+  expect_equal(nrow(out), 5L)
 })
 
 test_with_dir("Missing cache", {

--- a/tests/testthat/test-history.R
+++ b/tests/testthat/test-history.R
@@ -23,7 +23,7 @@ test_with_dir("basic history", {
 
   # Get and inspect the history.
   out <- drake_history(cache = cache, analyze = TRUE)
-  expect_equal(dim(out), c(22L, 8L))
+  expect_equal(dim(out), c(22L, 9L))
   cols <- c(
     "target",
     "time",
@@ -32,11 +32,13 @@ test_with_dir("basic history", {
     "latest",
     "command",
     "runtime",
+    "seed",
     "quiet"
   )
   expect_equal(sort(colnames(out)), sort(cols))
   expect_equal(sum(is.finite(out[["quiet"]])), 2L)
   expect_true(all(out[["quiet"]][out$target == "report"] == TRUE))
+  expect_true(is.integer(out$seed))
 
   # Without analysis
   x <- drake_history(cache = cache, analyze = FALSE)
@@ -57,7 +59,7 @@ test_with_dir("basic history", {
   # After garbage collection
   cache$gc()
   out <- drake_history(cache = cache, analyze = TRUE)
-  expect_equal(dim(out), c(22L, 8L))
+  expect_equal(dim(out), c(22L, 9L))
   expect_equal(sort(colnames(out)), sort(cols))
   expect_na <- out$target == "small" | !out$latest
   expect_equal(is.na(out$hash), expect_na)
@@ -65,7 +67,7 @@ test_with_dir("basic history", {
   # Clean everything.
   clean(cache = cache, garbage_collection = TRUE)
   out <- drake_history(cache = cache, analyze = TRUE)
-  expect_equal(dim(out), c(22L, 7L))
+  expect_equal(dim(out), c(22L, 8L))
 })
 
 test_with_dir("complicated history commands", {
@@ -82,7 +84,7 @@ test_with_dir("complicated history commands", {
   cache <- storr::storr_environment()
   make(plan, cache = cache, session_info = FALSE, history = TRUE)
   out <- drake_history(cache = cache, analyze = TRUE)
-  expect_equal(ncol(out), 10L)
+  expect_equal(ncol(out), 11L)
   expect_equal(out$a, rep("x", 2))
   expect_equal(out$w, rep("5", 2))
   expect_equal(out$y[2], 4L)

--- a/tests/testthat/test-random.R
+++ b/tests/testthat/test-random.R
@@ -322,25 +322,6 @@ test_with_dir("revert the seed trigger and end up with a new seed (#947)", {
   plan <- drake_plan(
     x = target(
       sample.int(n = 201, size = 3),
-      seed = 2
-    ),
-    y = sample.int(n = 200, size = 3),
-    z = sample.int(n = 200, size = 3),
-    mx = mean(x),
-    my = mean(y),
-    mz = mean(z)
-  )
-  config <- drake_config(
-    plan,
-    cache = config$cache,
-    session_info = FALSE
-  )
-  make(config = config)
-  expect_equal(justbuilt(config), character(0))
-
-  plan <- drake_plan(
-    x = target(
-      sample.int(n = 201, size = 3),
       seed = 3
     ),
     y = sample.int(n = 200, size = 3),

--- a/tests/testthat/test-random.R
+++ b/tests/testthat/test-random.R
@@ -301,7 +301,7 @@ test_with_dir("revert the seed trigger and end up with a new seed (#947)", {
 
   plan <- drake_plan(
     x = target(
-      sample.int(n = 200, size = 3),
+      sample.int(n = 201, size = 3),
       seed = 2,
       trigger = trigger(seed = FALSE)
     ),
@@ -317,26 +317,43 @@ test_with_dir("revert the seed trigger and end up with a new seed (#947)", {
     session_info = FALSE
   )
   make(config = config)
+  expect_equal(sort(justbuilt(config)), sort(c("x", "mx")))
+
+  plan <- drake_plan(
+    x = target(
+      sample.int(n = 201, size = 3),
+      seed = 2
+    ),
+    y = sample.int(n = 200, size = 3),
+    z = sample.int(n = 200, size = 3),
+    mx = mean(x),
+    my = mean(y),
+    mz = mean(z)
+  )
+  config <- drake_config(
+    plan,
+    cache = config$cache,
+    session_info = FALSE
+  )
+  make(config = config)
   expect_equal(justbuilt(config), character(0))
 
-  for (seed in c(2, 3)) {
-    plan <- drake_plan(
-      x = target(
-        sample.int(n = 200, size = 3),
-        seed = !!seed
-      ),
-      y = sample.int(n = 200, size = 3),
-      z = sample.int(n = 200, size = 3),
-      mx = mean(x),
-      my = mean(y),
-      mz = mean(z)
-    )
-    config <- drake_config(
-      plan,
-      cache = config$cache,
-      session_info = FALSE
-    )
-    make(config = config)
-    expect_equal(sort(justbuilt(config)), sort(c("x", "mx")))
-  }
+  plan <- drake_plan(
+    x = target(
+      sample.int(n = 201, size = 3),
+      seed = 3
+    ),
+    y = sample.int(n = 200, size = 3),
+    z = sample.int(n = 200, size = 3),
+    mx = mean(x),
+    my = mean(y),
+    mz = mean(z)
+  )
+  config <- drake_config(
+    plan,
+    cache = config$cache,
+    session_info = FALSE
+  )
+  make(config = config)
+  expect_equal(sort(justbuilt(config)), sort(c("x", "mx")))
 })

--- a/tests/testthat/test-random.R
+++ b/tests/testthat/test-random.R
@@ -169,19 +169,29 @@ test_with_dir("Random targets are reproducible", {
   expect_false(identical(readd(my), old_my))
   expect_false(identical(readd(mz), old_mz))
 
-  # Cannot supply a conflicting seed.
-  expect_error(
-    make(
-      data,
-      envir = env,
-      seed = con5$seed + 1,
-      parallelism = parallelism,
-      jobs = jobs,
-      verbose = 0L,
-      session_info = FALSE
-    ),
-    regexp = "already has a different seed"
+  # New seed invalidates old targets.
+  make(
+    data,
+    envir = env,
+    seed = con2$seed + 2,
+    parallelism = parallelism,
+    jobs = jobs,
+    verbose = 0L,
+    session_info = FALSE
   )
+  expect_equal(sort(justbuilt(con5)), sort(data$target))
+
+  make(
+    data,
+    envir = env,
+    parallelism = parallelism,
+    jobs = jobs,
+    verbose = 0L,
+    session_info = FALSE
+  )
+  expect_equal(justbuilt(con5), character(0))
+  expect_equal(con2$seed + 2, read_drake_seed())
+  expect_true(con2$seed + 2 > 1L)
 })
 
 test_with_dir("custom seeds (#947)", {

--- a/tests/testthat/test-random.R
+++ b/tests/testthat/test-random.R
@@ -211,6 +211,47 @@ test_with_dir("custom seeds", {
   expect_false(all(old_mx == old_my))
   expect_false(all(old_mx == old_mz))
   s <- diagnose(y, cache = config$cache)$seed
+
+  plan <- drake_plan(
+    x = target(
+      sample.int(n = 200, size = 3),
+      seed = s,
+      trigger = trigger(seed = FALSE)
+    ),
+    y = sample.int(n = 200, size = 3),
+    z = sample.int(n = 200, size = 3),
+    mx = mean(x),
+    my = mean(y),
+    mz = mean(z)
+  )
+  config <- drake_config(
+    plan,
+    cache = config$cache,
+    session_info = FALSE
+  )
+  make(config = config)
+  expect_equal(justbuilt(config), character(0))
+
+  plan <- drake_plan(
+    x = target(
+      sample.int(n = 200, size = 3),
+      seed = s
+    ),
+    y = sample.int(n = 200, size = 3),
+    z = sample.int(n = 200, size = 3),
+    mx = mean(x),
+    my = mean(y),
+    mz = mean(z)
+  )
+  config <- drake_config(
+    plan,
+    trigger = trigger(seed = FALSE),
+    cache = config$cache,
+    session_info = FALSE
+  )
+  make(config = config)
+  expect_equal(justbuilt(config), character(0))
+
   plan <- drake_plan(
     x = target(
       sample.int(n = 200, size = 3),

--- a/tests/testthat/test-triggers.R
+++ b/tests/testthat/test-triggers.R
@@ -104,6 +104,7 @@ test_with_dir("trigger() function works", {
     command = TRUE,
     depend = FALSE,
     file = FALSE,
+    seed = TRUE,
     condition = quote(1 + 1),
     change = quote(sqrt(1)),
     mode = "whitelist"


### PR DESCRIPTION
# Summary

- Allow a custom `seed` column of the plan to set target-level seeds. Overrides `drake`'s automatic seeds.
- Implement a new `seed` trigger to optionally ignore changes to seeds.

Paves the way for #945.

``` r
library(drake)
plan <- drake_plan(
  x = sample.int(n = 200, size = 3),
  y = sample.int(n = 200, size = 3),
  z = sample.int(n = 200, size = 3),
  mx = mean(x),
  my = mean(y),
  mz = mean(z)
)

make(plan)
#> target x
#> target y
#> target z
#> target mx
#> target my
#> target mz

s <- diagnose(y)$seed
s
#> [1] 965938315

# Change the seed
plan <- drake_plan(
  x = target(
    sample.int(n = 200, size = 3),
    seed = s
  ),
  y = sample.int(n = 200, size = 3),
  z = sample.int(n = 200, size = 3),
  mx = mean(x),
  my = mean(y),
  mz = mean(z)
)

make(plan)
#> target x
#> target mx

# Optionally ignore changes to the seed
plan <- drake_plan(
  x = target(
    sample.int(n = 200, size = 3),
    seed = s + 1,
    trigger = trigger(seed = FALSE)
  ),
  y = sample.int(n = 200, size = 3),
  z = sample.int(n = 200, size = 3),
  mx = mean(x),
  my = mean(y),
  mz = mean(z)
)

make(plan)
#> All targets are already up to date.
```

<sup>Created on 2019-07-17 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

# Related GitHub issues and pull requests

- Ref: #947 

# Checklist

- [x] I understand and agree to `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CODE_OF_CONDUCT.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) for any new functionality.
- [x] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).
