### PR TITLE
fst format for tibbles

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@ These changes invalidate some targets in some workflows, but they are necessary 
 
 ## New features
 
+* Add a new `"fst_tbl"` format for large `tibble` targets (#1154, @kendonB).
 * Add a new `format` argument to `make()`, an optional custom storage format for targets without an explicit `target(format = ...)` in the plan (#1124).
 * Add a new `lock_cache` argument to `make()` to optionally suppress cache locking (#1129). (It can be annoying to interrupt `make()` repeatedly and unlock the cache manually every time.)
 * Add new functions `cancel()` and `cancel_if()` function to cancel targets mid-build (#1131).

--- a/R/decorate_storr.R
+++ b/R/decorate_storr.R
@@ -286,6 +286,13 @@ dcst_get_.drake_format_fst <- function(value, key, .self) {
   fst::read_fst(.self$file_return_key(key))
 }
 
+dcst_get_.drake_format_fst_tbl <- function(value, key, .self) {
+  assert_pkg("fst")
+  assert_pkg("tibble")
+  out <- fst::read_fst(.self$file_return_key(key))
+  tibble::as_tibble(out)
+}
+
 dcst_get_.drake_format_fst_dt <- function(value, key, .self) { # nolint
   assert_pkg("data.table")
   assert_pkg("fst")
@@ -338,6 +345,13 @@ dcst_get_value_.drake_format_fst <- function(value, hash, .self) { # nolint
   fst::read_fst(.self$file_return_hash(hash))
 }
 
+dcst_get_value_.drake_format_fst_tbl <- function(value, hash, .self) { # nolint
+  assert_pkg("fst")
+  assert_pkg("tibble")
+  out <- fst::read_fst(.self$file_return_hash(hash))
+  tibble::as_tibble(out)
+}
+
 dcst_get_value_.drake_format_fst_dt <- function(value, hash, .self) { # nolint
   assert_pkg("data.table")
   assert_pkg("fst")
@@ -388,6 +402,8 @@ dcst_set.drake_format_fst <- function(value, key, ..., .self) {
   fst::write_fst(x = value$value, path = tmp)
   dcst_set_move_tmp(key = key, value = value, tmp = tmp, .self = .self)
 }
+
+dcst_set.drake_format_fst_tbl <- dcst_set.drake_format_fst
 
 dcst_set.drake_format_fst_dt <- function(value, key, ..., .self) {
   assert_pkg("data.table")

--- a/R/drake_config.R
+++ b/R/drake_config.R
@@ -845,7 +845,15 @@ plan_check_format_col <- function(plan) {
   }
   format <- plan$format
   format <- format[!is.na(format)]
-  formats <- c("fst", "fst_dt", "diskframe", "keras", "qs", "rds")
+  formats <- c(
+    "fst",
+    "fst_tbl",
+    "fst_dt",
+    "diskframe",
+    "keras",
+    "qs",
+    "rds"
+  )
   illegal <- setdiff(unique(format), formats)
   if (!length(illegal)) {
     return()

--- a/R/drake_plan.R
+++ b/R/drake_plan.R
@@ -68,11 +68,15 @@
 #'   - `"fst"`: save big data frames fast. Requirements:
 #'       1. The `fst` package must be installed.
 #'       2. The target's value must be a plain data frame. If it is not a
-#'         plain data frame (for example, a tibble or data.table)
+#'         plain data frame (for example, a `tibble` or `data.table`)
 #'         then drake will coerce it to a plain data frame with
 #'         `as.data.frame()`.
 #'         All non-data-frame-specific attributes are lost
 #'         when `drake` saves the target.
+#'   - `"fst_tbl"`: Like `"fst"`, but for `tibble`s. The `tibble` package
+#'     must be installed, and the target's value should be a `tibble` object.
+#'     As with the `"fst"` format, all non-data-data-frame non-`tibble`
+#'     attributes are lost.
 #'   - `"fst_dt"`: Like `"fst"` format, but for `data.table` objects.
 #'      Requirements:
 #'       1. The `data.table` and `fst` packages must be installed.

--- a/R/local_build.R
+++ b/R/local_build.R
@@ -383,6 +383,22 @@ sanitize_format.drake_format_fst <- function(x, target, config) { # nolint
   x
 }
 
+sanitize_format.drake_format_fst_tbl <- function(x, target, config) { # nolint
+  assert_pkg("tibble")
+  if (!inherits(x$value, "tbl_df")) {
+    msg <- paste0(
+      "You selected fst_tbl format for target ", target,
+      ", so drake will convert it from class ",
+      safe_deparse(class(x$value), backtick = TRUE),
+      " to a tibble."
+    )
+    warning(msg, call. = FALSE)
+    config$logger$minor(msg, target = target)
+  }
+  x$value <- tibble::as_tibble(x$value)
+  x
+}
+
 sanitize_format.drake_format_fst_dt <- function(x, target, config) { # nolint
   assert_pkg("data.table")
   if (!inherits(x$value, "data.table")) {

--- a/man/drake_plan.Rd
+++ b/man/drake_plan.Rd
@@ -136,12 +136,16 @@ Available formats:
 \enumerate{
 \item The \code{fst} package must be installed.
 \item The target's value must be a plain data frame. If it is not a
-plain data frame (for example, a tibble or data.table)
+plain data frame (for example, a \code{tibble} or \code{data.table})
 then drake will coerce it to a plain data frame with
 \code{as.data.frame()}.
 All non-data-frame-specific attributes are lost
 when \code{drake} saves the target.
 }
+\item \code{"fst_tbl"}: Like \code{"fst"}, but for \code{tibble}s. The \code{tibble} package
+must be installed, and the target's value should be a \code{tibble} object.
+As with the \code{"fst"} format, all non-data-data-frame non-\code{tibble}
+attributes are lost.
 \item \code{"fst_dt"}: Like \code{"fst"} format, but for \code{data.table} objects.
 Requirements:
 \enumerate{

--- a/tests/testthat/test-8-decorated-storr.R
+++ b/tests/testthat/test-8-decorated-storr.R
@@ -367,6 +367,29 @@ test_with_dir("Can save fst data frames", {
   expect_false(is.list(ref))
 })
 
+test_with_dir("Can save fst_tbl tibbles (#1154)", {
+  skip_if_not_installed("fst")
+  skip_if_not_installed("tibble")
+  plan <- drake_plan(
+    x = target(
+      tibble::tibble(x = letters, y = letters),
+      format = "fst_tbl"
+    )
+  )
+  make(plan)
+  out <- readd(x)
+  exp <- data.frame(x = letters, y = letters, stringsAsFactors = FALSE)
+  expect_equal(out, exp)
+  cache <- drake_cache()
+  expect_equal(cache$get_value(cache$get_hash("x")), exp)
+  ref <- cache$storr$get("x")
+  expect_true(inherits(ref, "drake_format"))
+  expect_true(inherits(ref, "drake_format_fst_tbl"))
+  expect_equal(length(ref), 1L)
+  expect_true(nchar(ref) < 100)
+  expect_false(is.list(ref))
+})
+
 test_with_dir("fst format forces data frames", {
   skip_on_cran()
   skip_if_not_installed("fst")
@@ -378,9 +401,10 @@ test_with_dir("fst format forces data frames", {
   )
   expect_warning(make(plan), regexp = "plain data frame")
   expect_true(inherits(readd(x), "data.frame"))
+  expect_false(inherits(readd(x), "tbl_df"))
 })
 
-test_with_dir("fst format and tibbles", {
+test_with_dir("regular fst format and tibbles", {
   skip_on_cran()
   skip_if_not_installed("fst")
   skip_if_not_installed("tibble")
@@ -397,6 +421,20 @@ test_with_dir("fst format and tibbles", {
   )
   expect_equal(readd(y), "data.frame")
   expect_false(inherits(readd(x), "tibble"))
+})
+
+test_with_dir("fst_tbl format forces tibbles (#1154)", {
+  skip_on_cran()
+  skip_if_not_installed("fst")
+  skip_if_not_installed("tibble")
+  plan <- drake_plan(
+    x = target(
+      list(x = letters, y = letters),
+      format = "fst_tbl"
+    )
+  )
+  expect_warning(make(plan), regexp = "tibble")
+  expect_true(inherits(readd(x), "tbl_df"))
 })
 
 test_with_dir("fst_dt", {


### PR DESCRIPTION
# Summary

Set `format = "fst_tbl"` to save `tibble` targets faster. It is like the existing `format = "fst"` except we preserve the classes required for `tibble` objects.

``` r
library(drake)
library(tibble)

plan <- drake_plan(x = target(as_tibble(mtcars), format = "fst_tbl"))

make(plan)
#> target x

readd(x)
#> # A tibble: 32 x 11
#>      mpg   cyl  disp    hp  drat    wt  qsec    vs    am  gear  carb
#>    <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>
#>  1  21       6  160    110  3.9   2.62  16.5     0     1     4     4
#>  2  21       6  160    110  3.9   2.88  17.0     0     1     4     4
#>  3  22.8     4  108     93  3.85  2.32  18.6     1     1     4     1
#>  4  21.4     6  258    110  3.08  3.22  19.4     1     0     3     1
#>  5  18.7     8  360    175  3.15  3.44  17.0     0     0     3     2
#>  6  18.1     6  225    105  2.76  3.46  20.2     1     0     3     1
#>  7  14.3     8  360    245  3.21  3.57  15.8     0     0     3     4
#>  8  24.4     4  147.    62  3.69  3.19  20       1     0     4     2
#>  9  22.8     4  141.    95  3.92  3.15  22.9     1     0     4     2
#> 10  19.2     6  168.   123  3.92  3.44  18.3     1     0     4     4
#> # … with 22 more rows
```

<sup>Created on 2020-01-29 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

cc @kendonB 

# Related GitHub issues and pull requests

- Ref: #1154

# Checklist

- [x] I understand and agree to `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CODE_OF_CONDUCT.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) for any new functionality.
- [x] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).
