### PR TITLE
Fixed typo in warning message

### DIFF
--- a/R/drake_build.R
+++ b/R/drake_build.R
@@ -51,7 +51,7 @@ drake_build <- function(
   if (!is.null(meta)) {
     warning(
       "drake_build() is exclusively user-side now, ",
-      "so we can affort to compute `meta` on the fly. ",
+      "so we can afford to compute `meta` on the fly. ",
       "Thus, the `meta` argument is deprecated."
     )
   }


### PR DESCRIPTION
Changed 'affort' to 'afford'.

# Summary

Just noticed a typo and wanted to help correct it. I've left two of the boxes in this PR template unchecked as this is not a substantial change, and there is no new functionality.

# Checklist

- [X] I understand and agree to `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CODE_OF_CONDUCT.md).
- [ ] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [ ] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) for any new functionality.
- [X] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).
