### PR TITLE
Fix readd() typo in make.R of drake_example("main")

### DIFF
--- a/inst/templates/usedrake/make.R
+++ b/inst/templates/usedrake/make.R
@@ -11,5 +11,5 @@ source("R/plan.R")      # Create your drake plan.
 
 # Call make() to run your work.
 # Your targets will be stored in a hidden .drake/ cache,
-# and you can read them back into memory with loadd() and read().
+# and you can read them back into memory with loadd() and readd().
 make(plan)


### PR DESCRIPTION
# Summary

The function has been typed as `read()` rather than `readd()` int the `make.R` file that users can download as part of `drake_example("main")`. This could be confusing for beginners.

# Related GitHub issues and pull requests

Searching for `readd` in open and closed issues and pull requests doesn't yield any relevant responses.

# Checklist

- [x] I understand and agree to `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CODE_OF_CONDUCT.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md). **[No need, just a typo.]**
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) for any new functionality. **[Not required]**
- [x] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).
