### PR TITLE
Bump digest version to 0.6.21

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -105,7 +105,7 @@ Depends:
   R (>= 3.3.0)
 Imports:
   base64url,
-  digest,
+  digest (>= 0.6.21),
   igraph,
   methods,
   parallel,

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 * Sanitize internal S3 classes for target storage (#1159, @rsangole).
+* Bump `digest` version to require 0.6.21 (#1166, @boshek)
 
 ## Enhancements
 


### PR DESCRIPTION
# Summary

I think that drake depends on `digest` version 0.6.21 or later because `getVDigest` was only exported after that version: 

https://github.com/eddelbuettel/digest/blob/199be2ee7be1afd81de8ccf251d1b2c0d5071c2c/ChangeLog#L160-L166

This is probably obvious but `getVDigest` is imported by drake here:

https://github.com/ropensci/drake/blob/8147258d28bba104a9aad9c57bdf5511cc8d55ab/R/package.R#L49


# Checklist

- [x] I understand and agree to `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CODE_OF_CONDUCT.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) for any new functionality.
- [x] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).
