### PR TITLE
Major bugfix: skip up-to-date dynamic sub-targets even when the parent did not finalize in the last make()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 * **Ensure up-to-date sub-targets are skipped even if the dynamic parent does not get a chance to finalize (#1209, #1211, @psadil, @kendonB).**
+* Add a trace argument to `cds_std_dyn_cmd()`. This one might invalidate people's dynamic targets, but it is important.
 * Restrict static transforms so they only use the upstream part of the plan (#1199, #1200, @bart1).
 * Correctly match the names and values of dynamic `cross()` sub-targets (#1204, @psadil). Expansion order is the same, but names are correctly matched now.
 * Stop trying to remove `file_out()` files in `clean()`, even when `garbage_collection` is `TRUE` (#521, @the-Hull).

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,12 +2,14 @@
 
 ## Bug fixes
 
+* **Ensure up-to-date sub-targets are skipped even if the dynamic parent does not get a chance to finalize (#1209, @psadil, @kendonB).**
 * Restrict static transforms so they only use the upstream part of the plan (#1199, #1200, @bart1).
 * Correctly match the names and values of dynamic `cross()` sub-targets (#1204, @psadil). Expansion order is the same, but names are correctly matched now.
 * Stop trying to remove `file_out()` files in `clean()`, even when `garbage_collection` is `TRUE` (#521, @the-Hull).
 * Fix `keep_going = TRUE` for formatted targets (#1206).
 * Use the correct variable names in logger helper (`progress_bar` instead of `progress`) so that `drake` works without the `progress` package (#1208, @mbaccou).
 * Avoid conflict between formats and upstream dynamic targets (#1210, @psadil).
+* Always compute trigger metadata up front because recovery keys need it.
 
 ## New features
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Bug fixes
 
-* **Ensure up-to-date sub-targets are skipped even if the dynamic parent does not get a chance to finalize (#1209, @psadil, @kendonB).**
+* **Ensure up-to-date sub-targets are skipped even if the dynamic parent does not get a chance to finalize (#1209, #1211, @psadil, @kendonB).**
 * Restrict static transforms so they only use the upstream part of the plan (#1199, #1200, @bart1).
 * Correctly match the names and values of dynamic `cross()` sub-targets (#1204, @psadil). Expansion order is the same, but names are correctly matched now.
 * Stop trying to remove `file_out()` files in `clean()`, even when `garbage_collection` is `TRUE` (#521, @the-Hull).

--- a/R/create_drake_spec.R
+++ b/R/create_drake_spec.R
@@ -390,6 +390,9 @@ cds_std_dyn_cmd <- function(x) {
   transform <- class(x)
   vars <- sort(all.vars(x))
   by <- as.character(x$.by)
+  # TODO: the mention of trace is a bug, but fixing it
+  # will invalidate everyone's sub-targets. Wait to fix it
+  # until drake 8.0.0.
   paste(c(transform, vars, by, trace), collapse = " ")
 }
 

--- a/R/create_drake_spec.R
+++ b/R/create_drake_spec.R
@@ -184,7 +184,7 @@ cds_prepare_spec <- function(args, spec) {
   cds_assert_trace(spec$dynamic, spec)
   spec$command_standardized <- cds_standardize_command(spec$command)
   if (inherits(spec$dynamic, "dynamic")) {
-    dynamic_command <- cds_std_dyn_cmd(spec$dynamic)
+    dynamic_command <- cds_std_dyn_cmd(spec$dynamic, spec$deps_dynamic_trace)
     spec$command_standardized <- paste(
       spec$command_standardized,
       dynamic_command
@@ -386,7 +386,7 @@ cds_standardize_command <- function(x) {
   safe_deparse(x, backtick = TRUE)
 }
 
-cds_std_dyn_cmd <- function(x) {
+cds_std_dyn_cmd <- function(x, trace) {
   transform <- class(x)
   vars <- sort(all.vars(x))
   by <- as.character(x$.by)

--- a/R/create_drake_spec.R
+++ b/R/create_drake_spec.R
@@ -184,7 +184,7 @@ cds_prepare_spec <- function(args, spec) {
   cds_assert_trace(spec$dynamic, spec)
   spec$command_standardized <- cds_standardize_command(spec$command)
   if (inherits(spec$dynamic, "dynamic")) {
-    dynamic_command <- cds_std_dyn_cmd(spec$dynamic, spec$deps_dynamic_trace)
+    dynamic_command <- cds_std_dyn_cmd(spec$dynamic)
     spec$command_standardized <- paste(
       spec$command_standardized,
       dynamic_command
@@ -386,7 +386,7 @@ cds_standardize_command <- function(x) {
   safe_deparse(x, backtick = TRUE)
 }
 
-cds_std_dyn_cmd <- function(x, trace) {
+cds_std_dyn_cmd <- function(x) {
   transform <- class(x)
   vars <- sort(all.vars(x))
   by <- as.character(x$.by)

--- a/R/decorate_storr.R
+++ b/R/decorate_storr.R
@@ -139,6 +139,21 @@ refclass_decorated_storr <- methods::setRefClass(
         hash = .self$ht_keys[[value]]
       )
     },
+    inc_dynamic_progress = function(subtarget, namespace) {
+      .self$driver$set_hash(
+        key = subtarget,
+        namespace = namespace,
+        hash = .self$ht_keys[["done"]]
+      )
+    },
+    clear_dynamic_progress = function(target) {
+      prefix <- dynamic_progress_ns_pfx(target)
+      namespaces <- .self$list_namespaces()
+      namespaces <- grep(pattern = prefix, x = namespaces, value = TRUE)
+      for (namespace in namespaces) {
+        .self$clear(namespace = namespace)
+      }
+    },
     get_progress = function(targets) {
       retrieve_progress(targets = targets, cache = .self)
     },

--- a/R/drake_meta_.R
+++ b/R/drake_meta_.R
@@ -151,7 +151,13 @@ dynamic_progress_namespace <- function(target, meta, config) {
 }
 
 dynamic_progress_key <- function(target, meta, config) {
-  command <- ifelse(
+  x <- dynamic_progress_prekey(target, meta, config)
+  x <- paste(as.character(x), collapse = "|")
+  digest_murmur32(x, serialize = FALSE)
+}
+
+dynamic_progress_prekey <- function(target, meta, config) {
+ command <- ifelse(
     meta$trigger$command,
     meta$command,
     NA_character_
@@ -188,19 +194,17 @@ dynamic_progress_key <- function(target, meta, config) {
     NA_character_,
     config$cache$digest(meta$trigger$value)
   )
-  x <- c(
-    command,
-    depend,
-    input_file_hash,
-    output_file_hash,
-    seed,
-    format,
-    condition,
-    mode,
-    change_hash
+  list(
+    command = command,
+    depend = depend,
+    input_file_hash = input_file_hash,
+    output_file_hash = output_file_hash,
+    seed = seed,
+    format = format,
+    condition = condition,
+    mode = mode,
+    change_hash = change_hash
   )
-  x <- paste(x, collapse = "|")
-  digest_murmur32(x, serialize = FALSE)
 }
 
 dynamic_progress_ns_pfx <- function(target) {

--- a/R/drake_meta_.R
+++ b/R/drake_meta_.R
@@ -146,28 +146,10 @@ drake_meta_impl.dynamic <- function(target, config) {
 # GitHub issue 1209
 dynamic_progress_namespace <- function(target, meta, config) {
   prefix <- dynamic_progress_ns_pfx(target)
-  key <- dynamic_progress_ns_key(target, meta, config)
+  key <- recovery_key(target, meta, config)
+  # Use murmur32 to avoid long file names on Windows.
+  key <- digest_murmur32(key, serialize = FALSE)
   paste0(prefix, key)
-}
-
-# Needs to be different from the recovery key.
-dynamic_progress_ns_key <- function(target, meta, config) {
-  change_hash <- ifelse(
-    is.null(meta$trigger$value),
-    NA_character_,
-    config$cache$digest(meta$trigger$value)
-  )
-  x <- c(
-    meta$command,
-    meta$dependency_hash,
-    meta$input_file_hash,
-    meta$output_file_hash,
-    meta$format,
-    as.character(meta$seed),
-    change_hash
-  )
-  x <- paste(x, collapse = "|")
-  digest_murmur32(x, serialize = FALSE)
 }
 
 dynamic_progress_ns_pfx <- function(target) {

--- a/R/dynamic.R
+++ b/R/dynamic.R
@@ -218,6 +218,9 @@ register_subtargets <- function(target, static_ok, dynamic_ok, config) {
   if (static_ok) {
     subtargets_build <- filter_subtargets(target, subtargets_all, config)
   }
+  namespace <- config$meta[[target]]$dynamic_progress_namespace
+  already_done <- config$cache$list(namespace = namespace)
+  subtargets_build <- setdiff(subtargets_build, already_done)
   if (length(subtargets_all)) {
     register_in_graph(target, subtargets_all, config)
     register_in_spec(target, subtargets_all, config)

--- a/R/dynamic.R
+++ b/R/dynamic.R
@@ -220,6 +220,7 @@ register_subtargets <- function(target, static_ok, dynamic_ok, config) {
   }
   namespace <- config$meta[[target]]$dynamic_progress_namespace
   already_done <- config$cache$list(namespace = namespace)
+
   subtargets_build <- setdiff(subtargets_build, already_done)
   if (length(subtargets_all)) {
     register_in_graph(target, subtargets_all, config)

--- a/R/dynamic.R
+++ b/R/dynamic.R
@@ -220,7 +220,7 @@ register_subtargets <- function(target, static_ok, dynamic_ok, config) {
   }
   namespace <- config$meta[[target]]$dynamic_progress_namespace
   already_done <- config$cache$list(namespace = namespace)
-
+  already_done <- intersect(already_done, ht_list(config$ht_target_exists))
   subtargets_build <- setdiff(subtargets_build, already_done)
   if (length(subtargets_all)) {
     register_in_graph(target, subtargets_all, config)

--- a/R/handle_triggers.R
+++ b/R/handle_triggers.R
@@ -120,11 +120,11 @@ recovery_key_impl.subtarget <- function(target, meta, config) {
 }
 
 recovery_key_impl.default <- function(target, meta, config, ...) {
-  if (is.null(meta$trigger$value)) {
-    change_hash <- NA_character_
-  } else {
-    change_hash <- config$cache$digest(meta$trigger$value)
-  }
+  change_hash <- ifelse(
+    is.null(meta$trigger$value),
+    NA_character_,
+    config$cache$digest(meta$trigger$value)
+  )
   x <- c(
     meta$command,
     meta$dependency_hash,

--- a/R/store_outputs.R
+++ b/R/store_outputs.R
@@ -12,11 +12,7 @@ store_outputs <- function(target, value, meta, config) {
     meta = meta,
     config = config
   )
-  set_progress(
-    target = target,
-    value = "done",
-    config = config
-  )
+  finalize_progress(target, config)
 }
 
 decorate_format_value <- function(value, target, config) {
@@ -347,4 +343,25 @@ microtime <- function() {
 
 proc_time <- function() {
   unclass(proc.time())
+}
+
+# GitHub issue 1209
+finalize_progress <- function(target, config) {
+  set_progress(target = target, value = "done", config = config)
+  if (is_dynamic(target, config)) {
+    finalize_progress_dynamic(target, config)
+  }
+  if (is_subtarget(target, config)) {
+    finalize_progress_subtarget(target, config)
+  }
+}
+
+finalize_progress_dynamic <- function(target, config) {
+  config$cache$clear_dynamic_progress(target)
+}
+
+finalize_progress_subtarget <- function(target, config) {
+  parent <- config$spec[[target]]$subtarget_parent
+  namespace <- config$meta[[parent]]$dynamic_progress_namespace
+  config$cache$inc_dynamic_progress(target, namespace)
 }

--- a/R/store_outputs.R
+++ b/R/store_outputs.R
@@ -269,12 +269,6 @@ finalize_triggers <- function(target, meta, config) {
   if (is.null(meta$command)) {
     meta$command <- spec$command_standardized
   }
-  if (is.null(meta$dependency_hash)) {
-    meta$dependency_hash <- static_dependency_hash(target, config)
-  }
-  if (is.null(meta$input_file_hash)) {
-    meta$input_file_hash <- input_file_hash(target = target, config = config)
-  }
   if (length(file_out) || is.null(file_out)) {
     meta$output_file_hash <- output_file_hash(
       target = target,

--- a/tests/testthat/test-9-dynamic.R
+++ b/tests/testthat/test-9-dynamic.R
@@ -2169,4 +2169,6 @@ test_with_dir("parent not finalized, sub-targets stay up to date (#1209)", {
   make(plan)
   expect_equal(length(justbuilt(config)), 4L)
   expect_true(all(jb2 %in% justbuilt(config)))
+  make(plan)
+  expect_equal(length(justbuilt(config)), 0L)
 })

--- a/tests/testthat/test-9-dynamic.R
+++ b/tests/testthat/test-9-dynamic.R
@@ -2273,6 +2273,32 @@ test_with_dir("dynamic_progress_prekey() default (#1209)", {
   expect_equal(sum(chr < 1L), 2L)
 })
 
+test_with_dir("dynamic_progress_prekey() suppressed (#1209)", {
+  skip_on_cran()
+  z <- 1
+  nums <- seq(0L, 2L)
+  plan <- drake_plan(
+    result = target(
+      stopifnot(nums + z <= 1L),
+      dynamic = map(nums),
+      trigger = trigger(
+        command = FALSE,
+        depend = FALSE,
+        file = FALSE,
+        seed = FALSE,
+        format = FALSE
+      )
+    )
+  )
+  config <- drake_config(plan)
+  meta <- drake_meta_("result", config)
+  x <- dynamic_progress_prekey("result", meta, config)
+  ns <- setdiff(names(x), c("mode", "condition"))
+  for (n in ns) {
+    expect_true(is.na(x[[n]]))
+  }
+})
+
 test_with_dir("dynamic_progress_prekey() special (#1209)", {
   skip_on_cran()
   skip_if_not_installed("fst")


### PR DESCRIPTION
# Summary

Thanks @psadil and @kendonB for pointing out #1209 and #1211. This bug was likely wasting runtime for everyone using dynamic branching. And like you two probably do, I need the time savings right now for a critical project at my day job.

This PR fixes the bug at #1209 and #1211 with the ad hoc but relatively painless solution at https://github.com/ropensci/drake/issues/1209#issuecomment-597666346. 

# Demonstration

``` r
library(drake)
library(testthat)
plan <- drake_plan(
  numbers = seq(0L, 2L),
  result = target(stopifnot(numbers <= 1L), dynamic = map(numbers))
)

# Tries to build everything.
try(make(plan), silent = TRUE)
#> ▶ target numbers
#> ▶ dynamic result
#> > subtarget result_8e9da519
#> > subtarget result_0b3474bd
#> > subtarget result_b2a5c9b8
#> x fail result_b2a5c9b8

# Skips up-to-date sub-targets
try(make(plan), silent = TRUE)
#> ▶ dynamic result
#> > subtarget result_b2a5c9b8
#> x fail result_b2a5c9b8

# Fix the error, which affects all sub-targets.
plan <- drake_plan(
  numbers = seq(0L, 2L),
  result = target(stopifnot(numbers <= 999L), dynamic = map(numbers))
)

# Run all sub-targets.
# Depending on the nature of the error, you may not have to
# run everything in your use case.
make(plan)
#> ▶ dynamic result
#> > subtarget result_8e9da519
#> > subtarget result_0b3474bd
#> > subtarget result_b2a5c9b8
#> ■ finalize result
```

<sup>Created on 2020-03-11 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

# Caveats

1. The mechanism that skips un-finalized up-to-date sub-targets is sensitive to the custom triggers you choose. If you change the triggers, all your sub-targets will start over on the next `make()`.
2. Other capabilities like `vctrs`-powered `loadd()` and `readd()`, along with the `subtargets()` function, still require the sub-targets to be finalized.

# Related GitHub issues and pull requests

- Ref: #1209

# Checklist

- [x] I understand and agree to `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CODE_OF_CONDUCT.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) for any new functionality.
- [x] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).
