### PR TITLE
Dynamic combine() is now dynamic group()

### DIFF
--- a/R/create_drake_layout.R
+++ b/R/create_drake_layout.R
@@ -327,13 +327,13 @@ cdl_assert_trace <- function(dynamic, layout) {
   UseMethod("cdl_assert_trace")
 }
 
-cdl_assert_trace.combine <- function(dynamic, layout) {
+cdl_assert_trace.group <- function(dynamic, layout) {
   bad <- setdiff(layout$deps_dynamic_trace, layout$deps_dynamic)
   if (!length(bad)) {
     return()
   }
   stop(
-    "in combine(), ",
+    "in dynamic group(), ",
     "the only legal dynamic trace variable ",
     "is the one you select with `.by`. ",
     "illegal dynamic trace variables for target ",

--- a/R/drake_config.R
+++ b/R/drake_config.R
@@ -171,12 +171,6 @@
 #'   - `TRUE`: same as `"promise"`.
 #'   - `FALSE`: same as `"eager"`.
 #'
-#'   `lazy_load` should not be `"promise"`
-#'   for `"parLapply"` parallelism combined with `jobs` greater than 1.
-#'   For local multi-session parallelism and lazy loading, try
-#'   `library(future); future::plan(multisession)` and then
-#'   `make(..., parallelism = "future_lapply", lazy_load = "bind")`.
-#'
 #'   If `lazy_load` is `"eager"`,
 #'   drake prunes the execution environment before each target/stage,
 #'   removing all superfluous targets
@@ -457,7 +451,7 @@
 #'
 #' @param max_expand Positive integer, optional.
 #'   `max_expand` is the maximum number of targets to generate in each
-#'   `map()`, `cross()`, or `combine()` dynamic transform.
+#'   `map()`, `cross()`, or `group()` dynamic transform.
 #'   Useful if you have a massive number of dynamic sub-targets and you want to
 #'   work with only the first few sub-targets before scaling up.
 #'   Note: the `max_expand` argument of `make()` and

--- a/R/drake_plan_helpers.R
+++ b/R/drake_plan_helpers.R
@@ -12,7 +12,7 @@
 #' @param transform A call to [map()], [split()], [cross()], or [combine()]
 #'   to apply a *static* transformation. Details:
 #'   <https://books.ropensci.org/drake/static.html>
-#' @param dynamic A call to [map()], [cross()], or [combine()]
+#' @param dynamic A call to [map()], [cross()], or [group()]
 #'   to apply a *dynamic* transformation. Details:
 #'   <https://books.ropensci.org/drake/dynamic.html>
 #' @param ... Optional columns of the plan for a given target.
@@ -244,8 +244,8 @@ trigger <- function(
 #' file.exists("mtcars.csv")
 #'
 #' # You may use `.id_chr` inside `file_out()` and `file_in()`
-#' # to refer  to the current target. This works inside `map()`,
-#' # `combine()`, `split()`, and `cross()`.
+#' # to refer  to the current target. This works inside
+#' # static `map()`, `combine()`, `split()`, and `cross()`.
 #'
 #' plan <- drake::drake_plan(
 #'   data = target(

--- a/R/dynamic.R
+++ b/R/dynamic.R
@@ -381,7 +381,7 @@ as_dynamic <- function(x) {
     return(x)
   }
   class(x) <- c(x[[1]], "dynamic", class(x))
-  match_call(x)
+  match_dynamic_call(x)
 }
 
 dynamic_subvalue <- function(value, index) {
@@ -417,22 +417,31 @@ dynamic_subvalue_vector <- function(value, index) {
   value[index]
 }
 
-match_call <- function(dynamic) {
+match_dynamic_call <- function(dynamic) {
   class <- class(dynamic)
-  out <- match_call_impl(dynamic)
+  out <- match_dynamic_call_impl(dynamic)
   class(out) <- class
   out
 }
 
-match_call_impl <- function(dynamic) {
-  UseMethod("match_call_impl")
+match_dynamic_call_impl <- function(dynamic) {
+  UseMethod("match_dynamic_call_impl")
 }
 
-match_call_impl.map <- match_call_impl.cross <- function(dynamic) {
+match_dynamic_call_impl.map <- match_dynamic_call_impl.cross <- function(dynamic) {
   match.call(definition = def_map, call = dynamic)
 }
 
-match_call_impl.group <- function(dynamic) {
+match_dynamic_call_impl.combine <- function(dynamic) {
+  stop(
+    "Dynamic combine() does not exist. ",
+    "use group() instead. ",
+    "Ref: https://github.com/ropensci/drake/issues/1065",
+    call. = FALSE
+  )
+}
+
+match_dynamic_call_impl.group <- function(dynamic) {
   match.call(definition = def_group, call = dynamic)
 }
 

--- a/R/dynamic.R
+++ b/R/dynamic.R
@@ -13,7 +13,7 @@
 #'   w = c("a", "a", "b", "b"),
 #'   x = seq_len(4),
 #'   y = target(x + 1, dynamic = map(x)),
-#'   z = target(list(y = y, w = w), dynamic = combine(y, .by = w))
+#'   z = target(list(y = y, w = w), dynamic = group(y, .by = w))
 #' )
 #' make(plan)
 #' subtargets(y)
@@ -54,12 +54,12 @@ subtargets <- function(
 #' @inheritParams readd
 #' @param trace Character, name of the trace
 #'   you want to extract. Such trace names are declared
-#'   in the `.trace` argument of `map()`, `cross()` or `combine()`.
+#'   in the `.trace` argument of `map()`, `cross()` or `group()`.
 #' @param trace Character, name of a target from which to extract
 #'   a trace.
 #' @param target The name of a dynamic target with one or more traces
 #'   defined using the `.trace` argument of dynamic `map()`, `cross()`,
-#'   or `combine()`.
+#'   or `group()`.
 #' @examples
 #' \dontrun{
 #' isolate_example("demonstrate dynamic trace", {
@@ -72,12 +72,12 @@ subtargets <- function(
 #'   y = target(c(w, x), dynamic = cross(w, x, .trace = w)),
 #'
 #'   # We can use the trace as a grouping variable for the next
-#'   # combine().
+#'   # group().
 #'   w_tr = get_trace("w", y),
 #'
 #'   # Now, we use the trace again to keep track of the
 #'   # values of w corresponding to the sub-targets of z.
-#'   z = target(y, dynamic = combine(y, .by = w_tr, .trace = w_tr))
+#'   z = target(y, dynamic = group(y, .by = w_tr, .trace = w_tr))
 #' )
 #' make(plan)
 #'
@@ -120,7 +120,7 @@ read_trace <- function(
 #'   a vector of values from a grouping variable.
 #' @param trace Character, name of the trace
 #'   you want to extract. Such trace names are declared
-#'   in the `.trace` argument of `map()`, `cross()` or `combine()`.
+#'   in the `.trace` argument of `map()`, `cross()` or `group()`.
 #' @param value The return value of the target with the trace.
 #' @examples
 #' \dontrun{
@@ -134,12 +134,12 @@ read_trace <- function(
 #'   y = target(c(w, x), dynamic = cross(w, x, .trace = w)),
 #'
 #'   # We can use the trace as a grouping variable for the next
-#'   # combine().
+#'   # group().
 #'   w_tr = get_trace("w", y),
 #'
 #'   # Now, we use the trace again to keep track of the
 #'   # values of w corresponding to the sub-targets of z.
-#'   z = target(y, dynamic = combine(y, .by = w_tr, .trace = w_tr))
+#'   z = target(y, dynamic = group(y, .by = w_tr, .trace = w_tr))
 #' )
 #' make(plan)
 #'
@@ -212,7 +212,7 @@ get_trace_impl.cross <- function(dynamic, value, layout, config) {
   trace
 }
 
-get_trace_impl.combine <- function(dynamic, value, layout, config) {
+get_trace_impl.group <- function(dynamic, value, layout, config) {
   by_key <- which_by(dynamic)
   by_value <- get(by_key, envir = config$envir_targets, inherits = FALSE)
   trace <- list(unique(by_value))
@@ -432,8 +432,8 @@ match_call_impl.map <- match_call_impl.cross <- function(dynamic) {
   match.call(definition = def_map, call = dynamic)
 }
 
-match_call_impl.combine <- function(dynamic) {
-  match.call(definition = def_combine, call = dynamic)
+match_call_impl.group <- function(dynamic) {
+  match.call(definition = def_group, call = dynamic)
 }
 
 # nocov start
@@ -441,7 +441,7 @@ def_map <- function(..., .trace = NULL) {
   NULL
 }
 
-def_combine <- function(..., .by = NULL, .trace = NULL) {
+def_group <- function(..., .by = NULL, .trace = NULL) {
   NULL
 }
 # nocov end
@@ -484,7 +484,7 @@ dynamic_hash_list.cross <- function(dynamic, target, config) {
   lapply(deps, read_dynamic_hashes, config = config)
 }
 
-dynamic_hash_list.combine <- function(dynamic, target, config) {
+dynamic_hash_list.group <- function(dynamic, target, config) {
   deps <- sort(which_vars(dynamic))
   out <- lapply(deps, read_dynamic_hashes, config = config)
   if (!is.null(dynamic$.by)) {
@@ -504,7 +504,7 @@ assert_equal_branches <- function(target, deps, hashes) {
   lengths <- lengths[keep]
   deps[is.na(deps)] <- ".by"
   stop(
-    "for dynamic map() and combine(), all grouping variables ",
+    "for dynamic map() and group(), all grouping variables ",
     "must have equal lengths. For target ", target,
     ", the lengths of ", paste(deps, collapse = ", "),
     " were ", paste0(lengths, collapse = ", "),
@@ -535,7 +535,7 @@ subtarget_hashes.cross <- function(dynamic, target, hashes, config) {
   apply(hashes, 1, paste, collapse = " ")
 }
 
-subtarget_hashes.combine <- function(dynamic, target, hashes, config) {
+subtarget_hashes.group <- function(dynamic, target, hashes, config) {
   if (is.null(hashes[["_by"]])) {
     return(lapply(hashes, paste, collapse = " "))
   }
@@ -571,7 +571,7 @@ subtarget_deps_impl.cross <- function(dynamic, target, index, config) {
   out
 }
 
-subtarget_deps_impl.combine <- function(
+subtarget_deps_impl.group <- function(
   dynamic,
   target,
   index,

--- a/R/make.R
+++ b/R/make.R
@@ -113,7 +113,7 @@
 #'   w = c("a", "a", "b", "b"),
 #'   x = seq_len(4),
 #'   y = target(x + 1, dynamic = map(x)),
-#'   z = target(list(y = y, w = w), dynamic = combine(y, .by = w))
+#'   z = target(list(y = y, w = w), dynamic = group(y, .by = w))
 #' )
 #' make(plan)
 #' subtargets(y)

--- a/R/manage_memory.R
+++ b/R/manage_memory.R
@@ -248,7 +248,7 @@ load_dynamic_subdep_impl <- function(dynamic, parent, dep, index, config) {
   UseMethod("load_dynamic_subdep_impl")
 }
 
-load_dynamic_subdep_impl.combine <- function( # nolint
+load_dynamic_subdep_impl.group <- function( # nolint
   dynamic,
   parent,
   dep,

--- a/R/package.R
+++ b/R/package.R
@@ -33,7 +33,7 @@
 #'   w = c("a", "a", "b", "b"),
 #'   x = seq_len(4),
 #'   y = target(x + 1, dynamic = map(x)),
-#'   z = target(list(y = y, w = w), dynamic = combine(y, .by = w))
+#'   z = target(list(y = y, w = w), dynamic = group(y, .by = w))
 #' )
 #' make(plan)
 #' subtargets(y)

--- a/R/transform_plan.R
+++ b/R/transform_plan.R
@@ -1,6 +1,6 @@
 #' @title Transformations in `drake_plan()`. \lifecycle{maturing}
 #' @name transformations
-#' @aliases map split cross combine
+#' @aliases map split cross combine group
 #' @description In [drake_plan()], you can define whole batches
 #'   of targets with transformations such as
 #'   `map()`, `split()`, `cross()`, and `combine()`.
@@ -32,16 +32,16 @@
 #'   but this is what it usage will look like.
 #'   - `map(..., .trace)`
 #'   - `cross(..., .trace)`
-#'   - `combine(..., .by, .trace)`
+#'   - `group(..., .by, .trace)`
 #'
 #'  `map()` and `cross()` create dynamic sub-targets from the variables
 #'  supplied to the dots. As with static branching, the variables
 #'  supplied to `map()` must all have equal length.
-#'  `split(f(data), .by = x)` makes a new dynamic sub-targets from
-#'   pieces of `data` for each unique element of `x`. Here,
-#'   `data` must not be dynamic.
-#'   `combine(f(data), .by = x)` makes new dynamic
-#'   sub-targets from `data`.
+#'   `group(f(data), .by = x)` makes new dynamic
+#'   sub-targets from `data`. Here, `data` can be either static or dynamic.
+#'   If `data` is dynamic, `group()` aggregates existing sub-targets.
+#'   If `data` is static, `group()` splits `data` into multiple
+#'   subsets based on the groupings from `.by`.
 #'
 #'  Differences from static branching:
 #'  - `...` must contain *unnamed* symbols with no values supplied,

--- a/man/drake-package.Rd
+++ b/man/drake-package.Rd
@@ -37,7 +37,7 @@ plan <- drake_plan(
   w = c("a", "a", "b", "b"),
   x = seq_len(4),
   y = target(x + 1, dynamic = map(x)),
-  z = target(list(y = y, w = w), dynamic = combine(y, .by = w))
+  z = target(list(y = y, w = w), dynamic = group(y, .by = w))
 )
 make(plan)
 subtargets(y)

--- a/man/drake_config.Rd
+++ b/man/drake_config.Rd
@@ -222,12 +222,6 @@ with \code{\link[=assign]{assign()}}.
 \item \code{FALSE}: same as \code{"eager"}.
 }
 
-\code{lazy_load} should not be \code{"promise"}
-for \code{"parLapply"} parallelism combined with \code{jobs} greater than 1.
-For local multi-session parallelism and lazy loading, try
-\verb{library(future); future::plan(multisession)} and then
-\code{make(..., parallelism = "future_lapply", lazy_load = "bind")}.
-
 If \code{lazy_load} is \code{"eager"},
 drake prunes the execution environment before each target/stage,
 removing all superfluous targets
@@ -513,7 +507,7 @@ whose names match your URL, \code{drake} will choose the closest match.}
 
 \item{max_expand}{Positive integer, optional.
 \code{max_expand} is the maximum number of targets to generate in each
-\code{map()}, \code{cross()}, or \code{combine()} dynamic transform.
+\code{map()}, \code{cross()}, or \code{group()} dynamic transform.
 Useful if you have a massive number of dynamic sub-targets and you want to
 work with only the first few sub-targets before scaling up.
 Note: the \code{max_expand} argument of \code{make()} and

--- a/man/drake_plan.Rd
+++ b/man/drake_plan.Rd
@@ -234,17 +234,17 @@ but this is what it usage will look like.
 \itemize{
 \item \code{map(..., .trace)}
 \item \code{cross(..., .trace)}
-\item \code{combine(..., .by, .trace)}
+\item \code{group(..., .by, .trace)}
 }
 
 \code{map()} and \code{cross()} create dynamic sub-targets from the variables
 supplied to the dots. As with static branching, the variables
 supplied to \code{map()} must all have equal length.
-\code{split(f(data), .by = x)} makes a new dynamic sub-targets from
-pieces of \code{data} for each unique element of \code{x}. Here,
-\code{data} must not be dynamic.
-\code{combine(f(data), .by = x)} makes new dynamic
-sub-targets from \code{data}.
+\code{group(f(data), .by = x)} makes new dynamic
+sub-targets from \code{data}. Here, \code{data} can be either static or dynamic.
+If \code{data} is dynamic, \code{group()} aggregates existing sub-targets.
+If \code{data} is static, \code{group()} splits \code{data} into multiple
+subsets based on the groupings from \code{.by}.
 
 Differences from static branching:
 \itemize{

--- a/man/file_in.Rd
+++ b/man/file_in.Rd
@@ -79,8 +79,8 @@ make(plan)
 file.exists("mtcars.csv")
 
 # You may use `.id_chr` inside `file_out()` and `file_in()`
-# to refer  to the current target. This works inside `map()`,
-# `combine()`, `split()`, and `cross()`.
+# to refer  to the current target. This works inside
+# static `map()`, `combine()`, `split()`, and `cross()`.
 
 plan <- drake::drake_plan(
   data = target(

--- a/man/get_trace.Rd
+++ b/man/get_trace.Rd
@@ -9,7 +9,7 @@ get_trace(trace, value)
 \arguments{
 \item{trace}{Character, name of the trace
 you want to extract. Such trace names are declared
-in the \code{.trace} argument of \code{map()}, \code{cross()} or \code{combine()}.}
+in the \code{.trace} argument of \code{map()}, \code{cross()} or \code{group()}.}
 
 \item{value}{The return value of the target with the trace.}
 }
@@ -39,12 +39,12 @@ plan <- drake_plan(
   y = target(c(w, x), dynamic = cross(w, x, .trace = w)),
 
   # We can use the trace as a grouping variable for the next
-  # combine().
+  # group().
   w_tr = get_trace("w", y),
 
   # Now, we use the trace again to keep track of the
   # values of w corresponding to the sub-targets of z.
-  z = target(y, dynamic = combine(y, .by = w_tr, .trace = w_tr))
+  z = target(y, dynamic = group(y, .by = w_tr, .trace = w_tr))
 )
 make(plan)
 

--- a/man/make.Rd
+++ b/man/make.Rd
@@ -240,12 +240,6 @@ with \code{\link[=assign]{assign()}}.
 \item \code{FALSE}: same as \code{"eager"}.
 }
 
-\code{lazy_load} should not be \code{"promise"}
-for \code{"parLapply"} parallelism combined with \code{jobs} greater than 1.
-For local multi-session parallelism and lazy loading, try
-\verb{library(future); future::plan(multisession)} and then
-\code{make(..., parallelism = "future_lapply", lazy_load = "bind")}.
-
 If \code{lazy_load} is \code{"eager"},
 drake prunes the execution environment before each target/stage,
 removing all superfluous targets
@@ -531,7 +525,7 @@ whose names match your URL, \code{drake} will choose the closest match.}
 
 \item{max_expand}{Positive integer, optional.
 \code{max_expand} is the maximum number of targets to generate in each
-\code{map()}, \code{cross()}, or \code{combine()} dynamic transform.
+\code{map()}, \code{cross()}, or \code{group()} dynamic transform.
 Useful if you have a massive number of dynamic sub-targets and you want to
 work with only the first few sub-targets before scaling up.
 Note: the \code{max_expand} argument of \code{make()} and
@@ -636,7 +630,7 @@ plan <- drake_plan(
   w = c("a", "a", "b", "b"),
   x = seq_len(4),
   y = target(x + 1, dynamic = map(x)),
-  z = target(list(y = y, w = w), dynamic = combine(y, .by = w))
+  z = target(list(y = y, w = w), dynamic = group(y, .by = w))
 )
 make(plan)
 subtargets(y)

--- a/man/read_trace.Rd
+++ b/man/read_trace.Rd
@@ -12,7 +12,7 @@ a trace.}
 
 \item{target}{The name of a dynamic target with one or more traces
 defined using the \code{.trace} argument of dynamic \code{map()}, \code{cross()},
-or \code{combine()}.}
+or \code{group()}.}
 
 \item{cache}{drake cache. See \code{\link[=new_cache]{new_cache()}}.
 If supplied, \code{path} is ignored.}
@@ -46,12 +46,12 @@ plan <- drake_plan(
   y = target(c(w, x), dynamic = cross(w, x, .trace = w)),
 
   # We can use the trace as a grouping variable for the next
-  # combine().
+  # group().
   w_tr = get_trace("w", y),
 
   # Now, we use the trace again to keep track of the
   # values of w corresponding to the sub-targets of z.
-  z = target(y, dynamic = combine(y, .by = w_tr, .trace = w_tr))
+  z = target(y, dynamic = group(y, .by = w_tr, .trace = w_tr))
 )
 make(plan)
 

--- a/man/subtargets.Rd
+++ b/man/subtargets.Rd
@@ -38,7 +38,7 @@ plan <- drake_plan(
   w = c("a", "a", "b", "b"),
   x = seq_len(4),
   y = target(x + 1, dynamic = map(x)),
-  z = target(list(y = y, w = w), dynamic = combine(y, .by = w))
+  z = target(list(y = y, w = w), dynamic = group(y, .by = w))
 )
 make(plan)
 subtargets(y)

--- a/man/target.Rd
+++ b/man/target.Rd
@@ -14,7 +14,7 @@ target(command = NULL, transform = NULL, dynamic = NULL, ...)
 to apply a \emph{static} transformation. Details:
 \url{https://books.ropensci.org/drake/static.html}}
 
-\item{dynamic}{A call to \code{\link[=map]{map()}}, \code{\link[=cross]{cross()}}, or \code{\link[=combine]{combine()}}
+\item{dynamic}{A call to \code{\link[=map]{map()}}, \code{\link[=cross]{cross()}}, or \code{\link[=group]{group()}}
 to apply a \emph{dynamic} transformation. Details:
 \url{https://books.ropensci.org/drake/dynamic.html}}
 

--- a/man/transformations.Rd
+++ b/man/transformations.Rd
@@ -6,6 +6,7 @@
 \alias{split}
 \alias{cross}
 \alias{combine}
+\alias{group}
 \title{Transformations in \code{drake_plan()}. \lifecycle{maturing}}
 \arguments{
 \item{...}{Grouping variables. New grouping variables must be
@@ -97,17 +98,17 @@ but this is what it usage will look like.
 \itemize{
 \item \code{map(..., .trace)}
 \item \code{cross(..., .trace)}
-\item \code{combine(..., .by, .trace)}
+\item \code{group(..., .by, .trace)}
 }
 
 \code{map()} and \code{cross()} create dynamic sub-targets from the variables
 supplied to the dots. As with static branching, the variables
 supplied to \code{map()} must all have equal length.
-\code{split(f(data), .by = x)} makes a new dynamic sub-targets from
-pieces of \code{data} for each unique element of \code{x}. Here,
-\code{data} must not be dynamic.
-\code{combine(f(data), .by = x)} makes new dynamic
-sub-targets from \code{data}.
+\code{group(f(data), .by = x)} makes new dynamic
+sub-targets from \code{data}. Here, \code{data} can be either static or dynamic.
+If \code{data} is dynamic, \code{group()} aggregates existing sub-targets.
+If \code{data} is static, \code{group()} splits \code{data} into multiple
+subsets based on the groupings from \code{.by}.
 
 Differences from static branching:
 \itemize{

--- a/tests/testthat/test-dynamic.R
+++ b/tests/testthat/test-dynamic.R
@@ -1436,3 +1436,12 @@ test_with_dir("dynamic group trace (#1052)", {
   expect_equal(get_trace("w_tr", value), LETTERS[seq_len(3)])
   expect_equal(read_trace("w_tr", "z"), LETTERS[seq_len(3)])
 })
+
+
+test_with_dir("dynamic combine() does not exist", {
+  plan <- drake_plan(
+    x = seq_len(8),
+    y = target(x, dynamic = combine(x, .by = x))
+  )
+  expect_error(make(plan), regexp = "does not exist")
+})


### PR DESCRIPTION
# Summary

As @dpmccabe and @JodyStats mentioned in #1064 and #1065, dynamic `combine()` is confusing because it covers both splitting and aggregation. `group()` really fits both, so I am changing the name. If you try to use `combine()`, you get an informative error.

``` r
library(drake)
library(magrittr)

plan <- drake_plan(
  data = mtcars,
  cyl = data$cyl,
  
  # splitting. Works with and without `.by`.
  subsets = target(
    data,
    dynamic = combine(data, .by = cyl)
  ),
  
  # aggregation. Works with and without `.by`.
  cars_per_cyl = target(
    purrr::map_int(subsets, nrow),
    dynamic = group(subsets)
  )
)

make(plan)
#> Error: Dynamic combine() does not exist. use group() instead. Ref: https://github.com/ropensci/drake/issues/1065
```

<sup>Created on 2019-11-14 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

Intended usage:

``` r
library(drake)
library(magrittr)

plan <- drake_plan(
  data = mtcars,
  cyl = data$cyl,
  
  # splitting
  subsets = target(
    data,
    dynamic = group(data, .by = cyl)
  ),
  
  # aggregation
  cars_per_cyl = target(
    purrr::map_int(subsets, nrow),
    dynamic = group(subsets)
  )
)

make(plan)
#> target data
#> target cyl
#> dynamic subsets
#> subtarget subsets_895749a8
#> subtarget subsets_503adfac
#> subtarget subsets_9278e453
#> aggregate subsets
#> dynamic cars_per_cyl
#> subtarget cars_per_cyl_736d8ea8
#> aggregate cars_per_cyl

readd(subsets) %>%
  setNames(read_trace("cyl", "subsets"))
#> [[1]]
#>                 mpg cyl  disp  hp drat    wt  qsec vs am gear carb
#> Mazda RX4      21.0   6 160.0 110 3.90 2.620 16.46  0  1    4    4
#> Mazda RX4 Wag  21.0   6 160.0 110 3.90 2.875 17.02  0  1    4    4
#> Hornet 4 Drive 21.4   6 258.0 110 3.08 3.215 19.44  1  0    3    1
#> Valiant        18.1   6 225.0 105 2.76 3.460 20.22  1  0    3    1
#> Merc 280       19.2   6 167.6 123 3.92 3.440 18.30  1  0    4    4
#> Merc 280C      17.8   6 167.6 123 3.92 3.440 18.90  1  0    4    4
#> Ferrari Dino   19.7   6 145.0 175 3.62 2.770 15.50  0  1    5    6
#> 
#> [[2]]
#>                 mpg cyl  disp  hp drat    wt  qsec vs am gear carb
#> Datsun 710     22.8   4 108.0  93 3.85 2.320 18.61  1  1    4    1
#> Merc 240D      24.4   4 146.7  62 3.69 3.190 20.00  1  0    4    2
#> Merc 230       22.8   4 140.8  95 3.92 3.150 22.90  1  0    4    2
#> Fiat 128       32.4   4  78.7  66 4.08 2.200 19.47  1  1    4    1
#> Honda Civic    30.4   4  75.7  52 4.93 1.615 18.52  1  1    4    2
#> Toyota Corolla 33.9   4  71.1  65 4.22 1.835 19.90  1  1    4    1
#> Toyota Corona  21.5   4 120.1  97 3.70 2.465 20.01  1  0    3    1
#> Fiat X1-9      27.3   4  79.0  66 4.08 1.935 18.90  1  1    4    1
#> Porsche 914-2  26.0   4 120.3  91 4.43 2.140 16.70  0  1    5    2
#> Lotus Europa   30.4   4  95.1 113 3.77 1.513 16.90  1  1    5    2
#> Volvo 142E     21.4   4 121.0 109 4.11 2.780 18.60  1  1    4    2
#> 
#> [[3]]
#>                      mpg cyl  disp  hp drat    wt  qsec vs am gear carb
#> Hornet Sportabout   18.7   8 360.0 175 3.15 3.440 17.02  0  0    3    2
#> Duster 360          14.3   8 360.0 245 3.21 3.570 15.84  0  0    3    4
#> Merc 450SE          16.4   8 275.8 180 3.07 4.070 17.40  0  0    3    3
#> Merc 450SL          17.3   8 275.8 180 3.07 3.730 17.60  0  0    3    3
#> Merc 450SLC         15.2   8 275.8 180 3.07 3.780 18.00  0  0    3    3
#> Cadillac Fleetwood  10.4   8 472.0 205 2.93 5.250 17.98  0  0    3    4
#> Lincoln Continental 10.4   8 460.0 215 3.00 5.424 17.82  0  0    3    4
#> Chrysler Imperial   14.7   8 440.0 230 3.23 5.345 17.42  0  0    3    4
#> Dodge Challenger    15.5   8 318.0 150 2.76 3.520 16.87  0  0    3    2
#> AMC Javelin         15.2   8 304.0 150 3.15 3.435 17.30  0  0    3    2
#> Camaro Z28          13.3   8 350.0 245 3.73 3.840 15.41  0  0    3    4
#> Pontiac Firebird    19.2   8 400.0 175 3.08 3.845 17.05  0  0    3    2
#> Ford Pantera L      15.8   8 351.0 264 4.22 3.170 14.50  0  1    5    4
#> Maserati Bora       15.0   8 301.0 335 3.54 3.570 14.60  0  1    5    8

readd(cars_per_cyl)
#> [[1]]
#> [1]  7 11 14
```

<sup>Created on 2019-11-14 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>



# Related GitHub issues and pull requests

- Ref: #1065

# Checklist

- [x] I understand and agree to `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CODE_OF_CONDUCT.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) for any new functionality.
- [x] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).
