### PR TITLE
Stylistic change in list of conditions

### DIFF
--- a/R/drake_history.R
+++ b/R/drake_history.R
@@ -34,10 +34,10 @@
 #' If `analyze` is `TRUE`, `drake`
 #'   scans your [drake_plan()] commands
 #'   for function arguments and mentions them in the history.
-#'   A function argument shows up if and only if
-#'     1. It has length 1.
+#'   A function argument shows up if and only if:
+#'     1. It has length 1. \cr
 #'     2. It is atomic, i.e. a base type: logical, integer,
-#'        real, complex, character, or raw.
+#'        real, complex, character, or raw. \cr
 #'     3. It is explicitly named in the function call,
 #'        For example, `x` is detected as `1` in
 #'        `fn(list(x = 1))` but not `f(list(1))`.
@@ -46,7 +46,7 @@
 #'        as `"my_file.csv"` in
 #'        `process_data(filename = file_in("my_file.csv"))`.
 #'        NB: in `process_data(filename = file_in("a", "b"))`
-#'        `filename` is not detected because the value must be atomic.
+#'        `filename` is not detected because the value must be atomic. \cr
 #' @export
 #' @return A data frame of target history.
 #' @inheritParams drake_config


### PR DESCRIPTION
# Summary

The list of condition items in `drake_history` appears in one line. Adding ` \cr` at the end should solve the issue based on https://stackoverflow.com/a/24165701/6888231. I had difficulty reading the help of this function before realizing that this was a list, so I thought this is a worthwhile edit.

# Checklist

- [x] I understand and agree to the [code of conduct](https://github.com/ropensci/drake/blob/master/CODE_OF_CONDUCT.md).
- [ ] ~~I have listed any substantial changes in the [development news](https://github.com/ropensci/drake/blob/master/NEWS.md).~~
- [ ] ~~I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/ropensci/drake/tree/master/tests/testthat) for any new functionality.~~
- [x] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).
