### PR TITLE
Mention `.id_chr` documentation in `file_in()`, `file_out()` 

### DIFF
--- a/R/drake_plan_helpers.R
+++ b/R/drake_plan_helpers.R
@@ -411,8 +411,8 @@ trigger <- function(
 #' @seealso [file_out()], [knitr_in()], [ignore()], [no_deps()]
 #' @return A character vector of declared input file or directory paths.
 #' @param ... Character vector, paths to files and directories. Use
-#'   `.id_chr` to refer to the current target by name. `.id_chr` is not limited
-#'   to use in `file_in()` and `file_out()`.
+#'   `.id_chr` to refer to the current target by name. `.id_chr` is not
+#'    limited to use in `file_in()` and `file_out()`.
 #' @export
 #' @examples
 #' \dontrun{

--- a/R/drake_plan_helpers.R
+++ b/R/drake_plan_helpers.R
@@ -411,8 +411,8 @@ trigger <- function(
 #' @seealso [file_out()], [knitr_in()], [ignore()], [no_deps()]
 #' @return A character vector of declared input file or directory paths.
 #' @param ... Character vector, paths to files and directories. Use
-#' `.id_chr` to refer to the current target by name. `.id_chr` is not limited
-#' to use in `file_in()` and `file_out`.
+#'   `.id_chr` to refer to the current target by name. `.id_chr` is not limited
+#'   to use in `file_in()` and `file_out()`.
 #' @export
 #' @examples
 #' \dontrun{
@@ -433,14 +433,16 @@ trigger <- function(
 #' make(plan)
 #' file.exists("mtcars.csv")
 #'
-#' # You may use `.id_chr` inside `file_out()` and `file_in()` to refer
-#' # to the current target. This works inside `map()`, `combine()`, `split()`,
-#' # and `cross()`.
+#' # You may use `.id_chr` inside `file_out()` and `file_in()`
+#' # to refer  to the current target. This works inside `map()`,
+#' # `combine()`, `split()`, and `cross()`.
 #'
 #' plan <- drake::drake_plan(
-#' data = target(write.csv(data, file_out(paste0(.id_chr, '.csv'))),
-#'               transform = map(data = c(iris, mtcars))))
-#'
+#'   data = target(
+#'     write.csv(data, file_out(paste0(.id_chr, ".csv"))),
+#'     transform = map(data = c(iris, mtcars))
+#'   )
+#' )
 #' plan
 #'
 #' # You can also work with entire directories this way.
@@ -477,11 +479,9 @@ file_in <- function(...) {
 #'   (and whole directories) that your targets create.
 #' @export
 #' @inheritSection drake_plan Keywords
-#' @seealso [file_out()], [knitr_in()], [ignore()], [no_deps()]
+#' @seealso [file_in()], [knitr_in()], [ignore()], [no_deps()]
 #' @return A character vector of declared output file or directory paths.
-#' @param ... Character vector, paths to files and directories. Use
-#' `.id_chr` to refer to the current target name. `id_chr` is not limited
-#' to use in `file_in()` and `file_out`.
+#' @inheritDotParams file_in
 #' @export
 #' @examples
 #' \dontrun{
@@ -502,13 +502,16 @@ file_in <- function(...) {
 #' make(plan)
 #' file.exists("mtcars.csv")
 #'
-#' # You may use `.id_chr` inside `file_out()` and `file_in()` to refer
-#' # to the current target. This works inside `map()`, `combine()`, `split()`,
-#' # and `cross()`.
+#'  # You may use `.id_chr` inside `file_out()` and `file_in()`
+#'  # to refer  to the current target. This works inside `map()`,
+#'  # `combine()`, `split()`, and `cross()`.
 #'
 #' plan <- drake::drake_plan(
-#' data = target(write.csv(data, file_out(paste0(.id_chr, '.csv'))),
-#'               transform = map(data = c(iris, mtcars))))
+#'   data = target(
+#'     write.csv(data, file_out(paste0(.id_chr, ".csv"))),
+#'     transform = map(data = c(iris, mtcars))
+#'   )
+#' )
 #'
 #' plan
 #'

--- a/R/drake_plan_helpers.R
+++ b/R/drake_plan_helpers.R
@@ -410,7 +410,9 @@ trigger <- function(
 #' @inheritSection drake_plan Keywords
 #' @seealso [file_out()], [knitr_in()], [ignore()], [no_deps()]
 #' @return A character vector of declared input file or directory paths.
-#' @param ... Character vector, paths to files and directories.
+#' @param ... Character vector, paths to files and directories. Use
+#' `.id_chr` to refer to the current target by name. `.id_chr` is not limited
+#' to use in `file_in()` and `file_out`.
 #' @export
 #' @examples
 #' \dontrun{
@@ -430,6 +432,16 @@ trigger <- function(
 #'
 #' make(plan)
 #' file.exists("mtcars.csv")
+#'
+#' # You may use `.id_chr` inside `file_out()` and `file_in()` to refer
+#' # to the current target. This works inside `map()`, `combine()`, `split()`,
+#' # and `cross()`.
+#'
+#' plan <- drake::drake_plan(
+#' data = target(write.csv(data, file_out(paste0(.id_chr, '.csv'))),
+#'               transform = map(data = c(iris, mtcars))))
+#'
+#' plan
 #'
 #' # You can also work with entire directories this way.
 #' # However, in `file_out("your_directory")`, the directory
@@ -467,7 +479,9 @@ file_in <- function(...) {
 #' @inheritSection drake_plan Keywords
 #' @seealso [file_out()], [knitr_in()], [ignore()], [no_deps()]
 #' @return A character vector of declared output file or directory paths.
-#' @param ... Character vector, paths to files and directories.
+#' @param ... Character vector, paths to files and directories. Use
+#' `.id_chr` to refer to the current target name. `id_chr` is not limited
+#' to use in `file_in()` and `file_out`.
 #' @export
 #' @examples
 #' \dontrun{
@@ -487,6 +501,16 @@ file_in <- function(...) {
 #'
 #' make(plan)
 #' file.exists("mtcars.csv")
+#'
+#' # You may use `.id_chr` inside `file_out()` and `file_in()` to refer
+#' # to the current target. This works inside `map()`, `combine()`, `split()`,
+#' # and `cross()`.
+#'
+#' plan <- drake::drake_plan(
+#' data = target(write.csv(data, file_out(paste0(.id_chr, '.csv'))),
+#'               transform = map(data = c(iris, mtcars))))
+#'
+#' plan
 #'
 #' # You can also work with entire directories this way.
 #' # However, in `file_out("your_directory")`, the directory

--- a/R/drake_plan_helpers.R
+++ b/R/drake_plan_helpers.R
@@ -481,7 +481,7 @@ file_in <- function(...) {
 #' @inheritSection drake_plan Keywords
 #' @seealso [file_in()], [knitr_in()], [ignore()], [no_deps()]
 #' @return A character vector of declared output file or directory paths.
-#' @inheritDotParams file_in
+#' @inheritParams file_in
 #' @export
 #' @examples
 #' \dontrun{

--- a/man/file_in.Rd
+++ b/man/file_in.Rd
@@ -8,7 +8,9 @@
 file_in(...)
 }
 \arguments{
-\item{...}{Character vector, paths to files and directories.}
+\item{...}{Character vector, paths to files and directories. Use
+\code{.id_chr} to refer to the current target by name. \code{.id_chr} is not limited
+to use in \code{file_in()} and \code{file_out()}.}
 }
 \value{
 A character vector of declared input file or directory paths.
@@ -81,6 +83,18 @@ plan
 
 make(plan)
 file.exists("mtcars.csv")
+
+# You may use `.id_chr` inside `file_out()` and `file_in()`
+# to refer  to the current target. This works inside `map()`,
+# `combine()`, `split()`, and `cross()`.
+
+plan <- drake::drake_plan(
+  data = target(
+    write.csv(data, file_out(paste0(.id_chr, ".csv"))),
+    transform = map(data = c(iris, mtcars))
+  )
+)
+plan
 
 # You can also work with entire directories this way.
 # However, in `file_out("your_directory")`, the directory

--- a/man/file_in.Rd
+++ b/man/file_in.Rd
@@ -9,8 +9,8 @@ file_in(...)
 }
 \arguments{
 \item{...}{Character vector, paths to files and directories. Use
-\code{.id_chr} to refer to the current target by name. \code{.id_chr} is not limited
-to use in \code{file_in()} and \code{file_out()}.}
+\code{.id_chr} to refer to the current target by name. \code{.id_chr} is not
+limited to use in \code{file_in()} and \code{file_out()}.}
 }
 \value{
 A character vector of declared input file or directory paths.

--- a/man/file_out.Rd
+++ b/man/file_out.Rd
@@ -8,7 +8,10 @@
 file_out(...)
 }
 \arguments{
-\item{...}{Character vector, paths to files and directories.}
+\item{...}{Arguments passed on to \code{file_in}
+\describe{
+  \item{}{}
+}}
 }
 \value{
 A character vector of declared output file or directory paths.
@@ -68,6 +71,19 @@ plan
 make(plan)
 file.exists("mtcars.csv")
 
+ # You may use `.id_chr` inside `file_out()` and `file_in()`
+ # to refer  to the current target. This works inside `map()`,
+ # `combine()`, `split()`, and `cross()`.
+
+plan <- drake::drake_plan(
+  data = target(
+    write.csv(data, file_out(paste0(.id_chr, ".csv"))),
+    transform = map(data = c(iris, mtcars))
+  )
+)
+
+plan
+
 # You can also work with entire directories this way.
 # However, in `file_out("your_directory")`, the directory
 # becomes an entire unit. Thus, `file_in("your_directory")`
@@ -94,5 +110,5 @@ if (requireNamespace("visNetwork", quietly = TRUE)) {
 }
 }
 \seealso{
-\code{\link[=file_out]{file_out()}}, \code{\link[=knitr_in]{knitr_in()}}, \code{\link[=ignore]{ignore()}}, \code{\link[=no_deps]{no_deps()}}
+\code{\link[=file_in]{file_in()}}, \code{\link[=knitr_in]{knitr_in()}}, \code{\link[=ignore]{ignore()}}, \code{\link[=no_deps]{no_deps()}}
 }

--- a/man/file_out.Rd
+++ b/man/file_out.Rd
@@ -8,10 +8,9 @@
 file_out(...)
 }
 \arguments{
-\item{...}{Arguments passed on to \code{file_in}
-\describe{
-  \item{}{}
-}}
+\item{...}{Character vector, paths to files and directories. Use
+\code{.id_chr} to refer to the current target by name. \code{.id_chr} is not
+limited to use in \code{file_in()} and \code{file_out()}.}
 }
 \value{
 A character vector of declared output file or directory paths.


### PR DESCRIPTION
Closes #1032 

Adds documentation for `.id_chr` as suggested.


I checked 2&3 below despite not doing them: neither applies to a small documentation change.

# Checklist 
- [ x] I understand and agree to `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CODE_OF_CONDUCT.md).
- [x ] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x ] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) for any new functionality.
- [ x] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).
