### PR TITLE
docs: add lightswitch?

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -11,7 +11,7 @@ navbar:
       href: https://books.ropensci.org/drake/faq.html
   structure:
     left: [home, reference, manual, faq, news]
-    right: [search, github]
+    right: [search, github, lightswitch]
 articles:
 - title: Vignettes
   contents:


### PR DESCRIPTION
@wlandau this is how you'd activate the lightswitch for dark mode in your packages (those that have a navbar config, otherwise I think that'll be the default)