### PR TITLE
Keep file_out() files in clean() unless garbage collection is activated.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # Version 7.5.2.9000
 
+## Enhancements
+
+- Keep `file_out()` files in `clean()`. That way, `make(recover = TRUE)` is a true "undo button" for `clean()`. `clean(garbage_collection = TRUE)` still removes data in the cache, as well as any `file_out()` files from uncleaned targets.
 
 # Version 7.5.2
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -318,10 +318,10 @@ Caveats:
 
 ```{r}
 # Is the data really gone?
-clean() # garbage_collection = FALSE
+clean()
 
-# Nope!
-make(plan, recover = TRUE) # The report still builds since report.md is gone.
+# Nope! You need clean(garbage_collection = TRUE) to delete stuff.
+make(plan, recover = TRUE)
 
 # When was the raw data *really* first built?
 diagnose(raw_data)$date

--- a/README.md
+++ b/README.md
@@ -78,38 +78,6 @@ Development
 </table>
 <br>
 
-# The drake R package <img src="https://ropensci.github.io/drake/figures/logo.svg" align="right" alt="logo" width="120" height = "139" style = "border: none; float: right;">
-
-Data analysis can be slow. A round of scientific computation can take
-several minutes, hours, or even days to complete. After it finishes, if
-you update your code or data, your hard-earned results may no longer be
-valid. How much of that valuable output can you keep, and how much do
-you need to update? How much runtime must you endure all over again?
-
-For projects in R, the `drake` package can help. It [analyzes your
-workflow](https://ropenscilabs.github.io/drake-manual/plans.html), skips
-steps with up-to-date results, and orchestrates the rest with [optional
-distributed
-computing](https://ropenscilabs.github.io/drake-manual/hpc.html). At the
-end, `drake` provides evidence that your results match the underlying
-code and data, which increases your ability to trust your research.
-
-# 6-minute video
-
-Visit the [first page of the
-manual](https://ropenscilabs.github.io/drake-manual/) to watch a short
-introduction.
-
-<center>
-
-<a href="https://ropenscilabs.github.io/drake-manual">
-<img src="https://ropensci.github.io/drake/figures/video.png" alt="video" align="center" style = "border: none; float: center;">
-</a>
-
-</center>
-
-<br>
-
 # What gets done stays done.
 
 Too many data science projects follow a [Sisyphean
@@ -341,18 +309,18 @@ history
 #> # A tibble: 12 x 10
 #>    target current built exists hash  command   seed runtime quiet
 #>    <chr>  <lgl>   <chr> <lgl>  <chr> <chr>    <int>   <dbl> <lgl>
-#>  1 data   TRUE    2019… TRUE   e580… raw_da… 1.29e9 0.01000 NA   
-#>  2 data   TRUE    2019… TRUE   e580… raw_da… 1.29e9 0.001   NA   
-#>  3 fit    TRUE    2019… TRUE   62a1… lm(Sep… 1.11e9 0.003   NA   
+#>  1 data   TRUE    2019… TRUE   e580… raw_da… 1.29e9 0.00300 NA   
+#>  2 data   TRUE    2019… TRUE   e580… raw_da… 1.29e9 0       NA   
+#>  3 fit    TRUE    2019… TRUE   62a1… lm(Sep… 1.11e9 0.004   NA   
 #>  4 fit    TRUE    2019… TRUE   62a1… lm(Sep… 1.11e9 0.001   NA   
 #>  5 hist   FALSE   2019… TRUE   10bc… create… 2.10e8 0.008   NA   
-#>  6 hist   FALSE   2019… TRUE   5252… create… 2.10e8 0.004   NA   
-#>  7 hist   TRUE    2019… TRUE   00fa… create… 2.10e8 0.00600 NA   
-#>  8 raw_d… TRUE    2019… TRUE   6317… "readx… 1.20e9 0.0130  NA   
-#>  9 raw_d… TRUE    2019… TRUE   6317… "readx… 1.20e9 0.00700 NA   
-#> 10 report TRUE    2019… TRUE   47a7… "rmark… 1.30e9 1.20    TRUE 
-#> 11 report TRUE    2019… TRUE   47a7… "rmark… 1.30e9 0.440   TRUE 
-#> 12 report TRUE    2019… TRUE   47a7… "rmark… 1.30e9 0.424   TRUE 
+#>  6 hist   FALSE   2019… TRUE   5252… create… 2.10e8 0.005   NA   
+#>  7 hist   TRUE    2019… TRUE   00fa… create… 2.10e8 0.007   NA   
+#>  8 raw_d… TRUE    2019… TRUE   6317… "readx… 1.20e9 0.016   NA   
+#>  9 raw_d… TRUE    2019… TRUE   6317… "readx… 1.20e9 0.007   NA   
+#> 10 report TRUE    2019… TRUE   7660… "rmark… 1.30e9 0.912   TRUE 
+#> 11 report TRUE    2019… TRUE   7660… "rmark… 1.30e9 0.45    TRUE 
+#> 12 report TRUE    2019… TRUE   7660… "rmark… 1.30e9 0.433   TRUE 
 #> # … with 1 more variable: output_file <chr>
 ```
 
@@ -382,15 +350,16 @@ cache$get_value(hash)
 
 ## Reproducible data recovery and renaming
 
-`drake`'s data recovery feature is another way to avoid rerunning commands. It is useful if:
+`drake`’s data recovery feature is another way to avoid rerunning
+commands. It is useful if:
 
-- You want to revert to your old code, maybe with `git reset`.
-- You accidentally `clean()`ed a target and want to get it back.
-- You want to rename an expensive target.
+  - You want to revert to your old code, maybe with `git reset`.
+  - You accidentally `clean()`ed a target and want to get it back.
+  - You want to rename an expensive target.
 
-In version 7.5.2 and above, `make(recover = TRUE)` can salvage
-the values of old targets. Before building a target, `drake` checks if
-you have ever built something else with the same command, dependencies,
+In version 7.5.2 and above, `make(recover = TRUE)` can salvage the
+values of old targets. Before building a target, `drake` checks if you
+have ever built something else with the same command, dependencies,
 seed, etc. that you have right now. If appropriate, `drake` assigns the
 old value to the new target instead of rerunning the command.
 
@@ -404,24 +373,26 @@ Caveats:
 
 ``` r
 # Is the data really gone?
-clean() # garbage_collection = FALSE
+clean()
 
-# Nope!
-make(plan, recover = TRUE) # The report still builds since report.md is gone.
+# Nope! You need clean(garbage_collection = TRUE) to delete stuff.
+make(plan, recover = TRUE)
 #> recover raw_data
 #> recover data
 #> recover fit
 #> recover hist
-#> target report
+#> recover report
 
 # When was the raw data *really* first built?
 diagnose(raw_data)$date
-#> [1] "2019-07-23 10:44:38.040644 -0400 GMT"
+#> [1] "2019-07-24 14:46:22.522768 -0400 GMT"
 ```
 
 ### Renaming
 
-You can use recovery to rename a target. The trick is to supply the random number generator seed that `drake` used with the old target name. Also, renaming a target unavoidably invalidates downstream targets.
+You can use recovery to rename a target. The trick is to supply the
+random number generator seed that `drake` used with the old target name.
+Also, renaming a target unavoidably invalidates downstream targets.
 
 ``` r
 # Get the old seed.

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -218,6 +218,7 @@ un
 unhandled
 Univa
 unparsable
+unregister
 untimed
 vectorization
 vectorized

--- a/man/clean.Rd
+++ b/man/clean.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/api-clean.R
 \name{clean}
 \alias{clean}
-\title{Remove targets/imports from the cache.}
+\title{Invalidate and unregister targets.}
 \usage{
 clean(..., list = character(0), destroy = FALSE, path = NULL,
   search = NULL, cache = drake::drake_cache(path = path, verbose =
@@ -61,64 +61,52 @@ metadata namespaces such as "meta", "build_times", and "errors".}
 Invisibly return \code{NULL}.
 }
 \description{
-Cleans up the work done by \code{\link[=make]{make()}}.
+Force targets to be out of date and remove target names
+from the data in the cache.
 }
 \details{
-By default, \code{clean()} removes references to cached data.
-To deep-clean the data to free up storage/memory, use
-\code{clean(garbage_collection = TRUE)}. Garbage collection is slower,
-but it purges data with no remaining references. To just do garbage
-collection without cleaning, see \code{\link[=drake_gc]{drake_gc()}}.
-Also, for \code{clean()}, you must be in your project's working directory
-or a subdirectory of it.
-WARNING: This deletes ALL work done with \code{\link[=make]{make()}},
-which includes
-file targets as well as the entire drake cache. Only use \code{clean()}
-if you're sure you won't lose anything important.
-}
-\section{Safeguards}{
-
-If you run \code{\link[=clean]{clean()}} with no arguments, \code{drake}'s response is to
-remove all the targets etc. from the cache. To prevent you from
-doing this accidentally in an interactive session, \code{\link[=clean]{clean()}}
-prompts you with a menu to confirm. The menu only appears
-once per session. You can disable it with
-\code{options(drake_clean_menu = FALSE)}.
+By default, \code{\link[=clean]{clean()}} invalidates \strong{all} targets,
+so be careful. \code{\link[=clean]{clean()}} always:
+\enumerate{
+\item Forces targets to be out of date so the next \code{\link[=make]{make()}}
+does not skip them.
+\item Dissociates targets' names from their values, so
+\code{loadd(your_target)} and \code{readd(your_target)} no longer work.
 }
 
+By default, \code{clean()} does not actually remove the underlying data.
+Even old targets from the distant past are still in the cache
+and recoverable via \code{drake_history()} and \code{make(recover = TRUE)}.
+To actually remove target data from the cache, as well as any
+\code{\link[=file_out]{file_out()}} files associated with as-yet uncleaned targets,
+run \code{clean(garbage_collection = TRUE)}.
+Garbage collection is slow, but it reduces the storage burden of the cache.
+}
 \examples{
 \dontrun{
 isolate_example("Quarantine side effects.", {
 if (suppressWarnings(require("knitr"))) {
 load_mtcars_example() # Get the code with drake_example("mtcars").
 make(my_plan) # Run the project, build the targets.
-# List objects in the cache, excluding R objects
-# imported from your workspace.
-cached(no_imported_objects = TRUE)
-# Remove 'summ_regression1_large' and 'small' from the cache.
-clean(summ_regression1_large, small)
-# Those objects should be gone.
-cached(no_imported_objects = TRUE)
-# Rebuild the missing targets.
-make(my_plan)
-# Remove all the targets and imports.
-# On non-Windows machines, parallelize over at most 2 jobs.
-clean(jobs = 2)
-# Make the targets again.
-make(my_plan)
-# Garbage collection removes data whose references are no longer present.
-# It is slow, but you should enable it if you want to reduce the
-# size of the cache.
-clean(garbage_collection = TRUE)
-# All the targets and imports are gone.
+# Show all registered targets in the cache.
 cached()
-# But there is still cached metadata.
-build_times()
-# To make even more room, use the "purge" flag.
-clean(purge = TRUE)
-build_times()
-# Completely remove the entire cache (default: '.drake/' folder).
-clean(destroy = TRUE)
+# Unregister 'summ_regression1_large' and 'small' in the cache.
+clean(summ_regression1_large, small)
+# Those objects are no longer registered as targets.
+cached()
+# Rebuild the invalidated/outdated targets.
+make(my_plan)
+# Clean everything.
+clean()
+# But the data objects and files are not actually gone!
+file.exists("report.md")
+drake_history()
+make(my_plan, recover = TRUE)
+# You need garbage collection to actually remove the data
+# and any file_out() files of any uncleaned targets.
+clean(garbage_collection = TRUE)
+drake_history()
+make(my_plan, recover = TRUE)
 }
 })
 }

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -22,6 +22,7 @@ test_with_dir("clean() removes the correct files", {
     cache = cache,
     session_info = FALSE
   )
+  clean(cache = cache)
   expect_true(file.exists("a.txt"))
   expect_true(file.exists("b.txt"))
   expect_true(file.exists("d.rds"))
@@ -29,7 +30,13 @@ test_with_dir("clean() removes the correct files", {
   expect_true(dir.exists("xyz"))
   expect_true(file.exists("abc/c.txt"))
   expect_true(file.exists("xyz/e.txt"))
-  clean(cache = cache)
+  make(
+    plan,
+    cache = cache,
+    session_info = FALSE,
+    recover = TRUE
+  )
+  clean(cache = cache, garbage_collection = TRUE)
   expect_true(file.exists("a.txt"))
   expect_true(file.exists("b.txt"))
   expect_false(file.exists("d.rds"))

--- a/tests/testthat/test-full-build.R
+++ b/tests/testthat/test-full-build.R
@@ -40,7 +40,7 @@ test_with_dir("scratch build with custom filesystem cache.", {
   # clean specific targets
   clean(b, c, list = c("drake_target_1", "nextone"),
     cache = cache)
-  expect_false(file.exists("intermediatefile.rds"))
+  expect_true(file.exists("intermediatefile.rds"))
   expect_true(file.exists("input.rds"))
   expect_equal(
     sort(config$cache$list()),
@@ -68,6 +68,14 @@ test_with_dir("scratch build with custom filesystem cache.", {
   expect_false("f" %in% config$cache$list())
 
   clean(destroy = FALSE, cache = cache)
+  expect_equal(config$cache$list(), character(0))
+  expect_true(file.exists("intermediatefile.rds"))
+  expect_true(file.exists("input.rds"))
+  expect_false(file.exists(default_cache_path()))
+  expect_true(file.exists(path))
+
+  testrun(config)
+  clean(destroy = FALSE, cache = cache, garbage_collection = TRUE)
   expect_equal(config$cache$list(), character(0))
   expect_false(file.exists("intermediatefile.rds"))
   expect_true(file.exists("input.rds"))


### PR DESCRIPTION
# Summary

Keep `file_out()` files in `clean()`. That way, `make(recover = TRUE)` is a true "undo button" for `clean()`. `clean(garbage_collection = TRUE)` still removes data in the cache, as well as any `file_out()` files from uncleaned targets.

``` r
library(drake)
load_mtcars_example() # Has an R Markdown report
make(my_plan)
#> target large
#> target small
#> target regression1_large
#> target regression2_large
#> target regression1_small
#> target regression2_small
#> target summ_regression1_large
#> target coef_regression1_large
#> target summ_regression2_large
#> target coef_regression2_large
#> target summ_regression1_small
#> target coef_regression1_small
#> target coef_regression2_small
#> target summ_regression2_small
#> target report
list.files()
#> [1] "report.md"              "report.Rmd"            
#> [3] "reprex_reprex.R"        "reprex_reprex.spin.R"  
#> [5] "reprex_reprex.spin.Rmd"
clean()
list.files() # report.md is still there.
#> [1] "report.md"              "report.Rmd"            
#> [3] "reprex_reprex.R"        "reprex_reprex.spin.R"  
#> [5] "reprex_reprex.spin.Rmd"
make(my_plan, recover = TRUE) # Now, we can recover the report.
#> recover large
#> recover small
#> recover regression1_large
#> recover regression2_large
#> recover regression1_small
#> recover regression2_small
#> recover summ_regression1_large
#> recover coef_regression1_large
#> recover summ_regression2_large
#> recover coef_regression2_large
#> recover summ_regression1_small
#> recover coef_regression1_small
#> recover coef_regression2_small
#> recover summ_regression2_small
#> recover report
```

<sup>Created on 2019-07-24 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

# Related GitHub issues and pull requests

- Ref: #957, #757

# Checklist

- [x] I understand and agree to `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CODE_OF_CONDUCT.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) for any new functionality.
- [x] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).
