### PR TITLE
Allow command to force unlock the cache to be pasted on windows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 ## Enhancements
 
 * Do not analyze dependencies of calls to `drake_plan()` (#1237, @januz).
-
+* Error message for locked cache gives paste-able error message in Windows (#1243, @billdenney).
 
 # Version 7.12.0
 

--- a/R/decorate_storr.R
+++ b/R/decorate_storr.R
@@ -232,7 +232,7 @@ refclass_decorated_storr <- methods::setRefClass(
         "drake's cache is locked.\nRead ",
         "https://docs.ropensci.org/drake/reference/make.html#cache-locking\n",
         "or force unlock the cache with drake::drake_cache(\"",
-        .self$path,
+        normalizePath(.self$path, winslash="/"),
         "\")$unlock()"
       )
     },

--- a/R/decorate_storr.R
+++ b/R/decorate_storr.R
@@ -232,7 +232,7 @@ refclass_decorated_storr <- methods::setRefClass(
         "drake's cache is locked.\nRead ",
         "https://docs.ropensci.org/drake/reference/make.html#cache-locking\n",
         "or force unlock the cache with drake::drake_cache(\"",
-        normalizePath(.self$path, winslash="/"),
+        normalizePath(.self$path, winslash = "/"),
         "\")$unlock()"
       )
     },


### PR DESCRIPTION
# Summary

Fix minor issue so that an error message can be pasted directly in Windows.

# Related GitHub issues and pull requests

- Ref: Fix #1243

# Checklist

- [x] I understand and agree to `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CODE_OF_CONDUCT.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [ ] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) for any new functionality.
- [x] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).
