### PR TITLE
Fix defunct error message bug

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # Version 7.12.5.9000
 
+## Bug fixes
 
+* Fix defunct functions error message when using namespace (#1310, @malcolmbarrett)
 
 # Version 7.12.5
 

--- a/R/defunct.R
+++ b/R/defunct.R
@@ -2,7 +2,11 @@ drake_defunct <- function(...) {
   .Defunct(
     new = "",
     package = "drake",
-    msg = paste0("function ", match.call()[[1]], "() in drake is defunct.")
+    msg = paste0(
+      "function ",
+      deparse(match.call()[[1]]),
+      "() in drake is defunct."
+    )
   )
 }
 

--- a/R/defunct.R
+++ b/R/defunct.R
@@ -4,7 +4,7 @@ drake_defunct <- function(...) {
     package = "drake",
     msg = paste0(
       "function ",
-      deparse(match.call()[[1]]),
+      safe_deparse(match.call()[[1]]),
       "() in drake is defunct."
     )
   )

--- a/tests/testthat/test-7-deprecate.R
+++ b/tests/testthat/test-7-deprecate.R
@@ -12,6 +12,7 @@ test_with_dir("defunct functions", {
       regexp = "drake_defunct"
     )
     expect_error(analyses(), regexp = "analyses")
+    expect_error(drake::analyses(), regexp = "drake::analyses")
     expect_error(from_plan(), regexp = "defunct")
   })
 })


### PR DESCRIPTION
# Summary

When functions marked defunct using `drake_defunct` include `drake::`, the call -> string conversion results in a mangled message

``` r
drake::analyses()
#> Error: function ::() in drake is defunct.function drake() in drake is defunct.function analyses() in drake is defunct.
```
<sup>Created on 2020-08-26 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

* This PR deparses `match.call()` prior to pasting. (rlang can also do this but I chose `deparse()` because there seems to be some discussion about [long-term deprecation of `quo_text()`](https://github.com/r-lib/rlang/issues/636) and cousins in favor of a different approach, and this struck me as too simple a problem to deal with it.)
* I also added a test for this bug.

With the PR, the output is now correct:

``` r
drake::analyses()
#> Error: function drake::analyses() in drake is defunct.
```
<sup>Created on 2020-08-26 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

# Checklist

- [x] I understand and agree to `drake`'s [code of conduct](https://github.com/ropensci/drake/blob/master/CODE_OF_CONDUCT.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) for any new functionality.
- [x] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).
