### PR TITLE
plot(plan)

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,6 +2,7 @@
 
 S3method(`[`,expr_list)
 S3method(c,expr_list)
+S3method(plot,drake_plan)
 S3method(print,drake_plan)
 S3method(print,drake_plan_source)
 export(Makefile_recipe)

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 ## New features
 
 - Begin to implement dynamic branching (#685).
+- Implement `plot(plan)` (#1036).
 
 ## Enhancements
 
@@ -14,6 +15,7 @@
 
 - `vis_drake_graph()`, `drake_graph_info()`, and `render_drake_graph()` now 
   take arguments that allow behavior to be defined upon selection of nodes. (#1031, @mstr3336).
+
 
 # Version 7.7.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,7 +13,7 @@
 ## New features
 
 - `vis_drake_graph()`, `drake_graph_info()`, and `render_drake_graph()` now 
-  take arguments that allow behaviour to be defined upon selection of nodes. (#1031, @mstr3336).
+  take arguments that allow behavior to be defined upon selection of nodes. (#1031, @mstr3336).
 
 # Version 7.7.0
 

--- a/R/drake_plan.R
+++ b/R/drake_plan.R
@@ -147,6 +147,7 @@
 #'   write.csv(mtcars[, c("mpg", "cyl")], file_out("mtcars.csv")),
 #'   value = read.csv(file_in("mtcars.csv"))
 #' )
+#' plot(mtcars_plan) # fast simplified call to vis_drake_graph()
 #' mtcars_plan
 #' make(mtcars_plan) # Makes `mtcars.csv` and then `value`
 #' head(readd(value))
@@ -154,6 +155,7 @@
 #'
 #' load_mtcars_example()
 #' head(my_plan)
+#' plot(my_plan)
 #'
 #' # The `knitr_in("report.Rmd")` tells `drake` to dive into the active
 #' # code chunks to find dependencies.
@@ -532,6 +534,30 @@ as_drake_plan <- function(plan, .force_df = FALSE) {
   } else {
     tibble::new_tibble(plan, nrow = nrow(plan), subclass = "drake_plan")
   }
+}
+
+#' @export
+#' @keywords internal
+plot.drake_plan <- function(x, ...) {
+  config <- drake_config(
+    x,
+    envir = new.env(parent = baseenv()),
+    verbose = 0L,
+    cache = storr::storr_environment(),
+    history = FALSE,
+    recoverable = FALSE,
+    session_info = FALSE
+  )
+  vis_drake_graph(
+    config,
+    build_times = "none",
+    targets_only = TRUE,
+    main = "",
+    hover = FALSE,
+    ncol_legend = 0,
+    make_imports = FALSE,
+    from_scratch = TRUE
+  )
 }
 
 #' @export

--- a/R/package.R
+++ b/R/package.R
@@ -14,6 +14,7 @@
 #' library(drake)
 #' load_mtcars_example() # Get the code with drake_example("mtcars").
 #' make(my_plan) # Build everything.
+#' plot(my_plan) # fast call to vis_drake_graph()
 #' make(my_plan) # Nothing is done because everything is already up to date.
 #' reg2 = function(d) { # Change one of your functions.
 #'   d$x3 = d$x^3

--- a/R/vis_drake_graph.R
+++ b/R/vis_drake_graph.R
@@ -158,11 +158,11 @@ vis_drake_graph <- function(
 #'   Analogous to `visNetwork::visOptions(collapse = TRUE)` or
 #'   `visNetwork::visOptions(collapse = TRUE)`.
 #' @param on_select defines node selection event handling.
-#'   Either a string of valid javascript that may be passed to
+#'   Either a string of valid JavaScript that may be passed to
 #'   `visNetwork::visEvents()`, or one of the following:
-#'   `TRUE`, `NULL`/`FALSE`. If `TRUE` , enables the default behaviour of
+#'   `TRUE`, `NULL`/`FALSE`. If `TRUE` , enables the default behavior of
 #'   opening the link specified by the `on_select_col` given to
-#'   `drake_graph_info()`. `NULL`/`FALSE` disables the behaviour.
+#'   `drake_graph_info()`. `NULL`/`FALSE` disables the behavior.
 #' @param ... Arguments passed to `visNetwork()`.
 #'
 #' @examples

--- a/man/drake-package.Rd
+++ b/man/drake-package.Rd
@@ -18,6 +18,7 @@ if (suppressWarnings(require("knitr"))) {
 library(drake)
 load_mtcars_example() # Get the code with drake_example("mtcars").
 make(my_plan) # Build everything.
+plot(my_plan) # fast call to vis_drake_graph()
 make(my_plan) # Nothing is done because everything is already up to date.
 reg2 = function(d) { # Change one of your functions.
   d$x3 = d$x^3

--- a/man/drake_plan.Rd
+++ b/man/drake_plan.Rd
@@ -266,6 +266,7 @@ mtcars_plan <- drake_plan(
   write.csv(mtcars[, c("mpg", "cyl")], file_out("mtcars.csv")),
   value = read.csv(file_in("mtcars.csv"))
 )
+plot(mtcars_plan) # fast simplified call to vis_drake_graph()
 mtcars_plan
 make(mtcars_plan) # Makes `mtcars.csv` and then `value`
 head(readd(value))
@@ -273,6 +274,7 @@ head(readd(value))
 
 load_mtcars_example()
 head(my_plan)
+plot(my_plan)
 
 # The `knitr_in("report.Rmd")` tells `drake` to dive into the active
 # code chunks to find dependencies.

--- a/man/render_drake_graph.Rd
+++ b/man/render_drake_graph.Rd
@@ -69,11 +69,11 @@ Analogous to \code{visNetwork::visOptions(collapse = TRUE)} or
 \code{visNetwork::visOptions(collapse = TRUE)}.}
 
 \item{on_select}{defines node selection event handling.
-Either a string of valid javascript that may be passed to
+Either a string of valid JavaScript that may be passed to
 \code{visNetwork::visEvents()}, or one of the following:
-\code{TRUE}, \code{NULL}/\code{FALSE}. If \code{TRUE} , enables the default behaviour of
+\code{TRUE}, \code{NULL}/\code{FALSE}. If \code{TRUE} , enables the default behavior of
 opening the link specified by the \code{on_select_col} given to
-\code{drake_graph_info()}. \code{NULL}/\code{FALSE} disables the behaviour.}
+\code{drake_graph_info()}. \code{NULL}/\code{FALSE} disables the behavior.}
 
 \item{...}{Arguments passed to \code{visNetwork()}.}
 }

--- a/man/vis_drake_graph.Rd
+++ b/man/vis_drake_graph.Rd
@@ -158,11 +158,11 @@ Analogous to \code{visNetwork::visOptions(collapse = TRUE)} or
 in the plan that should provide data for the \code{on_select} event.}
 
 \item{on_select}{defines node selection event handling.
-Either a string of valid javascript that may be passed to
+Either a string of valid JavaScript that may be passed to
 \code{visNetwork::visEvents()}, or one of the following:
-\code{TRUE}, \code{NULL}/\code{FALSE}. If \code{TRUE} , enables the default behaviour of
+\code{TRUE}, \code{NULL}/\code{FALSE}. If \code{TRUE} , enables the default behavior of
 opening the link specified by the \code{on_select_col} given to
-\code{drake_graph_info()}. \code{NULL}/\code{FALSE} disables the behaviour.}
+\code{drake_graph_info()}. \code{NULL}/\code{FALSE} disables the behavior.}
 
 \item{...}{Arguments passed to \code{visNetwork()}.}
 }

--- a/tests/testthat/test-visuals.R
+++ b/tests/testthat/test-visuals.R
@@ -11,6 +11,8 @@ test_with_dir("visNetwork graph runs", {
   skip_if_not_installed("visNetwork")
   config <- dbug()
   pdf(NULL)
+  graph <- plot(dbug_plan())
+  expect_true(inherits(graph, "visNetwork"))
   tmp <- vis_drake_graph(config)
   dev.off()
   for (hover in c(TRUE, FALSE)) {


### PR DESCRIPTION
# Summary

Quick and dirty plan plotting.

``` r
library(drake)
load_mtcars_example()
make(my_plan, verbose = FALSE)
plot(my_plan) # quick and dirty
```

![](https://i.imgur.com/TF7db6x.png)

``` r
# vis_drake_graph() is harder to use,
# but has more info and options.
config <- drake_config(my_plan)
vis_drake_graph(config)
```

![](https://i.imgur.com/fnslhee.png)

<sup>Created on 2019-10-25 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

# Related GitHub issues and pull requests

- Ref: #1036 


# Checklist

- [x] I understand and agree to `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CODE_OF_CONDUCT.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) for any new functionality.
- [x] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).
