### PR TITLE
Add formats section docs to target()

### DIFF
--- a/R/drake_plan_helpers.R
+++ b/R/drake_plan_helpers.R
@@ -5,6 +5,7 @@
 #' @export
 #' @inheritSection drake_plan Columns
 #' @inheritSection drake_plan Keywords
+#' @inheritSection drake_plan Formats
 #' @seealso [drake_plan()], [make()]
 #' @return A one-row workflow plan data frame with the named
 #' arguments as columns.


### PR DESCRIPTION
`target()` currently inherits the sections "Columns" and "Keywords" from `drake_plan()` but the description of `format` tells the reader to see the "Formats" section that is currently not inherited and therefore not available in the `target()` help pages.

https://github.com/ropensci/drake/blob/b88e4985080c74f129ba285d0ee94ccc682ce5aa/R/drake_plan.R#L30-L31

This PR is the one-line change that adds the "Formats" section to the `target()` help docs. I thought I'd just submit the PR instead of an issue, but I'd be happy to close this and open an issue if you'd rather go another direction.