### PR TITLE
make `seed_trigger` test for equality instead of identity

### DIFF
--- a/R/handle_trigger.R
+++ b/R/handle_trigger.R
@@ -178,7 +178,7 @@ seed_trigger <- function(target, meta, config) {
     field = "seed",
     cache = config$cache
   )
-  seed != meta$seed
+  !identical(as.integer(seed),  as.integer(meta$seed))
 }
 
 condition_trigger <- function(target, meta, config) {

--- a/R/handle_trigger.R
+++ b/R/handle_trigger.R
@@ -178,7 +178,7 @@ seed_trigger <- function(target, meta, config) {
     field = "seed",
     cache = config$cache
   )
-  !identical(seed, meta$seed)
+  seed!=meta$seed
 }
 
 condition_trigger <- function(target, meta, config) {

--- a/R/handle_trigger.R
+++ b/R/handle_trigger.R
@@ -178,7 +178,7 @@ seed_trigger <- function(target, meta, config) {
     field = "seed",
     cache = config$cache
   )
-  seed!=meta$seed
+  seed != meta$seed
 }
 
 condition_trigger <- function(target, meta, config) {


### PR DESCRIPTION
# Summary

After trying to figure out why a large number of my targets were out date I eventually discovered that for all of the "outdated" targets the seed stored by the cache was of type `double`  while the seed returned from `drake_meta_` was type `integer` (they were otherwise equal). I'm guessing this is due to me updating drake at some point.  Because `seed_trigger` currently uses `identical` to compare seeds, these targets were invalidated despite not having changed. 


# Related GitHub issues and pull requests

I should probably have made an issue about the erroneous invalidation of targets, but I don't think there's much hope of me being able to create a reprex.

- Ref: #

# Checklist

- [x] I understand and agree to `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CODE_OF_CONDUCT.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) for any new functionality.
- [x] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).
