### PR TITLE
fix typo in drake_history() documentation

### DIFF
--- a/R/api-history.R
+++ b/R/api-history.R
@@ -71,7 +71,7 @@
 #' print(out)
 #' # Let's use the history to recover the oldest version
 #' # of our regression2_small target.
-#' oldest_reg2_smsall <- max(which(out$target == "regression2_small"))
+#' oldest_reg2_small <- max(which(out$target == "regression2_small"))
 #' hash_oldest_reg2_small <- out[oldest_reg2_small, ]$hash
 #' cache <- drake_cache()
 #' cache$get_value(hash_oldest_reg2_small)


### PR DESCRIPTION
# Summary

Fixed a small typo that prevents the example from working as intended.

# Related GitHub issues and pull requests

_No related issue_

# Checklist

- [X] I understand and agree to `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CODE_OF_CONDUCT.md).
- [X] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [X] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) for any new functionality.
- [X] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).
