### PR TITLE
Improvements to logging and console output

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -136,6 +136,7 @@ Suggests:
   lubridate,
   networkD3,
   prettycode,
+  progress (>= 1.2.2),
   qs (>= 0.20.2),
   Rcpp,
   rmarkdown,

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,10 @@
 
 ## Enhancements
 
-* Assert dependencies of formats at the very beginning of `make()`, not in `drake_config()` (#1156). 
+* Assert dependencies of formats at the very beginning of `make()`, not in `drake_config()` (#1156).
+* In `make(verbose = 2)`, remove the spinner and use a progress bar to track how many targets are done so far.
+* Reduce logging of utility functions.
+* Improve the aesthetics of console messages using `cli` (optional package).
 
 # Version 7.10.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 * In `make(verbose = 2)`, remove the spinner and use a progress bar to track how many targets are done so far.
 * Reduce logging of utility functions.
 * Improve the aesthetics of console messages using `cli` (optional package).
+* Deprecate `console_log_file` in favor of `log_make` as an argument to `make()` and `drake_config()`.
 
 # Version 7.10.0
 

--- a/R/backend_clustermq.R
+++ b/R/backend_clustermq.R
@@ -12,7 +12,7 @@ drake_backend.clustermq <- function(config) {
     n_jobs = config$jobs,
     template = config$template
   )
-  config$logger$minor("set common data")
+  config$logger$log("set common data")
   cmq_set_common_data(config)
   config$counter <- new.env(parent = emptyenv())
   config$counter$remaining <- config$queue$size()
@@ -61,7 +61,7 @@ cmq_set_common_data <- function(config) {
 
 cmq_master <- function(config) {
   on.exit(config$workers$finalize())
-  config$logger$minor("begin scheduling targets")
+  config$logger$log("begin scheduling targets")
   while (config$counter$remaining > 0) {
     cmq_master_iter(config)
   }
@@ -74,7 +74,7 @@ cmq_master_iter <- function(config) {
   msg <- config$workers$receive_data()
   cmq_conclude_build(msg = msg, config = config)
   if (!identical(msg$token, "set_common_data_token")) {
-    config$logger$minor("sending common data")
+    config$logger$log("sending common data")
     config$workers$send_common_data()
   } else if (!config$queue$empty()) {
     cmq_next_target(config)
@@ -206,7 +206,7 @@ cmq_deps_list <- function(target, config) {
 #' @param ht_is_subtarget Internal, part of `config`
 #' @param config A [drake_config()] list.
 cmq_build <- function(target, meta, deps, spec, ht_is_subtarget, config) {
-  config$logger$minor("build on an hpc worker", target = target)
+  config$logger$log("build on an hpc worker", target = target)
   config$spec <- spec
   config$ht_is_subtarget <- ht_is_subtarget
   do_prework(config = config, verbose_packages = FALSE)
@@ -255,7 +255,7 @@ cmq_assign_deps <- function(deps, config) {
 }
 
 cmq_local_build <- function(target, config) {
-  config$logger$minor("build locally", target = target)
+  config$logger$log("build locally", target = target)
   local_build(target, config, downstream = NULL)
   cmq_conclude_target(target = target, config = config)
 }

--- a/R/backend_clustermq.R
+++ b/R/backend_clustermq.R
@@ -12,7 +12,7 @@ drake_backend.clustermq <- function(config) {
     n_jobs = config$jobs,
     template = config$template
   )
-  config$logger$log("set common data")
+  config$logger$disk("set common data")
   cmq_set_common_data(config)
   config$counter <- new.env(parent = emptyenv())
   config$counter$remaining <- config$queue$size()
@@ -61,7 +61,7 @@ cmq_set_common_data <- function(config) {
 
 cmq_master <- function(config) {
   on.exit(config$workers$finalize())
-  config$logger$log("begin scheduling targets")
+  config$logger$disk("begin scheduling targets")
   while (config$counter$remaining > 0) {
     cmq_master_iter(config)
   }
@@ -74,7 +74,7 @@ cmq_master_iter <- function(config) {
   msg <- config$workers$receive_data()
   cmq_conclude_build(msg = msg, config = config)
   if (!identical(msg$token, "set_common_data_token")) {
-    config$logger$log("sending common data")
+    config$logger$disk("sending common data")
     config$workers$send_common_data()
   } else if (!config$queue$empty()) {
     cmq_next_target(config)
@@ -206,7 +206,7 @@ cmq_deps_list <- function(target, config) {
 #' @param ht_is_subtarget Internal, part of `config`
 #' @param config A [drake_config()] list.
 cmq_build <- function(target, meta, deps, spec, ht_is_subtarget, config) {
-  config$logger$log("build on an hpc worker", target = target)
+  config$logger$disk("build on an hpc worker", target = target)
   config$spec <- spec
   config$ht_is_subtarget <- ht_is_subtarget
   do_prework(config = config, verbose_packages = FALSE)
@@ -255,7 +255,7 @@ cmq_assign_deps <- function(deps, config) {
 }
 
 cmq_local_build <- function(target, config) {
-  config$logger$log("build locally", target = target)
+  config$logger$disk("build locally", target = target)
   local_build(target, config, downstream = NULL)
   cmq_conclude_target(target = target, config = config)
 }

--- a/R/backend_future.R
+++ b/R/backend_future.R
@@ -54,7 +54,7 @@ ft_build_target <- function(target, id, running, protect, config) {
 }
 
 future_local_build <- function(target, protect, config) {
-  config$logger$log("local target", target = target)
+  config$logger$disk("local target", target = target)
   local_build(target, config, downstream = protect)
   decrease_revdep_keys(config$queue, target, config)
 }
@@ -165,7 +165,7 @@ future_build <- function(
   ht_is_subtarget,
   protect
 ) {
-  config$logger$log("build on an hpc worker", target = target)
+  config$logger$disk("build on an hpc worker", target = target)
   config$spec <- spec
   config$ht_is_subtarget <- ht_is_subtarget
   caching <- hpc_caching(target, config)

--- a/R/backend_future.R
+++ b/R/backend_future.R
@@ -29,11 +29,11 @@ ft_check_target <- function(target, id, config) {
   if (length(target)) {
     ft_do_target(target, id, config)
   } else {
-    ft_skip_target(config) # nocov
+    ft_no_target(config) # nocov
   }
 }
 
-ft_skip_target <- function(config) {
+ft_no_target <- function(config) {
   Sys.sleep(config$sleep(max(0L, config$sleeps$count)))
   config$sleeps$count <- config$sleeps$count + 1L
 }
@@ -57,6 +57,7 @@ future_local_build <- function(target, protect, config) {
   config$logger$disk("local target", target = target)
   local_build(target, config, downstream = protect)
   decrease_revdep_keys(config$queue, target, config)
+  config$logger$progress()
 }
 
 initialize_workers <- function(config) {
@@ -71,6 +72,7 @@ initialize_workers <- function(config) {
 ft_decide_worker <- function(target, protect, config) {
   meta <- drake_meta_(target, config)
   if (handle_triggers(target, meta, config)) {
+    config$logger$progress()
     return(empty_worker(target))
   }
   ft_launch_worker(target, meta, protect, config)
@@ -234,6 +236,7 @@ conclude_worker <- function(worker, config) {
     config = config
   )
   conclude_build(build = build, config = config)
+  config$logger$progress()
   out
 }
 

--- a/R/backend_future.R
+++ b/R/backend_future.R
@@ -54,7 +54,7 @@ ft_build_target <- function(target, id, running, protect, config) {
 }
 
 future_local_build <- function(target, protect, config) {
-  config$logger$minor("local target", target = target)
+  config$logger$log("local target", target = target)
   local_build(target, config, downstream = protect)
   decrease_revdep_keys(config$queue, target, config)
 }
@@ -165,7 +165,7 @@ future_build <- function(
   ht_is_subtarget,
   protect
 ) {
-  config$logger$minor("build on an hpc worker", target = target)
+  config$logger$log("build on an hpc worker", target = target)
   config$spec <- spec
   config$ht_is_subtarget <- ht_is_subtarget
   caching <- hpc_caching(target, config)

--- a/R/backend_loop.R
+++ b/R/backend_loop.R
@@ -10,4 +10,5 @@ loop_check <- function(config) {
   targets <- config$envir_loop$targets
   local_build(target = targets[1], config = config, downstream = targets[-1])
   config$envir_loop$targets <- config$envir_loop$targets[-1]
+  config$logger$progress()
 }

--- a/R/clean.R
+++ b/R/clean.R
@@ -242,12 +242,7 @@ clean_recovery_msg <- function() {
   }
   # invoked manually in test-always-skipped.R
   # nocov start
-  message(
-    "Undo clean(garbage_collection = FALSE) with ",
-    "make(your_plan, recover = TRUE). ",
-    "Also builds unrecoverable targets. Message shown once per session ",
-    "if options(drake_clean_recovery_msg) is not FALSE."
-  )
+  cli_msg("Undo clean() with recover = TRUE in make().")
   .pkg_envir[["drake_clean_recovery_msg"]] <- FALSE
   invisible()
   # nocov end

--- a/R/create_drake_graph.R
+++ b/R/create_drake_graph.R
@@ -22,7 +22,7 @@ create_drake_graph <- function(
 }
 
 cdg_create_edges <- function(args, spec) {
-  args$logger$minor("create graph edges")
+  args$logger$log("create graph edges")
   edges <- lightly_parallelize(
     X = spec,
     FUN = cdg_node_to_edges,
@@ -69,7 +69,7 @@ cdg_node_to_edges <- function(node, args) {
 }
 
 cdg_edges_thru_file_out <- function(edges, args) {
-  args$logger$minor("connect output files")
+  args$logger$log("connect output files")
   file_out <- edges$to[is_encoded_path(edges$to)]
   file_out_edges <- lapply(
     X = file_out,
@@ -83,26 +83,26 @@ cdg_edges_thru_file_out <- function(edges, args) {
 }
 
 cdg_transitive_edges <- function(vertex, edges, args) {
-  args$logger$minor("file_out", target = args$cache$display_keys(vertex))
+  args$logger$log("file_out", target = args$cache$display_keys(vertex))
   from <- unique(edges$from[edges$to == vertex])
   to <- unique(edges$to[edges$from == vertex])
   expand.grid(from = from, to = to, stringsAsFactors = FALSE)
 }
 
 cdg_finalize_graph <- function(edges, targets, args) {
-  args$logger$minor("finalize graph edges")
+  args$logger$log("finalize graph edges")
   file_out <- edges$to[edges$from %in% targets & is_encoded_path(edges$to)]
   to <- union(targets, file_out)
-  args$logger$minor("create igraph")
+  args$logger$log("create igraph")
   graph <- igraph::graph_from_data_frame(edges)
-  args$logger$minor("trim neighborhoods")
+  args$logger$log("trim neighborhoods")
   graph <- nbhd_graph(
     graph = graph,
     vertices = to,
     mode = "in",
     order = igraph::gorder(graph)
   )
-  args$logger$minor("add igraph attributes")
+  args$logger$log("add igraph attributes")
   graph <- igraph::set_vertex_attr(graph, "imported", value = TRUE)
   index <- c(args$plan$target, file_out)
   index <- intersect(index, igraph::V(graph)$name)
@@ -112,7 +112,7 @@ cdg_finalize_graph <- function(edges, targets, args) {
     index = index,
     value = FALSE
   )
-  args$logger$minor("finalize igraph")
+  args$logger$log("finalize igraph")
   igraph::simplify(
     graph,
     remove.loops = TRUE,

--- a/R/create_drake_graph.R
+++ b/R/create_drake_graph.R
@@ -22,7 +22,7 @@ create_drake_graph <- function(
 }
 
 cdg_create_edges <- function(args, spec) {
-  args$logger$log("create graph edges")
+  args$logger$disk("create graph edges")
   edges <- lightly_parallelize(
     X = spec,
     FUN = cdg_node_to_edges,
@@ -69,7 +69,7 @@ cdg_node_to_edges <- function(node, args) {
 }
 
 cdg_edges_thru_file_out <- function(edges, args) {
-  args$logger$log("connect output files")
+  args$logger$disk("connect output files")
   file_out <- edges$to[is_encoded_path(edges$to)]
   file_out_edges <- lapply(
     X = file_out,
@@ -83,26 +83,26 @@ cdg_edges_thru_file_out <- function(edges, args) {
 }
 
 cdg_transitive_edges <- function(vertex, edges, args) {
-  args$logger$log("file_out", target = args$cache$display_keys(vertex))
+  args$logger$disk("file_out", target = args$cache$display_keys(vertex))
   from <- unique(edges$from[edges$to == vertex])
   to <- unique(edges$to[edges$from == vertex])
   expand.grid(from = from, to = to, stringsAsFactors = FALSE)
 }
 
 cdg_finalize_graph <- function(edges, targets, args) {
-  args$logger$log("finalize graph edges")
+  args$logger$disk("finalize graph edges")
   file_out <- edges$to[edges$from %in% targets & is_encoded_path(edges$to)]
   to <- union(targets, file_out)
-  args$logger$log("create igraph")
+  args$logger$disk("create igraph")
   graph <- igraph::graph_from_data_frame(edges)
-  args$logger$log("trim neighborhoods")
+  args$logger$disk("trim neighborhoods")
   graph <- nbhd_graph(
     graph = graph,
     vertices = to,
     mode = "in",
     order = igraph::gorder(graph)
   )
-  args$logger$log("add igraph attributes")
+  args$logger$disk("add igraph attributes")
   graph <- igraph::set_vertex_attr(graph, "imported", value = TRUE)
   index <- c(args$plan$target, file_out)
   index <- intersect(index, igraph::V(graph)$name)
@@ -112,7 +112,7 @@ cdg_finalize_graph <- function(edges, targets, args) {
     index = index,
     value = FALSE
   )
-  args$logger$log("finalize igraph")
+  args$logger$disk("finalize igraph")
   igraph::simplify(
     graph,
     remove.loops = TRUE,

--- a/R/create_drake_spec.R
+++ b/R/create_drake_spec.R
@@ -43,7 +43,7 @@ create_drake_spec <- function(
 
 # https://github.com/ropensci/drake/issues/887 # nolint
 cds_set_knitr_files <- function(args, spec) {
-  args$logger$minor("set knitr files")
+  args$logger$log("set knitr files")
   knitr_files <- lightly_parallelize(
     X = spec,
     FUN = function(x) {
@@ -60,7 +60,7 @@ cds_set_knitr_files <- function(args, spec) {
 }
 
 cds_get_knitr_hash <- function(args, spec) {
-  args$logger$minor("get knitr hash")
+  args$logger$log("get knitr hash")
   if (!args$cache$exists(key = "knitr", namespace = "memoize")) {
     out <- args$cache$digest("", serialize = FALSE)
     return(out)
@@ -88,7 +88,7 @@ cds_imports_kernel <- function(args, imports) {
 }
 
 cds_prepare_imports <- function(args) {
-  args$logger$minor("analyze environment")
+  args$logger$log("analyze environment")
   imports <- as.list(args$envir)
   cds_unload_conflicts(
     imports = names(imports),
@@ -114,7 +114,7 @@ cds_unload_conflicts <- function(imports, targets, envir, logger) {
 }
 
 cds_analyze_imports <- function(args, imports) {
-  args$logger$minor("analyze imports")
+  args$logger$log("analyze imports")
   names <-  names(imports)
   out <- lightly_parallelize(
     X = seq_along(imports),
@@ -143,7 +143,7 @@ cdl_analyze_import <- function(index, imports, names, args) {
 }
 
 cds_analyze_commands <- function(args) {
-  args$logger$minor("analyze commands")
+  args$logger$log("analyze commands")
   args$plan$imported <- FALSE
   if ("trigger" %in% colnames(args$plan)) {
     args$plan$trigger <- lapply(

--- a/R/create_drake_spec.R
+++ b/R/create_drake_spec.R
@@ -103,7 +103,7 @@ cds_prepare_imports <- function(args) {
 cds_unload_conflicts <- function(imports, targets, envir, logger) {
   common <- intersect(imports, targets)
   if (length(common)) {
-    logger$major(
+    message(
       "unload",
       "targets from environment:\n",
       multiline_message(common),

--- a/R/create_drake_spec.R
+++ b/R/create_drake_spec.R
@@ -43,7 +43,7 @@ create_drake_spec <- function(
 
 # https://github.com/ropensci/drake/issues/887 # nolint
 cds_set_knitr_files <- function(args, spec) {
-  args$logger$log("set knitr files")
+  args$logger$disk("set knitr files")
   knitr_files <- lightly_parallelize(
     X = spec,
     FUN = function(x) {
@@ -60,7 +60,7 @@ cds_set_knitr_files <- function(args, spec) {
 }
 
 cds_get_knitr_hash <- function(args, spec) {
-  args$logger$log("get knitr hash")
+  args$logger$disk("get knitr hash")
   if (!args$cache$exists(key = "knitr", namespace = "memoize")) {
     out <- args$cache$digest("", serialize = FALSE)
     return(out)
@@ -88,7 +88,7 @@ cds_imports_kernel <- function(args, imports) {
 }
 
 cds_prepare_imports <- function(args) {
-  args$logger$log("analyze environment")
+  args$logger$disk("analyze environment")
   imports <- as.list(args$envir)
   cds_unload_conflicts(
     imports = names(imports),
@@ -103,18 +103,13 @@ cds_prepare_imports <- function(args) {
 cds_unload_conflicts <- function(imports, targets, envir, logger) {
   common <- intersect(imports, targets)
   if (length(common)) {
-    message(
-      "unload",
-      "targets from environment:\n",
-      multiline_message(common),
-      sep = ""
-    )
+    logger$term("unload", length(common), "targets from environment")
   }
   remove(list = common, envir = envir)
 }
 
 cds_analyze_imports <- function(args, imports) {
-  args$logger$log("analyze imports")
+  args$logger$disk("analyze imports")
   names <-  names(imports)
   out <- lightly_parallelize(
     X = seq_along(imports),
@@ -143,7 +138,7 @@ cdl_analyze_import <- function(index, imports, names, args) {
 }
 
 cds_analyze_commands <- function(args) {
-  args$logger$log("analyze commands")
+  args$logger$disk("analyze commands")
   args$plan$imported <- FALSE
   if ("trigger" %in% colnames(args$plan)) {
     args$plan$trigger <- lapply(

--- a/R/deps.R
+++ b/R/deps.R
@@ -86,11 +86,6 @@ deps_target_impl <- function(
   config,
   character_only = FALSE
 ) {
-  config$logger$log("begin deps_target()", target = target)
-  on.exit(
-    config$logger$log("end deps_target()", target = target),
-    add = TRUE
-  )
   if (!character_only) {
     target <- as.character(substitute(target))
   }

--- a/R/deps.R
+++ b/R/deps.R
@@ -86,9 +86,9 @@ deps_target_impl <- function(
   config,
   character_only = FALSE
 ) {
-  config$logger$minor("begin deps_target()", target = target)
+  config$logger$log("begin deps_target()", target = target)
   on.exit(
-    config$logger$minor("end deps_target()", target = target),
+    config$logger$log("end deps_target()", target = target),
     add = TRUE
   )
   if (!character_only) {

--- a/R/drake_build.R
+++ b/R/drake_build.R
@@ -50,11 +50,6 @@ drake_build_impl <- function(
   character_only = FALSE,
   replace = FALSE
 ) {
-  config$logger$log("begin drake_build()", target = target)
-  on.exit(
-    config$logger$log("end drake_build()", target = target),
-    add = TRUE
-  )
   deprecate_arg(meta)
   if (!character_only) {
     target <- as.character(substitute(target))

--- a/R/drake_build.R
+++ b/R/drake_build.R
@@ -50,9 +50,9 @@ drake_build_impl <- function(
   character_only = FALSE,
   replace = FALSE
 ) {
-  config$logger$minor("begin drake_build()", target = target)
+  config$logger$log("begin drake_build()", target = target)
   on.exit(
-    config$logger$minor("end drake_build()", target = target),
+    config$logger$log("end drake_build()", target = target),
     add = TRUE
   )
   deprecate_arg(meta)

--- a/R/drake_config.R
+++ b/R/drake_config.R
@@ -558,7 +558,7 @@ drake_config <- function(
   lock_cache = TRUE
 ) {
   logger <- logger(verbose = verbose, file = console_log_file)
-  logger$log("begin drake_config()")
+  logger$disk("begin drake_config()")
   deprecate_fetch_cache(fetch_cache)
   deprecate_arg(hook, "hook") # 2018-10-25 # nolint
   # 2018-11-01 # nolint
@@ -604,7 +604,7 @@ drake_config <- function(
   }
   cache <- decorate_storr(cache)
   cache$set_history(history)
-  logger$log("cache", cache$path)
+  logger$disk("cache", cache$path)
   seed <- choose_seed(supplied = seed, cache = cache)
   if (identical(force, TRUE)) {
     drake_set_session_info(cache = cache, full = session_info)
@@ -691,7 +691,7 @@ drake_config <- function(
   )
   class(out) <- c("drake_config", "drake")
   config_checks(out)
-  logger$log("end drake_config()")
+  logger$disk("end drake_config()")
   out
 }
 

--- a/R/drake_config.R
+++ b/R/drake_config.R
@@ -558,7 +558,7 @@ drake_config <- function(
   lock_cache = TRUE
 ) {
   logger <- logger(verbose = verbose, file = console_log_file)
-  logger$minor("begin drake_config()")
+  logger$log("begin drake_config()")
   deprecate_fetch_cache(fetch_cache)
   deprecate_arg(hook, "hook") # 2018-10-25 # nolint
   # 2018-11-01 # nolint
@@ -604,7 +604,7 @@ drake_config <- function(
   }
   cache <- decorate_storr(cache)
   cache$set_history(history)
-  logger$minor("cache", cache$path)
+  logger$log("cache", cache$path)
   seed <- choose_seed(supplied = seed, cache = cache)
   if (identical(force, TRUE)) {
     drake_set_session_info(cache = cache, full = session_info)
@@ -691,7 +691,7 @@ drake_config <- function(
   )
   class(out) <- c("drake_config", "drake")
   config_checks(out)
-  logger$minor("end drake_config()")
+  logger$log("end drake_config()")
   out
 }
 

--- a/R/drake_config.R
+++ b/R/drake_config.R
@@ -46,8 +46,9 @@
 #'
 #' @param verbose Integer, control printing to the console/terminal.
 #'   - `0`: print nothing.
-#'   - `1`: print targets, retries, and failures.
-#'   - `2`: also show a spinner when preprocessing tasks are underway.
+#'   - `1`: print target-by-target messages as [make()] progresses.
+#'   - `2`: show a progress bar to track how many targets are
+#'     done so far.
 #'
 #' @param hook Deprecated.
 #'

--- a/R/drake_config.R
+++ b/R/drake_config.R
@@ -306,7 +306,9 @@
 #'
 #' @param makefile_path Deprecated.
 #'
-#' @param console_log_file Optional character scalar of a file name or
+#' @param console_log_file Deprecated in favor of `log_make`.
+#'
+#' @param log_make Optional character scalar of a file name or
 #'   connection object (such as `stdout()`) to dump maximally verbose
 #'   log information for [make()] and other functions (all functions that
 #'   accept a `config` argument, plus `drake_config()`).
@@ -556,9 +558,10 @@ drake_config <- function(
   max_expand = NULL,
   log_build_times = TRUE,
   format = NULL,
-  lock_cache = TRUE
+  lock_cache = TRUE,
+  log_make = NULL
 ) {
-  logger <- logger(verbose = verbose, file = console_log_file)
+  logger <- logger(verbose = verbose, file = log_make)
   logger$disk("begin drake_config()")
   deprecate_fetch_cache(fetch_cache)
   deprecate_arg(hook, "hook") # 2018-10-25 # nolint
@@ -576,6 +579,7 @@ drake_config <- function(
   deprecate_arg(prepend, "prepend")
   deprecate_arg(makefile_path, "makefile_path")
   deprecate_arg(layout, "layout", "spec") # 2019-12-15
+  deprecate_arg(console_log_file, "console_log_file", "log_make") # 2020-02-08
   session_info <- resolve_session_info(session_info)
   memory_strategy <- match.arg(memory_strategy, choices = memory_strategies())
   if (memory_strategy == "memory") {

--- a/R/drake_ggraph.R
+++ b/R/drake_ggraph.R
@@ -85,8 +85,6 @@ drake_ggraph_impl <- function(
     clusters = clusters,
     show_output_files = show_output_files
   )
-  config$logger$log("begin drake_ggraph()")
-  on.exit(config$logger$log("end drake_ggraph()"), add = TRUE)
   if (is.null(main)) {
     main <- graph_info$default_title
   }

--- a/R/drake_ggraph.R
+++ b/R/drake_ggraph.R
@@ -85,8 +85,8 @@ drake_ggraph_impl <- function(
     clusters = clusters,
     show_output_files = show_output_files
   )
-  config$logger$minor("begin drake_ggraph()")
-  on.exit(config$logger$minor("end drake_ggraph()"), add = TRUE)
+  config$logger$log("begin drake_ggraph()")
+  on.exit(config$logger$log("end drake_ggraph()"), add = TRUE)
   if (is.null(main)) {
     main <- graph_info$default_title
   }

--- a/R/drake_graph_info.R
+++ b/R/drake_graph_info.R
@@ -743,6 +743,14 @@ style_hover_text <- function(x) {
   paste0(x, collapse = "<br>")
 }
 
+crop_text <- Vectorize(function(x, width = getOption("width")) {
+  if (nchar(x) > width) {
+    x <- paste0(substr(x, 1, width - 3), "...")
+  }
+  x
+},
+"x", USE.NAMES = FALSE)
+
 hover_lines <- 10
 hover_width <- 49
 

--- a/R/drake_graph_info.R
+++ b/R/drake_graph_info.R
@@ -596,6 +596,16 @@ node_color <- Vectorize(function(x) {
 },
 "x", USE.NAMES = FALSE)
 
+col2hex <- function(cname) {
+  assert_pkg("grDevices")
+  col_mat <- grDevices::col2rgb(cname)
+  grDevices::rgb(
+    red = col_mat[1, ] / 255,
+    green = col_mat[2, ] / 255,
+    blue = col_mat[3, ] / 255
+  )
+}
+
 node_shape <- Vectorize(function(x) {
   switch(
     x,

--- a/R/drake_graph_info.R
+++ b/R/drake_graph_info.R
@@ -166,8 +166,8 @@ drake_graph_info_impl <- function(
 ) {
   assert_pkg("visNetwork")
   assert_config(config)
-  config$logger$minor("begin drake_graph_info()")
-  on.exit(config$logger$minor("end drake_graph_info()"), add = TRUE)
+  config$logger$log("begin drake_graph_info()")
+  on.exit(config$logger$log("end drake_graph_info()"), add = TRUE)
   if (!length(V(config$graph)$name)) {
     return(null_graph())
   }

--- a/R/drake_graph_info.R
+++ b/R/drake_graph_info.R
@@ -166,8 +166,6 @@ drake_graph_info_impl <- function(
 ) {
   assert_pkg("visNetwork")
   assert_config(config)
-  config$logger$log("begin drake_graph_info()")
-  on.exit(config$logger$log("end drake_graph_info()"), add = TRUE)
   if (!length(V(config$graph)$name)) {
     return(null_graph())
   }

--- a/R/dynamic.R
+++ b/R/dynamic.R
@@ -224,7 +224,7 @@ register_subtargets <- function(target, static_ok, dynamic_ok, config) {
   }
   ndeps <- length(subtargets_build)
   if (ndeps) {
-    config$logger$log("register", ndeps, "subtargets", target = target)
+    config$logger$disk("register", ndeps, "subtargets", target = target)
     ht_set(config$ht_is_subtarget, subtargets_build)
     register_in_loop(subtargets_build, config)
     register_in_queue(subtargets_build, 0, config)

--- a/R/dynamic.R
+++ b/R/dynamic.R
@@ -225,6 +225,7 @@ register_subtargets <- function(target, static_ok, dynamic_ok, config) {
   ndeps <- length(subtargets_build)
   if (ndeps) {
     config$logger$disk("register", ndeps, "subtargets", target = target)
+    config$logger$inc_progress_total(ndeps)
     ht_set(config$ht_is_subtarget, subtargets_build)
     register_in_loop(subtargets_build, config)
     register_in_queue(subtargets_build, 0, config)

--- a/R/dynamic.R
+++ b/R/dynamic.R
@@ -224,7 +224,7 @@ register_subtargets <- function(target, static_ok, dynamic_ok, config) {
   }
   ndeps <- length(subtargets_build)
   if (ndeps) {
-    config$logger$minor("register", ndeps, "subtargets", target = target)
+    config$logger$log("register", ndeps, "subtargets", target = target)
     ht_set(config$ht_is_subtarget, subtargets_build)
     register_in_loop(subtargets_build, config)
     register_in_queue(subtargets_build, 0, config)

--- a/R/handle_triggers.R
+++ b/R/handle_triggers.R
@@ -36,14 +36,9 @@ recover_target <- function(target, meta, config) {
     return(FALSE) # nocov # Should not happen, just to be safe...
   }
   if (!is_dynamic(target, config)) {
-    config$logger$major(
-      "recover",
-      target,
-      target = target,
-      color = "recover"
-    )
+    config$logger$target(target, "recover")
   }
-  config$logger$log(
+  config$logger$disk(
     "recovered target originally stored on",
     recovery_meta$date,
     target = target
@@ -169,7 +164,7 @@ check_trigger_imported <- function(target, meta, config) {
 
 check_trigger_missing <- function(target, meta, config) {
   if (meta$missing) {
-    config$logger$log("trigger missing", target = target)
+    config$logger$disk("trigger missing", target = target)
     return(TRUE)
   }
   FALSE
@@ -179,7 +174,7 @@ check_trigger_condition <- function(target, meta, config) {
   condition <- trigger_condition(target = target, meta = meta, config = config)
   stopifnot(is.logical(condition))
   if (condition) {
-    config$logger$log("trigger condition", target = target)
+    config$logger$disk("trigger condition", target = target)
   }
   return(condition)
 }
@@ -187,7 +182,7 @@ check_trigger_condition <- function(target, meta, config) {
 check_trigger_command <- function(target, meta, meta_old, config) {
   if (identical(meta$trigger$command, TRUE)) {
     if (trigger_command(target, meta, meta_old, config)) {
-      config$logger$log("trigger command", target = target)
+      config$logger$disk("trigger command", target = target)
       return(TRUE)
     }
   }
@@ -197,7 +192,7 @@ check_trigger_command <- function(target, meta, meta_old, config) {
 check_trigger_depend <- function(target, meta, meta_old, config) {
   if (identical(meta$trigger$depend, TRUE)) {
     if (trigger_depend(target, meta, meta_old, config)) {
-      config$logger$log("trigger depend", target = target)
+      config$logger$disk("trigger depend", target = target)
       return(TRUE)
     }
   }
@@ -207,7 +202,7 @@ check_trigger_depend <- function(target, meta, meta_old, config) {
 check_trigger_file <- function(target, meta, meta_old, config) {
   if (identical(meta$trigger$file, TRUE)) {
     if (trigger_file(target, meta, meta_old, config)) {
-      config$logger$log("trigger file", target = target)
+      config$logger$disk("trigger file", target = target)
       return(TRUE)
     }
   }
@@ -217,7 +212,7 @@ check_trigger_file <- function(target, meta, meta_old, config) {
 check_trigger_seed <- function(target, meta, meta_old, config) {
   if (identical(meta$trigger$seed, TRUE)) {
     if (trigger_seed(target, meta, meta_old, config)) {
-      config$logger$log("trigger seed", target = target)
+      config$logger$disk("trigger seed", target = target)
       return(TRUE)
     }
   }
@@ -227,18 +222,18 @@ check_trigger_seed <- function(target, meta, meta_old, config) {
 check_trigger_change <- function(target, meta, config) {
   if (!is.null(meta$trigger$change)) {
     if (trigger_change(target = target, meta = meta, config = config)) {
-      config$logger$log("trigger change", target = target)
+      config$logger$disk("trigger change", target = target)
       return(TRUE)
     }
   }
-  config$logger$log("skip", target = target)
+  config$logger$disk("skip", target = target)
   FALSE
 }
 
 check_trigger_format <- function(target, meta, meta_old, config) {
   if (identical(meta$trigger$format, TRUE)) {
     if (trigger_format(target, meta, meta_old, config)) {
-      config$logger$log("trigger format", target = target)
+      config$logger$disk("trigger format", target = target)
       return(TRUE)
     }
   }
@@ -331,7 +326,7 @@ trigger_condition <- function(target, meta, config) {
       "The `condition` trigger must evaluate to a logical of length 1. ",
       "got `", value, "` for target ", target, "."
     )
-    config$logger$log(paste("Error:", msg))
+    config$logger$disk(paste("Error:", msg))
     stop(msg, call. = FALSE)
   }
   condition_decision(value = value, mode = meta$trigger$mode)

--- a/R/handle_triggers.R
+++ b/R/handle_triggers.R
@@ -43,7 +43,7 @@ recover_target <- function(target, meta, config) {
       color = "recover"
     )
   }
-  config$logger$minor(
+  config$logger$log(
     "recovered target originally stored on",
     recovery_meta$date,
     target = target
@@ -169,7 +169,7 @@ check_trigger_imported <- function(target, meta, config) {
 
 check_trigger_missing <- function(target, meta, config) {
   if (meta$missing) {
-    config$logger$minor("trigger missing", target = target)
+    config$logger$log("trigger missing", target = target)
     return(TRUE)
   }
   FALSE
@@ -179,7 +179,7 @@ check_trigger_condition <- function(target, meta, config) {
   condition <- trigger_condition(target = target, meta = meta, config = config)
   stopifnot(is.logical(condition))
   if (condition) {
-    config$logger$minor("trigger condition", target = target)
+    config$logger$log("trigger condition", target = target)
   }
   return(condition)
 }
@@ -187,7 +187,7 @@ check_trigger_condition <- function(target, meta, config) {
 check_trigger_command <- function(target, meta, meta_old, config) {
   if (identical(meta$trigger$command, TRUE)) {
     if (trigger_command(target, meta, meta_old, config)) {
-      config$logger$minor("trigger command", target = target)
+      config$logger$log("trigger command", target = target)
       return(TRUE)
     }
   }
@@ -197,7 +197,7 @@ check_trigger_command <- function(target, meta, meta_old, config) {
 check_trigger_depend <- function(target, meta, meta_old, config) {
   if (identical(meta$trigger$depend, TRUE)) {
     if (trigger_depend(target, meta, meta_old, config)) {
-      config$logger$minor("trigger depend", target = target)
+      config$logger$log("trigger depend", target = target)
       return(TRUE)
     }
   }
@@ -207,7 +207,7 @@ check_trigger_depend <- function(target, meta, meta_old, config) {
 check_trigger_file <- function(target, meta, meta_old, config) {
   if (identical(meta$trigger$file, TRUE)) {
     if (trigger_file(target, meta, meta_old, config)) {
-      config$logger$minor("trigger file", target = target)
+      config$logger$log("trigger file", target = target)
       return(TRUE)
     }
   }
@@ -217,7 +217,7 @@ check_trigger_file <- function(target, meta, meta_old, config) {
 check_trigger_seed <- function(target, meta, meta_old, config) {
   if (identical(meta$trigger$seed, TRUE)) {
     if (trigger_seed(target, meta, meta_old, config)) {
-      config$logger$minor("trigger seed", target = target)
+      config$logger$log("trigger seed", target = target)
       return(TRUE)
     }
   }
@@ -227,18 +227,18 @@ check_trigger_seed <- function(target, meta, meta_old, config) {
 check_trigger_change <- function(target, meta, config) {
   if (!is.null(meta$trigger$change)) {
     if (trigger_change(target = target, meta = meta, config = config)) {
-      config$logger$minor("trigger change", target = target)
+      config$logger$log("trigger change", target = target)
       return(TRUE)
     }
   }
-  config$logger$minor("skip", target = target)
+  config$logger$log("skip", target = target)
   FALSE
 }
 
 check_trigger_format <- function(target, meta, meta_old, config) {
   if (identical(meta$trigger$format, TRUE)) {
     if (trigger_format(target, meta, meta_old, config)) {
-      config$logger$minor("trigger format", target = target)
+      config$logger$log("trigger format", target = target)
       return(TRUE)
     }
   }
@@ -331,7 +331,7 @@ trigger_condition <- function(target, meta, config) {
       "The `condition` trigger must evaluate to a logical of length 1. ",
       "got `", value, "` for target ", target, "."
     )
-    config$logger$minor(paste("Error:", msg))
+    config$logger$log(paste("Error:", msg))
     stop(msg, call. = FALSE)
   }
   condition_decision(value = value, mode = meta$trigger$mode)

--- a/R/hpc.R
+++ b/R/hpc.R
@@ -170,7 +170,7 @@ wait_checksum <- function(
     "network file system. Checksum verification timed out after about ",
     timeout, " seconds."
   )
-  config$logger$log(paste("Error:", msg))
+  config$logger$disk(paste("Error:", msg))
   stop(msg, call. = FALSE)
 }
 
@@ -242,7 +242,7 @@ get_outfile_checksum <- function(target, config) {
 
 warn_no_checksum <- function(target, config) {
   msg <- paste0("No checksum available for target ", target, ".")
-  config$logger$log(paste("Warning:", msg))
+  config$logger$disk(paste("Warning:", msg))
   warning(msg, call. = FALSE)
 }
 

--- a/R/hpc.R
+++ b/R/hpc.R
@@ -170,7 +170,7 @@ wait_checksum <- function(
     "network file system. Checksum verification timed out after about ",
     timeout, " seconds."
   )
-  config$logger$minor(paste("Error:", msg))
+  config$logger$log(paste("Error:", msg))
   stop(msg, call. = FALSE)
 }
 
@@ -242,7 +242,7 @@ get_outfile_checksum <- function(target, config) {
 
 warn_no_checksum <- function(target, config) {
   msg <- paste0("No checksum available for target ", target, ".")
-  config$logger$minor(paste("Warning:", msg))
+  config$logger$log(paste("Warning:", msg))
   warning(msg, call. = FALSE)
 }
 

--- a/R/local_build.R
+++ b/R/local_build.R
@@ -493,8 +493,8 @@ handle_build_exceptions <- function(target, meta, config) {
     )
   }
   if (length(meta$messages) && config$logger$verbose) {
-    message(
-      "Target ", target, " messages:\n",
+    cli_msg(
+      "target ", target, " messages:\n",
       multiline_message(meta$messages)
     )
   }

--- a/R/local_build.R
+++ b/R/local_build.R
@@ -192,13 +192,13 @@ with_handling <- function(target, meta, config) {
   withCallingHandlers(
     value <- drake_with_call_stack_8a6af5(target = target, config = config),
     warning = function(w) {
-      config$logger$minor(paste("Warning:", w$message), target = target)
+      config$logger$log(paste("Warning:", w$message), target = target)
       warnings <<- c(warnings, w$message)
       invokeRestart("muffleWarning")
     },
     message = function(m) {
       msg <- gsub(pattern = "\n$", replacement = "", x = m$message)
-      config$logger$minor(msg, target = target)
+      config$logger$log(msg, target = target)
       messages <<- c(messages, msg)
       invokeRestart("muffleMessage")
     }
@@ -354,7 +354,7 @@ assign_format <- function(target, value, config) {
   if (drop_format) {
     return(value)
   }
-  config$logger$minor("format", format, target = target)
+  config$logger$log("format", format, target = target)
   out <- list(value = value)
   class(out) <- c(paste0("drake_format_", format), "drake_format")
   sanitize_format(x = out, target = target, config = config)
@@ -377,7 +377,7 @@ sanitize_format.drake_format_fst <- function(x, target, config) { # nolint
       " to a plain data frame."
     )
     warning(msg, call. = FALSE)
-    config$logger$minor(msg, target = target)
+    config$logger$log(msg, target = target)
   }
   x$value <- as.data.frame(x$value)
   x
@@ -393,7 +393,7 @@ sanitize_format.drake_format_fst_tbl <- function(x, target, config) { # nolint
       " to a tibble."
     )
     warning(msg, call. = FALSE)
-    config$logger$minor(msg, target = target)
+    config$logger$log(msg, target = target)
   }
   x$value <- tibble::as_tibble(x$value)
   x
@@ -409,7 +409,7 @@ sanitize_format.drake_format_fst_dt <- function(x, target, config) { # nolint
       " to a data.table object."
     )
     warning(msg, call. = FALSE)
-    config$logger$minor(msg, target = target)
+    config$logger$log(msg, target = target)
   }
   x$value <- data.table::as.data.table(x$value)
   x
@@ -428,7 +428,7 @@ sanitize_format.drake_format_diskframe <- function(x, target, config) { # nolint
       "(say, with as.disk.frame(outdir = drake_tempfile()))."
     )
     warning(msg, call. = FALSE)
-    config$logger$minor(msg, target = target)
+    config$logger$log(msg, target = target)
     x$value <- disk.frame::as.disk.frame(
       df = x$value,
       outdir = config$cache$file_tmp()
@@ -493,7 +493,7 @@ assert_output_files <- function(target, meta, config) {
       target, ":\n",
       multiline_message(missing_files)
     )
-    config$logger$minor(paste("Warning:", msg))
+    config$logger$log(paste("Warning:", msg))
     warning(msg, call. = FALSE)
   }
 }
@@ -535,7 +535,7 @@ handle_build_exceptions <- function(target, meta, config) {
         ")` for details. Error message:\n  ",
         meta$error$message
       )
-      config$logger$minor(msg)
+      config$logger$log(msg)
       unlock_environment(config$envir)
       stop(msg, call. = FALSE)
     }

--- a/R/local_build.R
+++ b/R/local_build.R
@@ -494,8 +494,8 @@ handle_build_exceptions <- function(target, meta, config) {
   }
   if (length(meta$messages) && config$logger$verbose) {
     cli_msg(
-      "target ", target, " messages:\n",
-      multiline_message(meta$messages)
+      "target", target, "messages:\n",
+      multiline_message(meta$messages, indent = " ")
     )
   }
   if (inherits(meta$error, "error")) {

--- a/R/local_build.R
+++ b/R/local_build.R
@@ -28,13 +28,8 @@ announce_static <- function(target, config) {
     value = "running",
     config = config
   )
-  color <- ifelse(is_subtarget(target, config), "subtarget", "target")
-  config$logger$major(
-    color,
-    target,
-    target = target,
-    color = color
-  )
+  action <- ifelse(is_subtarget(target, config), "subtarget", "target")
+  config$logger$target(target, action)
 }
 
 announce_dynamic <- function(target, config) {
@@ -43,17 +38,12 @@ announce_dynamic <- function(target, config) {
     value = "running",
     config = config
   )
-  msg <- ifelse(
+  action <- ifelse(
     is_registered_dynamic(target, config),
     "aggregate",
     "dynamic"
   )
-  config$logger$major(
-    msg,
-    target,
-    target = target,
-    color = "dynamic"
-  )
+  config$logger$target(target, action)
 }
 
 try_build <- function(target, meta, config) {
@@ -72,15 +62,7 @@ try_build <- function(target, meta, config) {
   max_retries <- as.integer(max_retries)
   while (retries <= max_retries) {
     if (retries > 0L) {
-      config$logger$major(
-        "retry",
-        target,
-        retries,
-        "of",
-        max_retries,
-        target = target,
-        color = "retry"
-      )
+      config$logger$target(target, "retry")
     }
     build <- with_seed_timeout(
       target = target,
@@ -192,13 +174,13 @@ with_handling <- function(target, meta, config) {
   withCallingHandlers(
     value <- drake_with_call_stack_8a6af5(target = target, config = config),
     warning = function(w) {
-      config$logger$log(paste("Warning:", w$message), target = target)
+      config$logger$disk(paste("Warning:", w$message), target = target)
       warnings <<- c(warnings, w$message)
       invokeRestart("muffleWarning")
     },
     message = function(m) {
       msg <- gsub(pattern = "\n$", replacement = "", x = m$message)
-      config$logger$log(msg, target = target)
+      config$logger$disk(msg, target = target)
       messages <<- c(messages, msg)
       invokeRestart("muffleMessage")
     }
@@ -334,7 +316,7 @@ conclude_build_impl <- function(value, target, meta, config) {
 
 conclude_build_impl.drake_cancel <- function(value, target, meta, config) { # nolint
   config$cache$set_progress(target = target, value = "cancelled")
-  config$logger$major("cancel", target, target = target, color = "cancel")
+  config$logger$target(target, "cancel")
 }
 
 conclude_build_impl.default <- function(value, target, meta, config) {
@@ -354,7 +336,7 @@ assign_format <- function(target, value, config) {
   if (drop_format) {
     return(value)
   }
-  config$logger$log("format", format, target = target)
+  config$logger$disk("format", format, target = target)
   out <- list(value = value)
   class(out) <- c(paste0("drake_format_", format), "drake_format")
   sanitize_format(x = out, target = target, config = config)
@@ -377,7 +359,7 @@ sanitize_format.drake_format_fst <- function(x, target, config) { # nolint
       " to a plain data frame."
     )
     warning(msg, call. = FALSE)
-    config$logger$log(msg, target = target)
+    config$logger$disk(msg, target = target)
   }
   x$value <- as.data.frame(x$value)
   x
@@ -393,7 +375,7 @@ sanitize_format.drake_format_fst_tbl <- function(x, target, config) { # nolint
       " to a tibble."
     )
     warning(msg, call. = FALSE)
-    config$logger$log(msg, target = target)
+    config$logger$disk(msg, target = target)
   }
   x$value <- tibble::as_tibble(x$value)
   x
@@ -409,7 +391,7 @@ sanitize_format.drake_format_fst_dt <- function(x, target, config) { # nolint
       " to a data.table object."
     )
     warning(msg, call. = FALSE)
-    config$logger$log(msg, target = target)
+    config$logger$disk(msg, target = target)
   }
   x$value <- data.table::as.data.table(x$value)
   x
@@ -428,7 +410,7 @@ sanitize_format.drake_format_diskframe <- function(x, target, config) { # nolint
       "(say, with as.disk.frame(outdir = drake_tempfile()))."
     )
     warning(msg, call. = FALSE)
-    config$logger$log(msg, target = target)
+    config$logger$disk(msg, target = target)
     x$value <- disk.frame::as.disk.frame(
       df = x$value,
       outdir = config$cache$file_tmp()
@@ -493,7 +475,7 @@ assert_output_files <- function(target, meta, config) {
       target, ":\n",
       multiline_message(missing_files)
     )
-    config$logger$log(paste("Warning:", msg))
+    config$logger$disk(paste("Warning:", msg))
     warning(msg, call. = FALSE)
   }
 }
@@ -517,12 +499,7 @@ handle_build_exceptions <- function(target, meta, config) {
     )
   }
   if (inherits(meta$error, "error")) {
-    config$logger$major(
-      "fail",
-      target,
-      target = target,
-      color = "fail"
-    )
+    config$logger$target(target, "fail")
     store_failure(target = target, meta = meta, config = config)
     if (is_subtarget(target, config)) {
       parent <- config$spec[[target]]$subtarget_parent
@@ -535,7 +512,7 @@ handle_build_exceptions <- function(target, meta, config) {
         ")` for details. Error message:\n  ",
         meta$error$message
       )
-      config$logger$log(msg)
+      config$logger$disk(msg)
       unlock_environment(config$envir)
       stop(msg, call. = FALSE)
     }

--- a/R/logger.R
+++ b/R/logger.R
@@ -31,7 +31,7 @@ refclass_logger <- methods::setRefClass(
   Class = "refclass_logger",
   fields = c("verbose", "file", "spinner"),
   methods = list(
-    minor = function(..., target = character(0)) {
+    log = function(..., target = character(0)) {
       drake_log_file(..., target = target, file = .self$file)
       drake_log_spin(spinner = .self$spinner, verbose = .self$verbose)
       invisible()

--- a/R/logger.R
+++ b/R/logger.R
@@ -90,7 +90,7 @@ drake_log_file <- function(..., target = character(0), file) {
   invisible()
 }
 
-cli_msg <- function(..., cli_sym = cli::symbol$info) {
+cli_msg <- function(..., cli_sym = cli::col_blue(cli::symbol$info)) {
   if (.pkg_envir$has_cli) {
     message(crop_text(paste(cli_sym, ...), width = getOption("width") - 2L))
   } else {

--- a/R/logger.R
+++ b/R/logger.R
@@ -92,9 +92,9 @@ drake_log_file <- function(..., target = character(0), file) {
 
 cli_msg <- function(..., cli_sym = cli::col_blue(cli::symbol$info)) {
   if (.pkg_envir$has_cli) {
-    message(crop_text(paste(cli_sym, ...), width = getOption("width") - 2L))
+    message(paste(cli_sym, ...))
   } else {
-    message(crop_text(paste(...))) # nocov
+    message(paste(...)) # nocov
   }
 }
 
@@ -105,15 +105,6 @@ target_msg <- function(target) {
     message(paste(class(target), target)) # nocov
   }
 }
-
-crop_text <- Vectorize(function(x, width = getOption("width")) {
-  if (nchar(x) > width) {
-    x <- paste0(substr(x, 1, width - 3), "...")
-  }
-  x
-},
-"x", USE.NAMES = FALSE)
-
 
 target_msg.aggregate <- function(target) {
   symbol <- cli::col_green(cli::symbol$stop)

--- a/R/logger.R
+++ b/R/logger.R
@@ -50,7 +50,7 @@ refclass_logger <- methods::setRefClass(
     progress = function() {
       pb <- .self$progress_bar
       .self$progress_index <- .self$progress_index + 1L
-      if (!is.null(pb)) {
+      if (!is.null(pb) && .self$verbose == 2L) {
         ratio <- min(1, .self$progress_index / .self$progress_total)
         pb$finished <- FALSE
         pb$update(ratio = ratio)

--- a/R/logger.R
+++ b/R/logger.R
@@ -44,7 +44,7 @@ refclass_logger <- methods::setRefClass(
       msg <- "All targets are already up to date."
       drake_log_file(file = .self$file, msg)
       if (.self$verbose >= 1L) {
-        cli_msg(msg, cli_fun = cli::cli_alert_success)
+        cli_msg(msg, cli_sym = cli::col_green(cli::symbol$tick))
       }
     },
     progress = function() {
@@ -90,9 +90,9 @@ drake_log_file <- function(..., target = character(0), file) {
   invisible()
 }
 
-cli_msg <- function(..., cli_fun = cli::cli_alert_info) {
+cli_msg <- function(..., cli_sym = cli::symbol$info) {
   if (.pkg_envir$has_cli) {
-    cli_fun(crop_text(paste(...), width = getOption("width") - 2L))
+    message(crop_text(paste(cli_sym, ...), width = getOption("width") - 2L))
   } else {
     message(crop_text(paste(...))) # nocov
   }

--- a/R/logger.R
+++ b/R/logger.R
@@ -144,7 +144,7 @@ target_msg.retry <- function(target) {
 
 target_msg.subtarget <- function(target) {
   symbol <- cli::col_green(cli::symbol$pointer)
-  msg <- paste(symbol, "target", target)
+  msg <- paste(symbol, "subtarget", target)
   message(msg)
 }
 

--- a/R/logger.R
+++ b/R/logger.R
@@ -1,59 +1,36 @@
-logger <- function(verbose, file) {
-  spinner <- NULL
-  if (verbose > 1L) {
-    spinner <- try_spinner()
-  }
-  refclass_logger$new(
-    verbose = verbose,
-    file = file,
-    spinner = spinner
-  )
-}
-
-try_spinner <- function() {
-  use_cli <- requireNamespace("cli", quietly = TRUE) &&
-    utils::compareVersion(
-      as.character(utils::packageVersion("cli")),
-      "1.1.0"
-    ) >= 0L
-  if (use_cli) {
-    return(cli::make_spinner())
-  }
-  # nocov start
-  message(
-    "Install the ", shQuote("cli"), " package version 1.1.0 or above ",
-    "to show a console spinner for make(verbose = 2)."
-  )
-  # nocov end
+logger <- function(verbose, file = NULL) {
+  verbose <- as.integer(verbose)
+  refclass_logger$new(verbose = verbose, file = file)
 }
 
 refclass_logger <- methods::setRefClass(
   Class = "refclass_logger",
-  fields = c("verbose", "file", "spinner"),
+  fields = c("verbose", "file"),
   methods = list(
-    log = function(..., target = character(0)) {
-      drake_log_file(..., target = target, file = .self$file)
-      drake_log_spin(spinner = .self$spinner, verbose = .self$verbose)
-      invisible()
+    disk = function(...) {
+      drake_log_file(..., file = .self$file)
     },
-    major = function(..., target = character(0), color = "default") {
-      drake_log_file(..., target = target, file = .self$file)
-      drake_log_term(
-        ...,
-        target = target,
-        color = color,
-        verbose = .self$verbose
-      )
-      invisible()
+    term = function(...) {
+      if (.self$verbose == 1L) {
+        cli_msg(...)
+      }
+    },
+    target = function(target, action) {
+      drake_log_file(target = target, file = .self$file, action)
+      if (.self$verbose == 1L) {
+        class(target) <- action
+        target_msg(target)
+      }
+    },
+    up_to_date = function() {
+      msg <- "All targets are already up to date."
+      drake_log_file(file = .self$file, msg)
+      if (.self$verbose >= 1L) {
+        cli_msg(msg, cli_fun = cli::cli_alert_success)
+      }
     }
   )
 )
-
-drake_log_spin <- function(spinner, verbose) {
-  if (!is.null(spinner) && verbose >= 1L) {
-    spinner$spin()
-  }
-}
 
 drake_log_file <- function(..., target = character(0), file) {
   if (is.null(file)) {
@@ -74,48 +51,20 @@ drake_log_file <- function(..., target = character(0), file) {
   invisible()
 }
 
-drake_log_term <- function(..., target, color, verbose) {
-  if (verbose < 1L) {
-    return()
+cli_msg <- function(..., cli_fun = cli::cli_alert_info) {
+  if (.pkg_envir$has_cli) {
+    cli_fun(crop_text(paste(...), width = getOption("width") - 2L))
+  } else {
+    message(crop_text(paste(...))) # nocov
   }
-  msg <- c(...)
-  hex <- text_color(color)
-  if (length(hex) && requireNamespace("crayon", quietly = TRUE)) {
-    msg[1] <- crayon::make_style(hex)(msg[1])
-  }
-  if (verbose > 1L) {
-    msg[1] <- paste0("\r", msg[1])
-  }
-  message(crop_text(paste(msg, collapse = " ")))
 }
 
-text_color <- Vectorize(function(x) {
-  color <- switch(
-    x,
-    default = "lightGray",
-    dynamic = "dodgerblue3",
-    subtarget = "dodgerblue4",
-    target = "green3",
-    recover = "#ffd700",
-    retry = "#9400d3",
-    missing = "red",
-    cancel = "#ffa500",
-    fail = "red",
-    "#888888"
-  )
-  col2hex(color)
-},
-"x", USE.NAMES = FALSE)
-
-# copied from the gtools package
-col2hex <- function(cname) {
-  assert_pkg("grDevices")
-  col_mat <- grDevices::col2rgb(cname)
-  grDevices::rgb(
-    red = col_mat[1, ] / 255,
-    green = col_mat[2, ] / 255,
-    blue = col_mat[3, ] / 255
-  )
+target_msg <- function(target) {
+  if (.pkg_envir$has_cli) {
+    UseMethod("target_msg")
+  } else {
+    message(paste(class(target), target)) # nocov
+  }
 }
 
 crop_text <- Vectorize(function(x, width = getOption("width")) {
@@ -125,3 +74,52 @@ crop_text <- Vectorize(function(x, width = getOption("width")) {
   x
 },
 "x", USE.NAMES = FALSE)
+
+
+target_msg.aggregate <- function(target) {
+  symbol <- cli::col_green(cli::symbol$stop)
+  msg <- paste(symbol, "aggregate", target)
+  message(msg)
+}
+
+target_msg.cancel <- function(target) {
+  symbol <- cli::col_yellow(cli::symbol$stop)
+  msg <- paste(symbol, "cancel", target)
+  message(msg)
+}
+
+target_msg.dynamic <- function(target) {
+  symbol <- cli::col_green(cli::symbol$play)
+  msg <- paste(symbol, "dynamic", target)
+  message(msg)
+}
+
+target_msg.fail <- function(target) {
+  symbol <- cli::col_red(cli::symbol$cross)
+  msg <- paste(symbol, "fail", target)
+  message(msg)
+}
+
+target_msg.recover <- function(target) {
+  symbol <- cli::col_green(cli::symbol$tick)
+  msg <- paste(symbol, "recover", target)
+  message(msg)
+}
+
+target_msg.retry <- function(target) {
+  symbol <- cli::col_yellow(cli::symbol$warning)
+  msg <- paste(symbol, "retry", target)
+  message(msg)
+}
+
+target_msg.subtarget <- function(target) {
+  symbol <- cli::col_green(cli::symbol$pointer)
+  msg <- paste(symbol, "target", target)
+  message(msg)
+}
+
+target_msg.target <- function(target) {
+  symbol <- cli::col_green(cli::symbol$play)
+  msg <- paste(symbol, "target", target)
+  message(msg)
+}

--- a/R/make.R
+++ b/R/make.R
@@ -234,8 +234,8 @@ make <- function(
 #' @description Not a user-side function.
 #' @param config a [drake_config()] object.
 make_impl <- function(config) {
-  config$logger$log("begin make()")
-  on.exit(config$logger$log("end make()"), add = TRUE)
+  config$logger$disk("begin make()")
+  on.exit(config$logger$disk("end make()"), add = TRUE)
   runtime_checks(config = config)
   if (config$lock_cache) {
     config$cache$lock()
@@ -292,7 +292,7 @@ run_native_backend <- function(config) {
     class(config) <- c(class(config), parallelism)
     drake_backend(config)
   } else {
-    config$logger$major("All targets are already up to date.", color = NULL)
+    config$logger$up_to_date()
   }
 }
 
@@ -315,7 +315,7 @@ run_external_backend <- function(config) {
 
 outdated_subgraph <- function(config) {
   outdated <- outdated_impl(config, do_prework = FALSE, make_imports = FALSE)
-  config$logger$log("isolate oudated targets")
+  config$logger$disk("isolate oudated targets")
   igraph::induced_subgraph(graph = config$graph, vids = outdated)
 }
 
@@ -604,10 +604,6 @@ r_make_message <- function(force) {
     )
   )
   if (force || (r_make_message && sample.int(n = 10, size = 1) < 1.5)) {
-    message(
-      "In drake, consider r_make() instead of make(). ",
-      "r_make() runs make() in a fresh R session ",
-      "for enhanced robustness and reproducibility."
-    )
+    cli_msg("Consider drake::r_make() to improve robustness.")
   }
 }

--- a/R/make.R
+++ b/R/make.R
@@ -281,6 +281,8 @@ process_targets <- function(config) {
   } else {
     run_external_backend(config)
   }
+  config$logger$terminate_progress()
+  invisible()
 }
 
 run_native_backend <- function(config) {
@@ -288,7 +290,9 @@ run_native_backend <- function(config) {
     config$parallelism,
     c("loop", "clustermq", "future")
   )
-  if (igraph::gorder(config$envir_graph$graph)) {
+  order <- igraph::gorder(config$envir_graph$graph)
+  if (order) {
+    config$logger$set_progress_total(order)
     class(config) <- c(class(config), parallelism)
     drake_backend(config)
   } else {

--- a/R/make.R
+++ b/R/make.R
@@ -164,7 +164,8 @@ make <- function(
   max_expand = NULL,
   log_build_times = TRUE,
   format = NULL,
-  lock_cache = TRUE
+  lock_cache = TRUE,
+  log_make = NULL
 ) {
   force(envir)
   deprecate_arg(config, "config")
@@ -223,7 +224,8 @@ make <- function(
     max_expand = max_expand,
     log_build_times = log_build_times,
     format = format,
-    lock_cache = lock_cache
+    lock_cache = lock_cache,
+    log_make = log_make
   )
   make_impl(config)
 }

--- a/R/make.R
+++ b/R/make.R
@@ -234,8 +234,8 @@ make <- function(
 #' @description Not a user-side function.
 #' @param config a [drake_config()] object.
 make_impl <- function(config) {
-  config$logger$minor("begin make()")
-  on.exit(config$logger$minor("end make()"), add = TRUE)
+  config$logger$log("begin make()")
+  on.exit(config$logger$log("end make()"), add = TRUE)
   runtime_checks(config = config)
   if (config$lock_cache) {
     config$cache$lock()
@@ -315,7 +315,7 @@ run_external_backend <- function(config) {
 
 outdated_subgraph <- function(config) {
   outdated <- outdated_impl(config, do_prework = FALSE, make_imports = FALSE)
-  config$logger$minor("isolate oudated targets")
+  config$logger$log("isolate oudated targets")
   igraph::induced_subgraph(graph = config$graph, vids = outdated)
 }
 

--- a/R/manage_memory.R
+++ b/R/manage_memory.R
@@ -91,7 +91,7 @@ discard_targets <- function(discard_these, target, config) {
   if (!length(discard_these)) {
     return()
   }
-  config$logger$minor("unload", discard_these, target = target)
+  config$logger$log("unload", discard_these, target = target)
   rm(list = discard_these, envir = config$envir_targets, inherits = FALSE)
   config$envir_loaded$targets <- setdiff(
     config$envir_loaded$targets,
@@ -121,7 +121,7 @@ clear_envir_subtargets <- function(target, config) {
 }
 
 clear_envir_targets <- function(target, config) {
-  config$logger$minor("clear target envir", target = target)
+  config$logger$log("clear target envir", target = target)
   rm(list = config$envir_loaded$targets, envir = config$envir_targets)
   rm(list = config$envir_loaded$dynamic, envir = config$envir_dynamic)
   config$envir_loaded$targets <- character(0)
@@ -143,7 +143,7 @@ try_load_deps <- function(targets, config, jobs = 1) {
     return()
   }
   if (config$lazy_load == "eager") {
-    config$logger$minor("load", targets)
+    config$logger$log("load", targets)
   }
   lapply(
     X = targets,

--- a/R/manage_memory.R
+++ b/R/manage_memory.R
@@ -91,7 +91,7 @@ discard_targets <- function(discard_these, target, config) {
   if (!length(discard_these)) {
     return()
   }
-  config$logger$log("unload", discard_these, target = target)
+  config$logger$disk("unload", discard_these, target = target)
   rm(list = discard_these, envir = config$envir_targets, inherits = FALSE)
   config$envir_loaded$targets <- setdiff(
     config$envir_loaded$targets,
@@ -121,7 +121,7 @@ clear_envir_subtargets <- function(target, config) {
 }
 
 clear_envir_targets <- function(target, config) {
-  config$logger$log("clear target envir", target = target)
+  config$logger$disk("clear target envir", target = target)
   rm(list = config$envir_loaded$targets, envir = config$envir_targets)
   rm(list = config$envir_loaded$dynamic, envir = config$envir_dynamic)
   config$envir_loaded$targets <- character(0)
@@ -143,7 +143,7 @@ try_load_deps <- function(targets, config, jobs = 1) {
     return()
   }
   if (config$lazy_load == "eager") {
-    config$logger$log("load", targets)
+    config$logger$disk("load", targets)
   }
   lapply(
     X = targets,

--- a/R/outdated.R
+++ b/R/outdated.R
@@ -77,8 +77,8 @@ recoverable_impl <- function(
   make_imports = TRUE,
   do_prework = TRUE
 ) {
-  config$logger$minor("begin recoverable()")
-  on.exit(config$logger$minor("end recoverable()"), add = TRUE)
+  config$logger$log("begin recoverable()")
+  on.exit(config$logger$log("end recoverable()"), add = TRUE)
   assert_config(config)
   if (make_imports && config$lock_cache) {
     config$cache$lock()
@@ -165,8 +165,8 @@ outdated_impl <- function(
   make_imports = TRUE,
   do_prework = TRUE
 ) {
-  config$logger$minor("begin outdated()")
-  on.exit(config$logger$minor("end outdated()"), add = TRUE)
+  config$logger$log("begin outdated()")
+  on.exit(config$logger$log("end outdated()"), add = TRUE)
   assert_config(config)
   if (make_imports && config$lock_cache) {
     config$cache$lock()
@@ -181,7 +181,7 @@ outdated_impl <- function(
     process_imports(config = config)
   }
   from <- first_outdated(config = config)
-  config$logger$minor("find downstream outdated targets")
+  config$logger$log("find downstream outdated targets")
   to <- downstream_nodes(config$graph, from)
   out <- sort(unique(as.character(c(from, to))))
   out[!is_encoded_path(out)]
@@ -202,7 +202,7 @@ first_outdated <- function(config) {
 }
 
 stage_outdated <- function(envir, config) {
-  config$logger$minor("find more outdated targets")
+  config$logger$log("find more outdated targets")
   new_leaves <- setdiff(leaf_nodes(envir$graph), envir$outdated)
   do_build <- lightly_parallelize(
     X = new_leaves,
@@ -265,8 +265,8 @@ missed <- function(..., config = NULL) {
 #' @description Not a user-side function.
 #' @param config A [drake_config()] object.
 missed_impl <- function(config) {
-  config$logger$minor("begin missed()")
-  on.exit(config$logger$minor("end missed()"), add = TRUE)
+  config$logger$log("begin missed()")
+  on.exit(config$logger$log("end missed()"), add = TRUE)
   assert_config(config)
   imports <- all_imports(config)
   is_missing <- lightly_parallelize(

--- a/R/outdated.R
+++ b/R/outdated.R
@@ -77,8 +77,6 @@ recoverable_impl <- function(
   make_imports = TRUE,
   do_prework = TRUE
 ) {
-  config$logger$log("begin recoverable()")
-  on.exit(config$logger$log("end recoverable()"), add = TRUE)
   assert_config(config)
   if (make_imports && config$lock_cache) {
     config$cache$lock()
@@ -165,9 +163,10 @@ outdated_impl <- function(
   make_imports = TRUE,
   do_prework = TRUE
 ) {
-  config$logger$log("begin outdated()")
-  on.exit(config$logger$log("end outdated()"), add = TRUE)
   assert_config(config)
+  if (!identical(config$running_make, TRUE)) {
+    config$logger$file <- NULL
+  }
   if (make_imports && config$lock_cache) {
     config$cache$lock()
     on.exit(config$cache$unlock(), add = TRUE)
@@ -181,7 +180,6 @@ outdated_impl <- function(
     process_imports(config = config)
   }
   from <- first_outdated(config = config)
-  config$logger$log("find downstream outdated targets")
   to <- downstream_nodes(config$graph, from)
   out <- sort(unique(as.character(c(from, to))))
   out[!is_encoded_path(out)]
@@ -202,7 +200,6 @@ first_outdated <- function(config) {
 }
 
 stage_outdated <- function(envir, config) {
-  config$logger$log("find more outdated targets")
   new_leaves <- setdiff(leaf_nodes(envir$graph), envir$outdated)
   do_build <- lightly_parallelize(
     X = new_leaves,
@@ -265,8 +262,6 @@ missed <- function(..., config = NULL) {
 #' @description Not a user-side function.
 #' @param config A [drake_config()] object.
 missed_impl <- function(config) {
-  config$logger$log("begin missed()")
-  on.exit(config$logger$log("end missed()"), add = TRUE)
   assert_config(config)
   imports <- all_imports(config)
   is_missing <- lightly_parallelize(

--- a/R/predict_runtime.R
+++ b/R/predict_runtime.R
@@ -74,8 +74,6 @@ predict_runtime_impl <- function(
   default_time = 0,
   warn = TRUE
 ) {
-  config$logger$log("begin predict_runtime()")
-  on.exit(config$logger$log("end predict_runtime()"), add = TRUE)
   worker_prediction_info(
     config = config,
     targets = targets_predict,
@@ -187,8 +185,6 @@ predict_workers_impl <- function(
   default_time = 0,
   warn = TRUE
 ) {
-  config$logger$log("begin predict_workers()")
-  on.exit(config$logger$log("end predict_workers()"), add = TRUE)
   worker_prediction_info(
     config,
     targets = targets_predict,
@@ -214,6 +210,7 @@ worker_prediction_info <- function(
   warn = TRUE
 ) {
   assert_config(config)
+  config$logger$file <- NULL
   deprecate_targets_only(targets_only) # 2019-01-03 # nolint
   assumptions <- timing_assumptions(
     config = config,

--- a/R/predict_runtime.R
+++ b/R/predict_runtime.R
@@ -74,8 +74,8 @@ predict_runtime_impl <- function(
   default_time = 0,
   warn = TRUE
 ) {
-  config$logger$minor("begin predict_runtime()")
-  on.exit(config$logger$minor("end predict_runtime()"), add = TRUE)
+  config$logger$log("begin predict_runtime()")
+  on.exit(config$logger$log("end predict_runtime()"), add = TRUE)
   worker_prediction_info(
     config = config,
     targets = targets_predict,
@@ -187,8 +187,8 @@ predict_workers_impl <- function(
   default_time = 0,
   warn = TRUE
 ) {
-  config$logger$minor("begin predict_workers()")
-  on.exit(config$logger$minor("end predict_workers()"), add = TRUE)
+  config$logger$log("begin predict_workers()")
+  on.exit(config$logger$log("end predict_workers()"), add = TRUE)
   worker_prediction_info(
     config,
     targets = targets_predict,

--- a/R/priority_queue.R
+++ b/R/priority_queue.R
@@ -1,5 +1,5 @@
 priority_queue <- function(config, jobs = config$jobs_preprocess) {
-  config$logger$minor("construct priority queue")
+  config$logger$log("construct priority queue")
   targets <- igraph::V(config$envir_graph$graph)$name
   if (!length(targets)) {
     return(empty_queue())

--- a/R/priority_queue.R
+++ b/R/priority_queue.R
@@ -1,5 +1,5 @@
 priority_queue <- function(config, jobs = config$jobs_preprocess) {
-  config$logger$log("construct priority queue")
+  config$logger$disk("construct priority queue")
   targets <- igraph::V(config$envir_graph$graph)$name
   if (!length(targets)) {
     return(empty_queue())

--- a/R/process_imports.R
+++ b/R/process_imports.R
@@ -24,13 +24,13 @@ process_import <- function(import, config) {
     is_missing <- identical(value, NA_character_)
   }
   if (is_missing) {
-    config$logger$log(
+    config$logger$disk(
       "missing",
       target = config$cache$display_keys(import),
       color = "missing"
     )
   } else {
-    config$logger$log("import", target = config$cache$display_keys(import))
+    config$logger$disk("import", target = config$cache$display_keys(import))
   }
   store_item(
     target = import,
@@ -81,7 +81,7 @@ process_imports_mclapply <- function(config) {
 }
 
 process_imports_parLapply <- function(config) { # nolint
-  config$logger$log(
+  config$logger$disk(
     "load parallel socket cluster with",
     config$jobs_preprocess,
     "workers"

--- a/R/process_imports.R
+++ b/R/process_imports.R
@@ -24,13 +24,13 @@ process_import <- function(import, config) {
     is_missing <- identical(value, NA_character_)
   }
   if (is_missing) {
-    config$logger$minor(
+    config$logger$log(
       "missing",
       target = config$cache$display_keys(import),
       color = "missing"
     )
   } else {
-    config$logger$minor("import", target = config$cache$display_keys(import))
+    config$logger$log("import", target = config$cache$display_keys(import))
   }
   store_item(
     target = import,
@@ -81,7 +81,7 @@ process_imports_mclapply <- function(config) {
 }
 
 process_imports_parLapply <- function(config) { # nolint
-  config$logger$minor(
+  config$logger$log(
     "load parallel socket cluster with",
     config$jobs_preprocess,
     "workers"

--- a/R/sankey_drake_graph.R
+++ b/R/sankey_drake_graph.R
@@ -93,8 +93,6 @@ sankey_drake_graph_impl <- function(
     clusters = clusters,
     show_output_files = show_output_files
   )
-  config$logger$log("begin sankey_drake_graph()")
-  on.exit(config$logger$log("end sankey_drake_graph()"), add = TRUE)
   render_sankey_drake_graph(
     graph_info,
     file = file,

--- a/R/sankey_drake_graph.R
+++ b/R/sankey_drake_graph.R
@@ -93,8 +93,8 @@ sankey_drake_graph_impl <- function(
     clusters = clusters,
     show_output_files = show_output_files
   )
-  config$logger$minor("begin sankey_drake_graph()")
-  on.exit(config$logger$minor("end sankey_drake_graph()"), add = TRUE)
+  config$logger$log("begin sankey_drake_graph()")
+  on.exit(config$logger$log("end sankey_drake_graph()"), add = TRUE)
   render_sankey_drake_graph(
     graph_info,
     file = file,

--- a/R/store_outputs.R
+++ b/R/store_outputs.R
@@ -2,7 +2,7 @@ store_outputs <- function(target, value, meta, config) {
   if (inherits(meta$error, "error")) {
     return()
   }
-  config$logger$log("store", target = target)
+  config$logger$disk("store", target = target)
   store_triggers(target, meta, config)
   meta$name <- target
   store_item(
@@ -261,7 +261,7 @@ log_time <- function(target, meta, config) {
   } else {
     tail <- " (install lubridate to print runtimes in the log)" # nocov
   }
-  config$logger$log("time", tail, target = target)
+  config$logger$disk("time", tail, target = target)
 }
 
 runtime_entry <- function(runtime, target) {

--- a/R/store_outputs.R
+++ b/R/store_outputs.R
@@ -257,7 +257,7 @@ log_time <- function(target, meta, config) {
   if (requireNamespace("lubridate", quietly = TRUE)) {
     exec <- round(lubridate::dseconds(meta$time_command$elapsed), 3)
     total <- round(lubridate::dseconds(meta$time_build$elapsed), 3)
-    tail <- paste("", exec, "|", total, " (exec | total)")
+    tail <- paste("", exec, ":", total, " (exec : total)")
   } else {
     tail <- " (install lubridate to print runtimes in the log)" # nocov
   }

--- a/R/store_outputs.R
+++ b/R/store_outputs.R
@@ -2,7 +2,7 @@ store_outputs <- function(target, value, meta, config) {
   if (inherits(meta$error, "error")) {
     return()
   }
-  config$logger$minor("store", target = target)
+  config$logger$log("store", target = target)
   store_triggers(target, meta, config)
   meta$name <- target
   store_item(
@@ -261,7 +261,7 @@ log_time <- function(target, meta, config) {
   } else {
     tail <- " (install lubridate to print runtimes in the log)" # nocov
   }
-  config$logger$minor("time", tail, target = target)
+  config$logger$log("time", tail, target = target)
 }
 
 runtime_entry <- function(runtime, target) {

--- a/R/text_drake_graph.R
+++ b/R/text_drake_graph.R
@@ -85,8 +85,8 @@ text_drake_graph_impl <- function(
     show_output_files = show_output_files,
     hover = FALSE
   )
-  config$logger$minor("begin text_drake_graph()")
-  on.exit(config$logger$minor("end text_drake_graph()"), add = TRUE)
+  config$logger$log("begin text_drake_graph()")
+  on.exit(config$logger$log("end text_drake_graph()"), add = TRUE)
   render_text_drake_graph(
     graph_info = graph_info,
     nchar = nchar,

--- a/R/text_drake_graph.R
+++ b/R/text_drake_graph.R
@@ -85,8 +85,6 @@ text_drake_graph_impl <- function(
     show_output_files = show_output_files,
     hover = FALSE
   )
-  config$logger$log("begin text_drake_graph()")
-  on.exit(config$logger$log("end text_drake_graph()"), add = TRUE)
   render_text_drake_graph(
     graph_info = graph_info,
     nchar = nchar,

--- a/R/utils.R
+++ b/R/utils.R
@@ -183,12 +183,12 @@ random_tempdir <- function() {
   dir
 }
 
-multiline_message <- function(x) {
+multiline_message <- function(x, indent = "  ") {
   n <- 30
   if (length(x) > n) {
     x <- c(x[1:(n - 1)], "...")
   }
-  x <- paste0("  ", x)
+  x <- paste0(indent, x)
   paste(x, collapse = "\n")
 }
 

--- a/R/vis_drake_graph.R
+++ b/R/vis_drake_graph.R
@@ -113,8 +113,8 @@ vis_drake_graph_impl <- function(
     hover = hover,
     on_select_col = on_select_col
   )
-  config$logger$minor("begin vis_drake_graph()")
-  on.exit(config$logger$minor("end vis_drake_graph()"), add = TRUE)
+  config$logger$log("begin vis_drake_graph()")
+  on.exit(config$logger$log("end vis_drake_graph()"), add = TRUE)
   if (is.null(main)) {
     main <- graph_info$default_title
   }

--- a/R/vis_drake_graph.R
+++ b/R/vis_drake_graph.R
@@ -113,8 +113,6 @@ vis_drake_graph_impl <- function(
     hover = hover,
     on_select_col = on_select_col
   )
-  config$logger$log("begin vis_drake_graph()")
-  on.exit(config$logger$log("end vis_drake_graph()"), add = TRUE)
   if (is.null(main)) {
     main <- graph_info$default_title
   }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -35,6 +35,7 @@ drake_tip_ <- function() {
 .onLoad <- function(libname, pkgname) {
   warn_rdata()
   invisible()
+  .pkg_envir[["has_cli"]] <- requireNamespace("cli", quietly = TRUE)
   .pkg_envir[["on_windows"]] <- this_os() == "windows"
 }
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -36,6 +36,7 @@ drake_tip_ <- function() {
   warn_rdata()
   invisible()
   .pkg_envir[["has_cli"]] <- requireNamespace("cli", quietly = TRUE)
+  .pkg_envir[["has_progress"]] <- requireNamespace("progress", quietly = TRUE)
   .pkg_envir[["on_windows"]] <- this_os() == "windows"
 }
 

--- a/codemeta.json
+++ b/codemeta.json
@@ -222,14 +222,7 @@
     {
       "@type": "SoftwareApplication",
       "identifier": "disk.frame",
-      "name": "disk.frame",
-      "provider": {
-        "@id": "https://cran.r-project.org",
-        "@type": "Organization",
-        "name": "Comprehensive R Archive Network (CRAN)",
-        "url": "https://cran.r-project.org"
-      },
-      "sameAs": "https://CRAN.R-project.org/package=disk.frame"
+      "name": "disk.frame"
     },
     {
       "@type": "SoftwareApplication",
@@ -355,6 +348,19 @@
         "url": "https://cran.r-project.org"
       },
       "sameAs": "https://CRAN.R-project.org/package=prettycode"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "progress",
+      "name": "progress",
+      "version": ">= 1.2.2",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=progress"
     },
     {
       "@type": "SoftwareApplication",
@@ -623,7 +629,7 @@
   ],
   "releaseNotes": "https://github.com/ropensci/drake/blob/master/NEWS.md",
   "readme": "https://github.com/ropensci/drake/blob/master/README.md",
-  "fileSize": "1108.463KB",
+  "fileSize": "1108.37KB",
   "contIntegration": [
     "https://travis-ci.org/ropensci/drake",
     "https://ci.appveyor.com/project/ropensci/drake",

--- a/man/build_drake_graph.Rd
+++ b/man/build_drake_graph.Rd
@@ -58,19 +58,7 @@ to help decide on an appropriate number of jobs.
 For details, visit
 \url{https://books.ropensci.org/drake/time.html}.}
 
-\item{console_log_file}{Optional character scalar of a file name or
-connection object (such as \code{stdout()}) to dump maximally verbose
-log information for \code{\link[=make]{make()}} and other functions (all functions that
-accept a \code{config} argument, plus \code{drake_config()}).
-If you choose to use a text file as the console log,
-it will persist over multiple function calls
-until you delete it manually.
-Fields in each row the log file, from left to right:
-- The node name (short host name) of the
-computer (from \code{Sys.info()["nodename"]}).
-- The process ID (from \code{Sys.getpid()}).
-- A timestamp with the date and time (in microseconds).
-- A brief description of what \code{drake} was doing.\verb{ The fields are separated by pipe symbols (}"|"`).}
+\item{console_log_file}{Deprecated in favor of \code{log_make}.}
 
 \item{trigger}{Name of the trigger to apply to all targets.
 Ignored if \code{plan} has a \code{trigger} column.

--- a/man/build_drake_graph.Rd
+++ b/man/build_drake_graph.Rd
@@ -47,8 +47,9 @@ then reproducibly tracked as dependencies.}
 \item{verbose}{Integer, control printing to the console/terminal.
 \itemize{
 \item \code{0}: print nothing.
-\item \code{1}: print targets, retries, and failures.
-\item \code{2}: also show a spinner when preprocessing tasks are underway.
+\item \code{1}: print target-by-target messages as \code{\link[=make]{make()}} progresses.
+\item \code{2}: show a progress bar to track how many targets are
+done so far.
 }}
 
 \item{jobs}{Maximum number of parallel workers for processing the targets.

--- a/man/default_Makefile_args.Rd
+++ b/man/default_Makefile_args.Rd
@@ -13,8 +13,9 @@ default_Makefile_args(jobs, verbose)
 \item{verbose}{Integer, control printing to the console/terminal.
 \itemize{
 \item \code{0}: print nothing.
-\item \code{1}: print targets, retries, and failures.
-\item \code{2}: also show a spinner when preprocessing tasks are underway.
+\item \code{1}: print target-by-target messages as \code{\link[=make]{make()}} progresses.
+\item \code{2}: show a progress bar to track how many targets are
+done so far.
 }}
 }
 \value{

--- a/man/drake_config.Rd
+++ b/man/drake_config.Rd
@@ -60,7 +60,8 @@ drake_config(
   max_expand = NULL,
   log_build_times = TRUE,
   format = NULL,
-  lock_cache = TRUE
+  lock_cache = TRUE,
+  log_make = NULL
 )
 }
 \arguments{
@@ -313,19 +314,7 @@ if targets fail.}
 
 \item{makefile_path}{Deprecated.}
 
-\item{console_log_file}{Optional character scalar of a file name or
-connection object (such as \code{stdout()}) to dump maximally verbose
-log information for \code{\link[=make]{make()}} and other functions (all functions that
-accept a \code{config} argument, plus \code{drake_config()}).
-If you choose to use a text file as the console log,
-it will persist over multiple function calls
-until you delete it manually.
-Fields in each row the log file, from left to right:
-- The node name (short host name) of the
-computer (from \code{Sys.info()["nodename"]}).
-- The process ID (from \code{Sys.getpid()}).
-- A timestamp with the date and time (in microseconds).
-- A brief description of what \code{drake} was doing.\verb{ The fields are separated by pipe symbols (}"|"`).}
+\item{console_log_file}{Deprecated in favor of \code{log_make}.}
 
 \item{ensure_workers}{Deprecated.}
 
@@ -542,6 +531,20 @@ and you will need to manually unlock it with
 \code{drake::drake_cache("xyz")$unlock()}. Repeatedly unlocking the cache
 by hand is annoying, and \code{lock_cache = FALSE} prevents the cache
 from locking in the first place.}
+
+\item{log_make}{Optional character scalar of a file name or
+connection object (such as \code{stdout()}) to dump maximally verbose
+log information for \code{\link[=make]{make()}} and other functions (all functions that
+accept a \code{config} argument, plus \code{drake_config()}).
+If you choose to use a text file as the console log,
+it will persist over multiple function calls
+until you delete it manually.
+Fields in each row the log file, from left to right:
+- The node name (short host name) of the
+computer (from \code{Sys.info()["nodename"]}).
+- The process ID (from \code{Sys.getpid()}).
+- A timestamp with the date and time (in microseconds).
+- A brief description of what \code{drake} was doing.\verb{ The fields are separated by pipe symbols (}"|"`).}
 }
 \value{
 A configured \code{drake} workflow.

--- a/man/drake_config.Rd
+++ b/man/drake_config.Rd
@@ -94,8 +94,9 @@ then reproducibly tracked as dependencies.}
 \item{verbose}{Integer, control printing to the console/terminal.
 \itemize{
 \item \code{0}: print nothing.
-\item \code{1}: print targets, retries, and failures.
-\item \code{2}: also show a spinner when preprocessing tasks are underway.
+\item \code{1}: print target-by-target messages as \code{\link[=make]{make()}} progresses.
+\item \code{2}: show a progress bar to track how many targets are
+done so far.
 }}
 
 \item{hook}{Deprecated.}

--- a/man/get_cache.Rd
+++ b/man/get_cache.Rd
@@ -40,19 +40,7 @@ is the root. The following are equivalent and correct:
 
 \item{fetch_cache}{Deprecated.}
 
-\item{console_log_file}{Optional character scalar of a file name or
-connection object (such as \code{stdout()}) to dump maximally verbose
-log information for \code{\link[=make]{make()}} and other functions (all functions that
-accept a \code{config} argument, plus \code{drake_config()}).
-If you choose to use a text file as the console log,
-it will persist over multiple function calls
-until you delete it manually.
-Fields in each row the log file, from left to right:
-- The node name (short host name) of the
-computer (from \code{Sys.info()["nodename"]}).
-- The process ID (from \code{Sys.getpid()}).
-- A timestamp with the date and time (in microseconds).
-- A brief description of what \code{drake} was doing.\verb{ The fields are separated by pipe symbols (}"|"`).}
+\item{console_log_file}{Deprecated in favor of \code{log_make}.}
 }
 \description{
 Use \code{\link[=drake_cache]{drake_cache()}} instead.

--- a/man/make.Rd
+++ b/man/make.Rd
@@ -61,7 +61,8 @@ make(
   max_expand = NULL,
   log_build_times = TRUE,
   format = NULL,
-  lock_cache = TRUE
+  lock_cache = TRUE,
+  log_make = NULL
 )
 }
 \arguments{
@@ -316,19 +317,7 @@ if targets fail.}
 
 \item{makefile_path}{Deprecated.}
 
-\item{console_log_file}{Optional character scalar of a file name or
-connection object (such as \code{stdout()}) to dump maximally verbose
-log information for \code{\link[=make]{make()}} and other functions (all functions that
-accept a \code{config} argument, plus \code{drake_config()}).
-If you choose to use a text file as the console log,
-it will persist over multiple function calls
-until you delete it manually.
-Fields in each row the log file, from left to right:
-- The node name (short host name) of the
-computer (from \code{Sys.info()["nodename"]}).
-- The process ID (from \code{Sys.getpid()}).
-- A timestamp with the date and time (in microseconds).
-- A brief description of what \code{drake} was doing.\verb{ The fields are separated by pipe symbols (}"|"`).}
+\item{console_log_file}{Deprecated in favor of \code{log_make}.}
 
 \item{ensure_workers}{Deprecated.}
 
@@ -545,6 +534,20 @@ and you will need to manually unlock it with
 \code{drake::drake_cache("xyz")$unlock()}. Repeatedly unlocking the cache
 by hand is annoying, and \code{lock_cache = FALSE} prevents the cache
 from locking in the first place.}
+
+\item{log_make}{Optional character scalar of a file name or
+connection object (such as \code{stdout()}) to dump maximally verbose
+log information for \code{\link[=make]{make()}} and other functions (all functions that
+accept a \code{config} argument, plus \code{drake_config()}).
+If you choose to use a text file as the console log,
+it will persist over multiple function calls
+until you delete it manually.
+Fields in each row the log file, from left to right:
+- The node name (short host name) of the
+computer (from \code{Sys.info()["nodename"]}).
+- The process ID (from \code{Sys.getpid()}).
+- A timestamp with the date and time (in microseconds).
+- A brief description of what \code{drake} was doing.\verb{ The fields are separated by pipe symbols (}"|"`).}
 }
 \value{
 nothing

--- a/man/make.Rd
+++ b/man/make.Rd
@@ -95,8 +95,9 @@ then reproducibly tracked as dependencies.}
 \item{verbose}{Integer, control printing to the console/terminal.
 \itemize{
 \item \code{0}: print nothing.
-\item \code{1}: print targets, retries, and failures.
-\item \code{2}: also show a spinner when preprocessing tasks are underway.
+\item \code{1}: print target-by-target messages as \code{\link[=make]{make()}} progresses.
+\item \code{2}: show a progress bar to track how many targets are
+done so far.
 }}
 
 \item{hook}{Deprecated.}

--- a/man/this_cache.Rd
+++ b/man/this_cache.Rd
@@ -22,19 +22,7 @@ this_cache(
 
 \item{fetch_cache}{Deprecated.}
 
-\item{console_log_file}{Optional character scalar of a file name or
-connection object (such as \code{stdout()}) to dump maximally verbose
-log information for \code{\link[=make]{make()}} and other functions (all functions that
-accept a \code{config} argument, plus \code{drake_config()}).
-If you choose to use a text file as the console log,
-it will persist over multiple function calls
-until you delete it manually.
-Fields in each row the log file, from left to right:
-- The node name (short host name) of the
-computer (from \code{Sys.info()["nodename"]}).
-- The process ID (from \code{Sys.getpid()}).
-- A timestamp with the date and time (in microseconds).
-- A brief description of what \code{drake} was doing.\verb{ The fields are separated by pipe symbols (}"|"`).}
+\item{console_log_file}{Deprecated in favor of \code{log_make}.}
 }
 \value{
 A drake/storr cache at the specified path, if it exists.

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -4,4 +4,4 @@ Sys.setenv("drake_session_info" = "false")
 library(testthat)
 library(drake)
 
-test_check("drake")
+test_check("drake", reporter = "summary")

--- a/tests/testthat/test-1-interactive.R
+++ b/tests/testthat/test-1-interactive.R
@@ -55,24 +55,22 @@ test_with_dir("logger", {
   # testthat suppresses messages,
   # so we need to inspect the console output manually.
   files <- list.files()
-  x <- logger(verbose = 0L, file = NULL)
-  x$major("abc") # Should be empty.
-  x$log("abc") # Should be empty.
-  x <- logger(verbose = 1L, file = NULL)
-  x$major("abc") # Should show "abc".
-  x$log("abc") # Should be empty.
-  x <- logger(verbose = 2L, file = NULL)
-  x$major("abc") # Should show "abc".
-  x$log("abc") # Should show the spinner.
+  x <- refclass_logger$new(verbose = 0L, file = NULL)
+  x$disk("abc") # Should be empty.
+  x <- refclass_logger$new(verbose = 1L, file = NULL)
+  x$disk("abc") # Should be empty.
+  x <- refclass_logger$new(verbose = 2L, file = NULL)
+  x$disk("abc") # Should be empty.
   expect_equal(files, list.files())
+  x$term("abc", "def") # Should say "abc def"
   for (verbose in c(0L, 1L, 2L)) {
     tmp <- tempfile()
-    x <- logger(verbose = 0L, file = tmp)
+    x <- refclass_logger$new(verbose = verbose, file = tmp)
     expect_equal(x$file, tmp)
     expect_false(file.exists(tmp))
-    x$major("abc")
+    x$disk("abc")
     expect_equal(length(readLines(tmp)), 1L)
-    x$log("abc")
+    x$target("abc", "target") # Should say "target abc"
     expect_equal(length(readLines(tmp)), 2L)
   }
 })

--- a/tests/testthat/test-1-interactive.R
+++ b/tests/testthat/test-1-interactive.R
@@ -73,6 +73,10 @@ test_with_dir("logger", {
     x$target("abc", "target") # Should say "target abc"
     expect_equal(length(readLines(tmp)), 2L)
   }
+  # Retries need a special test since the logger is muted
+  # in those tests.
+  plan <- drake_plan(x = target(stop(1), retries = 3))
+  expect_error(make(plan, verbose = 1L))
 })
 
 if (FALSE) {

--- a/tests/testthat/test-1-interactive.R
+++ b/tests/testthat/test-1-interactive.R
@@ -57,13 +57,13 @@ test_with_dir("logger", {
   files <- list.files()
   x <- logger(verbose = 0L, file = NULL)
   x$major("abc") # Should be empty.
-  x$minor("abc") # Should be empty.
+  x$log("abc") # Should be empty.
   x <- logger(verbose = 1L, file = NULL)
   x$major("abc") # Should show "abc".
-  x$minor("abc") # Should be empty.
+  x$log("abc") # Should be empty.
   x <- logger(verbose = 2L, file = NULL)
   x$major("abc") # Should show "abc".
-  x$minor("abc") # Should show the spinner.
+  x$log("abc") # Should show the spinner.
   expect_equal(files, list.files())
   for (verbose in c(0L, 1L, 2L)) {
     tmp <- tempfile()
@@ -72,7 +72,7 @@ test_with_dir("logger", {
     expect_false(file.exists(tmp))
     x$major("abc")
     expect_equal(length(readLines(tmp)), 1L)
-    x$minor("abc")
+    x$log("abc")
     expect_equal(length(readLines(tmp)), 2L)
   }
 })

--- a/tests/testthat/test-1-interactive.R
+++ b/tests/testthat/test-1-interactive.R
@@ -383,4 +383,34 @@ test_with_dir("Output from the callr RStudio addins", {
   expect_true(inherits(graph, "visNetwork"))
 })
 
+test_with_dir("progress bars", {
+  skip_on_cran()
+  # Needs visual inspection at every step
+  plan <- drake_plan(
+    x = target(
+      Sys.sleep(.1),
+      transform = map(y = !!seq_len(40))
+    )
+  )
+  make(plan, verbose = 2)
+  plan <- drake_plan(
+    x = target(
+      Sys.sleep(.1),
+      transform = map(y = !!seq_len(40))
+    ),
+    w = seq_len(40),
+    z = target(
+      Sys.sleep(.1),
+      dynamic = map(y = w)
+    )
+  )
+  make(plan, verbose = 2)
+  clean()
+  make(plan, verbose = 2, parallelism = "future")
+  skip_on_os("windows")
+  clean()
+  options(clustermq.scheduler = "multicore")
+  make(plan, verbose = 2, parallelism = "clustermq")
+})
+
 }

--- a/tests/testthat/test-1-interactive.R
+++ b/tests/testthat/test-1-interactive.R
@@ -112,15 +112,15 @@ test_with_dir("time stamps and large files", {
   plan <- drake_plan(x = file_in(!!file_large))
   cache <- storr::storr_rds(tempfile())
   config <- drake_config(plan, cache = cache)
-  make(plan, cache = cache, console_log_file = log1) # should be a little slow
+  make(plan, cache = cache, log_make = log1) # should be a little slow
   expect_equal(justbuilt(config), "x")
-  make(plan, cache = cache, console_log_file = log2) # should be quick
+  make(plan, cache = cache, log_make = log2) # should be quick
   expect_equal(justbuilt(config), character(0))
   tmp <- file.append(file_large, file_csv)
-  make(plan, cache = cache, console_log_file = log3) # should be a little slow
+  make(plan, cache = cache, log_make = log3) # should be a little slow
   expect_equal(justbuilt(config), "x")
   system2("touch", file_large)
-  make(plan, cache = cache, console_log_file = log4) # should be a little slow
+  make(plan, cache = cache, log_make = log4) # should be a little slow
   expect_equal(justbuilt(config), character(0))
   # Now, compare the times stamps on the logs.
   # Make sure the imported file takes a long time to process the first time

--- a/tests/testthat/test-3-lazy.R
+++ b/tests/testthat/test-3-lazy.R
@@ -60,6 +60,7 @@ test_with_dir("lazy loading is actually lazy", {
   config$ht_dynamic <- ht_new()
   config$envir_graph <- ht_new()
   config$envir_graph$graph <- config$graph
+  config$logger$set_progress_total(igraph::gorder(config$graph))
   drake_backend.loop(config)
   loaded <- ls(envir = config$envir_targets)
   expect_true(all(lazily_loaded %in% loaded))

--- a/tests/testthat/test-5-console.R
+++ b/tests/testthat/test-5-console.R
@@ -26,15 +26,15 @@ test_with_dir("console to file", {
   tmp <- capture.output({
       make(
         my_plan, cache = cache, verbose = 1L, session_info = FALSE,
-        console_log_file = "log.txt"
+        log_make = "log.txt"
       )
       make(
         my_plan, cache = cache, verbose = 1L, session_info = FALSE,
-        console_log_file = "log.txt"
+        log_make = "log.txt"
       )
       make(
         my_plan, cache = cache, verbose = 1L, session_info = FALSE,
-        trigger = trigger(condition = TRUE), console_log_file = "log.txt"
+        trigger = trigger(condition = TRUE), log_make = "log.txt"
       )
     },
     type = "message"
@@ -71,7 +71,7 @@ test_with_dir("drake_warning() and drake_error()", {
   expect_true(any(grepl("some_error", as.character(unlist(o$error$calls)))))
   expect_false(file.exists("log.txt"))
   expect_error(expect_warning(make(
-    plan, console_log_file = "log.txt",
+    plan, log_make = "log.txt",
     cache = storr::storr_environment(),
     session_info = FALSE
   )))

--- a/tests/testthat/test-6-hpc.R
+++ b/tests/testthat/test-6-hpc.R
@@ -148,7 +148,7 @@ test_with_dir("parallelism can be a scheduler function", {
   loop_ <- function(config) {
     targets <- igraph::topo_sort(config$graph)$name
     for (target in targets) {
-      config$logger$minor(target)
+      config$logger$log(target)
       config$envir_targets[[target]] <- build_(
         target = target,
         config = config

--- a/tests/testthat/test-6-hpc.R
+++ b/tests/testthat/test-6-hpc.R
@@ -148,7 +148,6 @@ test_with_dir("parallelism can be a scheduler function", {
   loop_ <- function(config) {
     targets <- igraph::topo_sort(config$graph)$name
     for (target in targets) {
-      config$logger$log(target)
       config$envir_targets[[target]] <- build_(
         target = target,
         config = config

--- a/tests/testthat/test-6-visuals.R
+++ b/tests/testthat/test-6-visuals.R
@@ -97,10 +97,6 @@ test_with_dir("Sankey diagram runs", {
 
 test_with_dir("colors and shapes", {
   skip_on_cran() # CRAN gets whitelist tests only (check time limits).
-  expect_is(text_color("target"), "character")
-  expect_is(text_color("import"), "character")
-  expect_is(text_color("not found"), "character")
-  expect_is(text_color("not found"), "character")
   expect_is(node_color("target"), "character")
   expect_is(node_color("import"), "character")
   expect_is(node_color("not found"), "character")

--- a/tests/testthat/test-9-future.R
+++ b/tests/testthat/test-9-future.R
@@ -138,11 +138,11 @@ test_with_dir("can gracefully conclude a crashed worker", {
   }
 })
 
-test_with_dir("ft_skip_target()", {
+test_with_dir("ft_no_target()", {
   skip_on_cran()
   con <- dbug()
   con$sleeps <- new.env(parent = emptyenv())
   con$sleeps$count <- 1L
-  ft_skip_target(con)
+  ft_no_target(con)
   expect_equal(con$sleeps$count, 2L)
 })

--- a/tests/testthat/test-zzz-callr.R
+++ b/tests/testthat/test-zzz-callr.R
@@ -111,7 +111,7 @@ test_with_dir("supply the source explicitly", {
     c(
       "library(drake)",
       "load_mtcars_example()",
-      "drake_config(my_plan, console_log_file = \"log.txt\")"
+      "drake_config(my_plan, log_make = \"log.txt\")"
     ),
     "my_script.R"
   )
@@ -144,7 +144,7 @@ test_with_dir("r_make() loads packages and sets options", {
       "library(abind)",
       "options(drake_abind_opt = 2L)",
       "plan <- drake_plan(x = abind(1L, getOption(\"drake_abind_opt\")))",
-      "drake_config(plan, console_log_file = \"log.txt\")"
+      "drake_config(plan, log_make = \"log.txt\")"
     ),
     default_drake_source
   )


### PR DESCRIPTION
# Summary

This PR implements several improvements to logging.

## progress bar

`verbose = 2` in `make()` now has a different meaning. The spinner for preprocessing is gone, and now we have a progress bar for targets. Simplifications to infrastructure make this possible. cc @kendonB. 

```r
plan <- drake_plan(
  x = target(
    Sys.sleep(.1),
    transform = map(y = !!seq_len(40))
  ),
  w = seq_len(40),
  z = target(
    Sys.sleep(.1),
    dynamic = map(y = w)
  )
)

make(plan)
targets [==============================>-----]  86%
```

## cli symbols instead of colors

`drake`'s default line-by-line target-level console messages have always had a color scheme that was awkward and not optimized for white terminals. Now, we are using `cli` symbols and only the most basic colors for the symbols. The text is always the default color now.

``` r
library(drake)
plan <- drake_plan(
  a = 1,
  b = cancel(),
  c = stop(),
  d = target(stop(), retries = 2),
  e = seq_len(2),
  f = target(e, dynamic = map(e))
)

make(plan, keep_going = TRUE)
#> ▶ target a
#> ▶ target b
#> ■ cancel b
#> ▶ target c
#> x fail c
#> ▶ target d
#> ! retry d
#> ! retry d
#> x fail d
#> ▶ target e
#> ▶ dynamic f
#> > subtarget f_0b3474bd
#> > subtarget f_b2a5c9b8
#> ■ aggregate f

plan <- drake_plan(a = 1)

make(plan)
#> ✓ All targets are already up to date.
```

<sup>Created on 2020-02-08 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

## console_log_file

The `console_log_file` argument of `make()` has an awkward name. This PR deprecates it and renames it `log_make`.

# Checklist

- [x] I understand and agree to `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CODE_OF_CONDUCT.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) for any new functionality.
- [x] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).
